### PR TITLE
Apstra 412 support

### DIFF
--- a/apstra/api_blueprints.go
+++ b/apstra/api_blueprints.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"net/url"
 	"time"
@@ -458,7 +457,6 @@ func (o *Client) createBlueprintFromTemplate(ctx context.Context, req *rawCreate
 }
 
 func (o *Client) deleteBlueprint(ctx context.Context, id ObjectId) error {
-	log.Printf("delete blueprint id '%s'\n", id)
 	return o.talkToApstra(ctx, &talkToApstraIn{
 		method: http.MethodDelete,
 		urlStr: fmt.Sprintf(apiUrlBlueprintById, id),

--- a/apstra/api_design_logical_devices_test.go
+++ b/apstra/api_design_logical_devices_test.go
@@ -105,11 +105,13 @@ func TestCreateGetUpdateDeleteLogicalDevice(t *testing.T) {
 		PortIndexingHorizontalFirst,
 	}
 
+	randStr := randString(5, "hex")
+
 	for clientName, client := range clients {
 		deviceConfigs := make([]LogicalDeviceData, len(indexingTypes))
 		for i, indexing := range indexingTypes {
 			deviceConfigs[i] = LogicalDeviceData{
-				DisplayName: fmt.Sprintf("AAAA-%s-%d", t.Name(), i),
+				DisplayName: fmt.Sprintf("AAAA-%s-%s-%d", t.Name(), randStr, i),
 				Panels: []LogicalDevicePanel{
 					{
 						PanelLayout: LogicalDevicePanelLayout{
@@ -161,6 +163,8 @@ func TestCreateGetUpdateDeleteLogicalDevice(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+
+				previous.Data.DisplayName = d.Data.DisplayName
 
 				log.Printf("testing updateLogicalDevice() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 				err = client.client.updateLogicalDevice(context.TODO(), id[i], previous.Data.raw())

--- a/apstra/api_property_sets_test.go
+++ b/apstra/api_property_sets_test.go
@@ -5,7 +5,6 @@ package apstra
 
 import (
 	"context"
-	"errors"
 	"log"
 	"math/rand"
 	"testing"
@@ -62,33 +61,19 @@ func TestCreateGetUpdateGetDeletePropertySet(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		log.Printf("testing createPropertySet() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		id2, err := client.client.createPropertySet(ctx, ps)
-		if err != nil {
-			t.Fatal(err)
-		}
-
 		log.Printf("testing getPropertySetsByLabel() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		psSlice, err := client.client.GetPropertySetsByLabel(ctx, ps.Label)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if len(psSlice) != 2 {
-			t.Fatalf("expected 2 property sets, got %d", len(psSlice))
-		}
-		if !equal(psSlice[0].Data, psSlice[1].Data) {
-			t.Fatal("property sets don't match")
+		if len(psSlice) != 1 {
+			t.Fatalf("expected 1 property set, got %d", len(psSlice))
 		}
 
 		log.Printf("testing getPropertySetByLabel() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		_, err = client.client.getPropertySetByLabel(ctx, ps.Label)
-		if err == nil {
-			t.Fatal("expected multiple match error, but got no error")
-		} else {
-			var ace ApstraClientErr
-			if errors.As(err, &ace) && ace.Type() != ErrMultipleMatch {
-				t.Fatalf("expected multiple match error, got %s", err.Error())
-			}
+		if err != nil {
+			t.Fatal(err)
 		}
 
 		log.Printf("testing getPropertySet() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
@@ -130,18 +115,6 @@ func TestCreateGetUpdateGetDeletePropertySet(t *testing.T) {
 
 		log.Printf("testing deletePropertySet() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		err = client.client.deletePropertySet(ctx, id1)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		log.Printf("testing getPropertySetByLabel() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		_, err = client.client.getPropertySetByLabel(ctx, polished1.Data.Label)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		log.Printf("testing deletePropertySet() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		err = client.client.deletePropertySet(ctx, id2)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/apstra/api_resources_int_test.go
+++ b/apstra/api_resources_int_test.go
@@ -434,23 +434,7 @@ func TestGetVniPoolByName(t *testing.T) {
 			t.Fatalf("expected '%s', got '%s", id, p.Id)
 		}
 
-		log.Printf("testing createVniPool() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		dupId, err := client.client.createVniPool(context.Background(), &VniPoolRequest{DisplayName: poolName})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		log.Printf("testing getVniPoolByName() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		_, err = client.client.getVniPoolByName(context.Background(), poolName)
-		if err == nil {
-			t.Fatalf("expected error: pool '%s' and '%s' both should be named '%s'", id, dupId, poolName)
-		}
-
 		err = client.client.deleteVniPool(context.TODO(), id)
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = client.client.deleteVniPool(context.TODO(), dupId)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/apstra/api_resources_int_test.go
+++ b/apstra/api_resources_int_test.go
@@ -223,23 +223,7 @@ func TestGetAsnPoolByName(t *testing.T) {
 			t.Fatalf("expected '%s', got '%s", id, p.Id)
 		}
 
-		log.Printf("testing createAsnPool() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		dupId, err := client.client.createAsnPool(context.Background(), &AsnPoolRequest{DisplayName: poolName})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		log.Printf("testing getAsnPoolByName() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		_, err = client.client.getAsnPoolByName(context.Background(), poolName)
-		if err == nil {
-			t.Fatalf("expected error: pool '%s' and '%s' both should be named '%s'", id, dupId, poolName)
-		}
-
 		err = client.client.deleteAsnPool(context.TODO(), id)
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = client.client.deleteAsnPool(context.TODO(), dupId)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/apstra/client.go
+++ b/apstra/client.go
@@ -633,7 +633,24 @@ func (o *Client) GetBlueprintStatusByName(ctx context.Context, name string) (*Bl
 
 // DeleteBlueprint deletes the specified blueprint
 func (o *Client) DeleteBlueprint(ctx context.Context, id ObjectId) error {
-	return o.deleteBlueprint(ctx, id)
+	err := o.deleteBlueprint(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	t := immediateTicker(clientPollingIntervalMs)
+	defer t.Stop()
+	for {
+		<-t.C
+		ids, err := o.listAllBlueprintIds(ctx)
+		if err != nil {
+			return err
+		}
+		if !itemInSlice(id, ids) {
+			break
+		}
+	}
+	return nil
 }
 
 // CreateIp4Pool creates an IPv4 resource pool

--- a/apstra/client_test.go
+++ b/apstra/client_test.go
@@ -91,7 +91,7 @@ func TestGetBlueprintOverlayControlProtocol(t *testing.T) {
 	}
 
 	type testCase struct {
-		bpFunc      func(context.Context, *testing.T, *Client) (*TwoStageL3ClosClient, func() error)
+		bpFunc      func(context.Context, *testing.T, *Client) (*TwoStageL3ClosClient, func(context.Context) error)
 		expectedOcp OverlayControlProtocol
 	}
 
@@ -104,7 +104,7 @@ func TestGetBlueprintOverlayControlProtocol(t *testing.T) {
 		for i := range testCases {
 			bpClient, bpDel := testCases[i].bpFunc(ctx, t, client.client)
 			defer func() {
-				err := bpDel()
+				err := bpDel(ctx)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/apstra/compatibility.go
+++ b/apstra/compatibility.go
@@ -3,12 +3,12 @@ package apstra
 import "strings"
 
 const (
-	apstraSupportedApiVersions = "4.1.0, 4.1.1"
+	apstraSupportedApiVersions = "4.1.0, 4.1.1, 4.1.2"
 	apstraSupportedVersionSep  = ","
 
-	PodBasedTemplateFabricAddressingPolicyForbiddenVersions = "4.1.1"
+	PodBasedTemplateFabricAddressingPolicyForbiddenVersions = "4.1.1, 4.1.2"
 
-	RackBasedTemplateFabricAddressingPolicyForbiddenVersions = "4.1.1"
+	RackBasedTemplateFabricAddressingPolicyForbiddenVersions = "4.1.1, 4.1.2"
 )
 
 func parseVersionList(s string) StringSliceWithIncludes {

--- a/apstra/helpers.go
+++ b/apstra/helpers.go
@@ -39,3 +39,12 @@ func immediateTicker(interval time.Duration) *time.Ticker {
 	ticker.C = nc
 	return ticker
 }
+
+func itemInSlice[A comparable](item A, slice []A) bool {
+	for i := range slice {
+		if item == slice[i] {
+			return true
+		}
+	}
+	return false
+}

--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -156,7 +156,7 @@ func testBlueprintA(ctx context.Context, t *testing.T, client *Client) (*TwoStag
 	}
 
 	bpDeleteFunc := func() error {
-		return client.deleteBlueprint(ctx, bpId)
+		return client.DeleteBlueprint(ctx, bpId)
 	}
 
 	return bpClient, bpDeleteFunc
@@ -178,7 +178,7 @@ func testBlueprintB(ctx context.Context, t *testing.T, client *Client) (*TwoStag
 	}
 
 	bpDeleteFunc := func() error {
-		return client.deleteBlueprint(ctx, bpId)
+		return client.DeleteBlueprint(ctx, bpId)
 	}
 
 	return bpClient, bpDeleteFunc
@@ -200,7 +200,7 @@ func testBlueprintC(ctx context.Context, t *testing.T, client *Client) (*TwoStag
 	}
 
 	bpDeleteFunc := func() error {
-		return client.deleteBlueprint(ctx, bpId)
+		return client.DeleteBlueprint(ctx, bpId)
 	}
 
 	return bpClient, bpDeleteFunc

--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -140,7 +140,7 @@ func TestImmediateTickerSecondTick(t *testing.T) {
 	log.Printf("start %s first tick %s second tick %s", start, firstTick, secondTick)
 }
 
-func testBlueprintA(ctx context.Context, t *testing.T, client *Client) (*TwoStageL3ClosClient, func() error) {
+func testBlueprintA(ctx context.Context, t *testing.T, client *Client) (*TwoStageL3ClosClient, func(context.Context) error) {
 	bpId, err := client.CreateBlueprintFromTemplate(context.Background(), &CreateBlueprintFromTemplateRequest{
 		RefDesign:  RefDesignDatacenter,
 		Label:      randString(5, "hex"),
@@ -155,14 +155,14 @@ func testBlueprintA(ctx context.Context, t *testing.T, client *Client) (*TwoStag
 		t.Fatal(err)
 	}
 
-	bpDeleteFunc := func() error {
+	bpDeleteFunc := func(ctx context.Context) error {
 		return client.DeleteBlueprint(ctx, bpId)
 	}
 
 	return bpClient, bpDeleteFunc
 }
 
-func testBlueprintB(ctx context.Context, t *testing.T, client *Client) (*TwoStageL3ClosClient, func() error) {
+func testBlueprintB(ctx context.Context, t *testing.T, client *Client) (*TwoStageL3ClosClient, func(context.Context) error) {
 	bpId, err := client.CreateBlueprintFromTemplate(context.Background(), &CreateBlueprintFromTemplateRequest{
 		RefDesign:  RefDesignDatacenter,
 		Label:      randString(5, "hex"),
@@ -177,14 +177,14 @@ func testBlueprintB(ctx context.Context, t *testing.T, client *Client) (*TwoStag
 		t.Fatal(err)
 	}
 
-	bpDeleteFunc := func() error {
+	bpDeleteFunc := func(ctx context.Context) error {
 		return client.DeleteBlueprint(ctx, bpId)
 	}
 
 	return bpClient, bpDeleteFunc
 }
 
-func testBlueprintC(ctx context.Context, t *testing.T, client *Client) (*TwoStageL3ClosClient, func() error) {
+func testBlueprintC(ctx context.Context, t *testing.T, client *Client) (*TwoStageL3ClosClient, func(context.Context) error) {
 	bpId, err := client.CreateBlueprintFromTemplate(context.Background(), &CreateBlueprintFromTemplateRequest{
 		RefDesign:  RefDesignDatacenter,
 		Label:      randString(5, "hex"),
@@ -199,7 +199,7 @@ func testBlueprintC(ctx context.Context, t *testing.T, client *Client) (*TwoStag
 		t.Fatal(err)
 	}
 
-	bpDeleteFunc := func() error {
+	bpDeleteFunc := func(ctx context.Context) error {
 		return client.DeleteBlueprint(ctx, bpId)
 	}
 

--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -205,3 +205,53 @@ func testBlueprintC(ctx context.Context, t *testing.T, client *Client) (*TwoStag
 
 	return bpClient, bpDeleteFunc
 }
+
+func TestItemInSlice(t *testing.T) {
+	type testCase struct {
+		item     any
+		slice    []any
+		expected bool
+	}
+
+	testCases := []testCase{
+		{item: 1, slice: []any{1, 2, 3}, expected: true},
+		{item: 1, slice: []any{1, 2, 3, 1}, expected: true},
+		{item: 1, slice: []any{3, 2, 1}, expected: true},
+		{item: 0, slice: []any{1, 2, 3}, expected: false},
+		{item: 0, slice: []any{}, expected: false},
+		{item: 1, slice: []any{}, expected: false},
+		{item: "foo", slice: []any{"foo", "bar"}, expected: true},
+		{item: "foo", slice: []any{"bar", "foo"}, expected: true},
+		{item: "foo", slice: []any{"foo", "bar", "foo"}, expected: true},
+		{item: "foo", slice: []any{"bar", "baz"}, expected: false},
+		{item: "foo", slice: []any{""}, expected: false},
+		{item: "foo", slice: []any{"", ""}, expected: false},
+		{item: "foo", slice: []any{}, expected: false},
+		{item: "", slice: []any{"bar", "foo"}, expected: false},
+		{item: "", slice: []any{"bar", "", "foo"}, expected: true},
+		{item: "", slice: []any{}, expected: false},
+	}
+
+	var result bool
+	for i, tc := range testCases {
+		switch tc.item.(type) {
+		case int:
+			item := tc.item.(int)
+			slice := make([]int, len(tc.slice))
+			for j := range tc.slice {
+				slice[j] = tc.slice[j].(int)
+			}
+			result = itemInSlice(item, slice)
+		case string:
+			item := tc.item.(string)
+			slice := make([]string, len(tc.slice))
+			for j := range tc.slice {
+				slice[j] = tc.slice[j].(string)
+			}
+			result = itemInSlice(item, slice)
+		}
+		if result != tc.expected {
+			t.Fatalf("test case %d produced %t, expected %t", i, result, tc.expected)
+		}
+	}
+}

--- a/apstra/two_stage_l3_clos_interface_map_test.go
+++ b/apstra/two_stage_l3_clos_interface_map_test.go
@@ -5,77 +5,45 @@ package apstra
 
 import (
 	"context"
-	"fmt"
 	"log"
-	"strings"
 	"testing"
 )
 
 func TestGetSetInterfaceMapAssignments(t *testing.T) {
-	clients, err := getTestClients(context.Background())
+	ctx := context.Background()
+	clients, err := getTestClients(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	skipMsg := make(map[string]string)
 	for clientName, client := range clients {
-		log.Printf("testing listAllBlueprintIds() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		bpIds, err := client.client.listAllBlueprintIds(context.TODO())
+		bpClient, bpDel := testBlueprintA(ctx, t, client.client)
+		defer func() {
+			err = bpDel(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		log.Printf("testing GetInterfaceMapAssignments() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		ifMapAss, err := bpClient.GetInterfaceMapAssignments(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		// reduce bpIds to just "datacenter" blueprints
-		for i := len(bpIds) - 1; i >= 0; i-- {
-			bpStatus, err := client.client.getBlueprintStatus(context.TODO(), bpIds[i])
-			if err != nil {
-				t.Fatal(err)
+		for k, v := range ifMapAss {
+			if v == nil {
+				v = "<nil>"
 			}
-			if bpStatus.Design != refDesignDatacenter {
-				bpIds[i] = bpIds[len(bpIds)-1] // move last element to current position
-				bpIds = bpIds[:len(bpIds)-1]   // remove last element
-			}
+			log.Printf("'%s' -> '%s'", k, v)
 		}
 
-		if len(bpIds) == 0 {
-			skipMsg[clientName] = fmt.Sprintf("cannot get interface map assignments - no 'datacenter' blueprint in '%s'", clientName)
-			continue
+		// todo check length before using in assignment
+
+		log.Printf("testing SetInterfaceMapAssignments() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		err = bpClient.SetInterfaceMapAssignments(ctx, ifMapAss)
+		if err != nil {
+			t.Fatal(err)
 		}
-
-		for _, bpId := range bpIds {
-			log.Printf("testing NewTwoStageL3ClosClient() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-			bpClient, err := client.client.NewTwoStageL3ClosClient(context.TODO(), bpId)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			log.Printf("testing GetInterfaceMapAssignments() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-			ifMapAss, err := bpClient.GetInterfaceMapAssignments(context.TODO())
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			for k, v := range ifMapAss {
-				if v == nil {
-					v = "<nil>"
-				}
-				log.Printf("'%s' -> '%s'", k, v)
-			}
-
-			// todo check length before using in assignment
-
-			log.Printf("testing SetInterfaceMapAssignments() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-			err = bpClient.SetInterfaceMapAssignments(context.TODO(), ifMapAss)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}
-	}
-	if len(skipMsg) > 0 {
-		sb := strings.Builder{}
-		for _, msg := range skipMsg {
-			sb.WriteString(msg + ";")
-		}
-		t.Skip(sb.String())
 	}
 }

--- a/apstra/two_stage_l3_clos_routing_policies_integration_test.go
+++ b/apstra/two_stage_l3_clos_routing_policies_integration_test.go
@@ -113,7 +113,7 @@ func TestRoutingPolicies(t *testing.T) {
 	for clientName, client := range clients {
 		bpClient, bpDel := testBlueprintA(ctx, t, client.client)
 		defer func() {
-			err := bpDel()
+			err := bpDel(ctx)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/apstra/two_stage_l3_clos_security_zones_integration_test.go
+++ b/apstra/two_stage_l3_clos_security_zones_integration_test.go
@@ -24,7 +24,7 @@ func TestCreateUpdateDeleteRoutingZone(t *testing.T) {
 	for clientName, client := range clients {
 		bpClient, bpDel := testBlueprintA(ctx, t, client.client)
 		defer func() {
-			err := bpDel()
+			err := bpDel(ctx)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -178,7 +178,7 @@ func TestGetDefaultRoutingZone(t *testing.T) {
 	for clientName, client := range clients {
 		bpClient, bpDel := testBlueprintA(ctx, t, client.client)
 		defer func() {
-			err := bpDel()
+			err := bpDel(ctx)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/apstra/two_stage_l3_clos_virtual_networks_integration_test.go
+++ b/apstra/two_stage_l3_clos_virtual_networks_integration_test.go
@@ -183,7 +183,7 @@ func TestCreateUpdateDeleteVirtualNetwork(t *testing.T) {
 	for clientName, client := range clients {
 		bpClient, bpDel := testBlueprintC(ctx, t, client.client)
 		defer func() {
-			err := bpDel()
+			err := bpDel(ctx)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Support for Apstra 4.1.2 has come down to:

1. Adding 4.1.2 to the list of supported versions.
2. Eliminating tests which produce objects (pools, templates, property sets...) with name collisions.

We should perhaps explore removing `GetThingsByName()` methods which return `[]Thing` because these methods assume name collisions are possible, but that feature (?) has been eliminated.