### PR TITLE
add missing 'failed' job state to iota methods and tests

### DIFF
--- a/apstra/api_system_agents.go
+++ b/apstra/api_system_agents.go
@@ -163,6 +163,8 @@ func (o AgentJobState) String() string {
 		return string(agentJobStateInProgress)
 	case AgentJobStateSuccess:
 		return string(agentJobStateSuccess)
+	case AgentJobStateFailed:
+		return string(agentJobStateFailed)
 	default:
 		return fmt.Sprintf(agentJobStateUnknown, o)
 	}
@@ -200,6 +202,8 @@ func (o rawAgentJobState) parse() int {
 		return int(AgentJobStateInProgress)
 	case agentJobStateSuccess:
 		return int(AgentJobStateSuccess)
+	case agentJobStateFailed:
+		return int(AgentJobStateFailed)
 	default:
 		return int(AgentJobStateUnknown)
 	}

--- a/apstra/api_system_agents_test.go
+++ b/apstra/api_system_agents_test.go
@@ -277,6 +277,7 @@ func TestSystemAgentsStrings(t *testing.T) {
 		{stringVal: "init", intType: AgentJobStateInit, stringType: agentJobStateInit},
 		{stringVal: "inprogress", intType: AgentJobStateInProgress, stringType: agentJobStateInProgress},
 		{stringVal: "success", intType: AgentJobStateSuccess, stringType: agentJobStateSuccess},
+		{stringVal: "failed", intType: AgentJobStateFailed, stringType: agentJobStateFailed},
 	}
 
 	for i, td := range testData {


### PR DESCRIPTION
This PR adds the `failed` system agent job state to the iota methods and tests.