### PR TITLE
Add supported versions function

### DIFF
--- a/apstra/client.go
+++ b/apstra/client.go
@@ -1306,11 +1306,6 @@ func (o *Client) ApiVersion() string {
 	return o.apiVersion
 }
 
-// SupportedVersions returns the Apstra API versions supported by the client
-func (o *Client) SupportedVersions() []string {
-	return parseVersionList(apstraSupportedApiVersions)
-}
-
 // GetDeviceProfile returns device profile
 func (o *Client) GetDeviceProfile(ctx context.Context, id ObjectId) (*DeviceProfile, error) {
 	raw, err := o.getDeviceProfile(ctx, id)

--- a/apstra/client.go
+++ b/apstra/client.go
@@ -1306,6 +1306,11 @@ func (o *Client) ApiVersion() string {
 	return o.apiVersion
 }
 
+// SupportedVersions returns the Apstra API versions supported by the client
+func (o *Client) SupportedVersions() []string {
+	return parseVersionList(apstraSupportedApiVersions)
+}
+
 // GetDeviceProfile returns device profile
 func (o *Client) GetDeviceProfile(ctx context.Context, id ObjectId) (*DeviceProfile, error) {
 	raw, err := o.getDeviceProfile(ctx, id)

--- a/apstra/compatibility.go
+++ b/apstra/compatibility.go
@@ -41,3 +41,9 @@ func rackBasedTemplateFabricAddressingPolicyForbidden() StringSliceWithIncludes 
 func podBasedTemplateFabricAddressingPolicyForbidden() StringSliceWithIncludes {
 	return parseVersionList(PodBasedTemplateFabricAddressingPolicyForbiddenVersions)
 }
+
+// ApstraApiSupportedVersions returns the Apstra versions supported by this
+// SDK version.
+func ApstraApiSupportedVersions() StringSliceWithIncludes {
+	return apstraSupportedApi()
+}


### PR DESCRIPTION
This PR adds public function `ApstraApiSupportedVersions()` to indicate versions of Apstra supported by the SDK.