### PR TITLE
Weeding: Findings from GoLand's "problems" feature

### DIFF
--- a/apstra/api_blueprints.go
+++ b/apstra/api_blueprints.go
@@ -79,7 +79,7 @@ func (o *RefDesign) FromString(s string) error {
 	if err != nil {
 		return err
 	}
-	*o = RefDesign(i)
+	*o = i
 	return nil
 }
 

--- a/apstra/api_blueprints_deploy.go
+++ b/apstra/api_blueprints_deploy.go
@@ -98,14 +98,14 @@ func (o *Client) deployBlueprint(ctx context.Context, in *BlueprintDeployRequest
 		Version:     in.Version,
 	}
 
-	url, err := url.Parse(fmt.Sprintf(apiUrlBlueprintDeploy, in.Id))
+	deployUrl, err := url.Parse(fmt.Sprintf(apiUrlBlueprintDeploy, in.Id))
 	if err != nil {
 		return nil, err
 	}
 
 	err = o.talkToApstra(ctx, &talkToApstraIn{
 		method:   http.MethodPut,
-		url:      url,
+		url:      deployUrl,
 		apiInput: request,
 	})
 	if err != nil {
@@ -115,7 +115,7 @@ func (o *Client) deployBlueprint(ctx context.Context, in *BlueprintDeployRequest
 	response := &rawBlueprintDeployResponse{}
 	err = o.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodGet,
-		url:         url,
+		url:         deployUrl,
 		apiResponse: &response,
 	})
 

--- a/apstra/api_design_configlets.go
+++ b/apstra/api_design_configlets.go
@@ -101,7 +101,7 @@ func (o *ConfigletGenerator) raw() *rawConfigletGenerator {
 	cg.Filename = o.Filename
 	cg.NegationTemplateText = o.NegationTemplateText
 	cg.ConfigStyle = o.ConfigStyle.raw().string()
-	cg.Section = string(ConfigletSection(o.Section).raw())
+	cg.Section = string(o.Section.raw())
 
 	return &cg
 }

--- a/apstra/api_design_interface_map_digests_test.go
+++ b/apstra/api_design_interface_map_digests_test.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"math/rand"
 	"testing"
-	"time"
 )
 
 func TestGetInterfaceMapDigest(t *testing.T) {
@@ -36,7 +35,6 @@ func TestGetInterfaceMapDigest(t *testing.T) {
 }
 
 func TestGetInterfaceMapDigestsByLogicalDevice(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	clients, err := getTestClients(context.Background(), t)
 	if err != nil {
 		t.Fatal(err)
@@ -62,7 +60,6 @@ func TestGetInterfaceMapDigestsByLogicalDevice(t *testing.T) {
 }
 
 func TestGetInterfaceMapDigestsByDeviceProfile(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	clients, err := getTestClients(context.Background(), t)
 	if err != nil {
 		t.Fatal(err)

--- a/apstra/api_design_interface_maps_test.go
+++ b/apstra/api_design_interface_maps_test.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"math/rand"
 	"testing"
-	"time"
 )
 
 func TestInterfaceSettingParam(t *testing.T) {
@@ -38,7 +37,6 @@ func TestInterfaceSettingParam(t *testing.T) {
 }
 
 func TestListGetAllInterfaceMaps(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	clients, err := getTestClients(context.Background(), t)
 	if err != nil {
 		t.Fatal(err)

--- a/apstra/api_design_rack_types_test.go
+++ b/apstra/api_design_rack_types_test.go
@@ -8,11 +8,9 @@ import (
 	"log"
 	"math/rand"
 	"testing"
-	"time"
 )
 
 func TestListGetOneRackType(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	clients, err := getTestClients(context.Background(), t)
 	if err != nil {
 		t.Fatal(err)
@@ -72,7 +70,6 @@ func TestListGetAllGetRackType(t *testing.T) {
 			t.Fatalf("got %d rack type IDs but %d rack types", len(rackTypeIds), len(rackTypes))
 		}
 
-		rand.Seed(time.Now().UnixNano())
 		randRackid := rackTypeIds[rand.Intn(len(rackTypeIds))]
 		log.Printf("testing getRackType() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		rt, err := client.client.GetRackType(context.TODO(), randRackid)

--- a/apstra/api_design_templates.go
+++ b/apstra/api_design_templates.go
@@ -1365,7 +1365,7 @@ func (o *CreateRackBasedTemplateRequest) raw(ctx context.Context, client *Client
 
 		// prep the rackTypeCount object using the caller's map key (ObjectId) as
 		// the link between the racktype data copy and the racktypecount
-		rackTypeCounts[i].RackTypeId = ObjectId(k)
+		rackTypeCounts[i].RackTypeId = k
 		rackTypeCounts[i].Count = ri.Count
 		i++
 	}

--- a/apstra/api_design_templates_test.go
+++ b/apstra/api_design_templates_test.go
@@ -11,7 +11,6 @@ import (
 	"math/rand"
 	"strings"
 	"testing"
-	"time"
 )
 
 func TestUnmarshalTemplate(t *testing.T) {
@@ -445,7 +444,6 @@ func TestGetTemplate(t *testing.T) {
 
 func TestGetTemplateMethods(t *testing.T) {
 	var n int
-	rand.Seed(time.Now().UnixNano())
 
 	clients, err := getTestClients(context.Background(), t)
 	if err != nil {

--- a/apstra/api_metricdb_test.go
+++ b/apstra/api_metricdb_test.go
@@ -59,7 +59,6 @@ func TestUseAggregation(t *testing.T) {
 }
 
 func TestQueryMetricdb(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	clients, err := getTestClients(context.Background(), t)
 	if err != nil {
 		t.Fatal(err)

--- a/apstra/api_property_sets_test.go
+++ b/apstra/api_property_sets_test.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"math/rand"
 	"testing"
-	"time"
 )
 
 func TestCreateGetUpdateGetDeletePropertySet(t *testing.T) {
@@ -44,7 +43,6 @@ func TestCreateGetUpdateGetDeletePropertySet(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rand.Seed(time.Now().UnixNano())
 	samples := rand.Intn(10) + 3
 	ps := &PropertySetData{
 		Label:  randString(10, "hex"),

--- a/apstra/api_ready.go
+++ b/apstra/api_ready.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ready tests whether an Apstra server is ready to handle client requests.
-// It's based based on a code sample shared by JP Senior
+// It's based on a code sample shared by JP Senior
 // https://apstra-eng.slack.com/archives/C2DFCFHJR/p1674246878325579?thread_ts=1674244723.467159&cid=C2DFCFHJR
 func (o *Client) ready(ctx context.Context) error {
 	var err error

--- a/apstra/api_resources_int_test.go
+++ b/apstra/api_resources_int_test.go
@@ -11,7 +11,6 @@ import (
 	"math/rand"
 	"sort"
 	"testing"
-	"time"
 )
 
 const (
@@ -30,7 +29,6 @@ const (
 )
 
 func TestEmptyAsnPool(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	clients, err := getTestClients(context.Background(), t)
 	if err != nil {
 		t.Fatal(err)
@@ -249,7 +247,6 @@ func TestListAsnPoolIds(t *testing.T) {
 }
 
 func TestEmptyVniPool(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	clients, err := getTestClients(context.Background(), t)
 	if err != nil {
 		t.Fatal(err)

--- a/apstra/api_system_agent_test.go
+++ b/apstra/api_system_agent_test.go
@@ -16,7 +16,10 @@ func TestGetSetSystemAgentManagerConfiguration(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		client.client.Login(context.Background())
+		err = client.client.Login(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
 		// initial fetch
 		log.Printf("testing getSystemAgentManagerConfig() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		mgrCfg, err := client.client.getSystemAgentManagerConfig(context.Background())

--- a/apstra/client.go
+++ b/apstra/client.go
@@ -391,7 +391,7 @@ func (o *Client) ListVniPoolIds(ctx context.Context) ([]ObjectId, error) {
 	return o.listVniPoolIds(ctx)
 }
 
-// CreateVniPool adds an Vni pool to Apstra
+// CreateVniPool adds a VNI pool to Apstra
 func (o *Client) CreateVniPool(ctx context.Context, in *VniPoolRequest) (ObjectId, error) {
 	response, err := o.createVniPool(ctx, in)
 	if err != nil {
@@ -410,12 +410,12 @@ func (o *Client) GetVniPoolByName(ctx context.Context, name string) (*VniPool, e
 	return o.getVniPoolByName(ctx, name)
 }
 
-// DeleteVniPool deletes an Vni pool, by ObjectId from Apstra
+// DeleteVniPool deletes a VNI pool, by ObjectId from Apstra
 func (o *Client) DeleteVniPool(ctx context.Context, in ObjectId) error {
 	return o.deleteVniPool(ctx, in)
 }
 
-// UpdateVniPool updates an Vni pool by ObjectId with new Vni pool config
+// UpdateVniPool updates a VNI pool by ObjectId with new Vni pool config
 func (o *Client) UpdateVniPool(ctx context.Context, id ObjectId, cfg *VniPoolRequest) error {
 	// VniPool "write" operations are not concurrency safe
 	// It is important that this lock is performed in the public method, rather than the private
@@ -426,7 +426,7 @@ func (o *Client) UpdateVniPool(ctx context.Context, id ObjectId, cfg *VniPoolReq
 	return o.updateVniPool(ctx, id, cfg)
 }
 
-// CreateVniPoolRange updates an Vni pool by adding a new VniRange
+// CreateVniPoolRange updates a VNI pool by adding a new VniRange
 func (o *Client) CreateVniPoolRange(ctx context.Context, poolId ObjectId, newRange IntfIntRange) error {
 	return o.createVniPoolRange(ctx, poolId, newRange)
 }
@@ -437,7 +437,7 @@ func (o *Client) VniPoolRangeExists(ctx context.Context, poolId ObjectId, VniRan
 	return o.vniPoolRangeExists(ctx, poolId, VniRange)
 }
 
-// DeleteVniPoolRange updates an Vni pool by adding a new VniRange
+// DeleteVniPoolRange updates a VNI pool by adding a new VniRange
 func (o *Client) DeleteVniPoolRange(ctx context.Context, poolId ObjectId, deleteme IntfIntRange) error {
 	return o.deleteVniPoolRange(ctx, poolId, deleteme)
 }
@@ -950,7 +950,7 @@ func (o *Client) GetAllConfiglets(ctx context.Context) ([]Configlet, error) {
 	return result, nil
 }
 
-// ListAllConfiglets gets the List of All configlets' ids
+// ListAllConfiglets gets the List of All configlet IDs
 func (o *Client) ListAllConfiglets(ctx context.Context) ([]ObjectId, error) {
 	return o.listAllConfiglets(ctx)
 }
@@ -1018,7 +1018,7 @@ func (o *Client) GetAllRackBasedTemplates(ctx context.Context) ([]TemplateRackBa
 }
 
 // GetRackBasedTemplateByName returns *RackBasedTemplate if exactly one pod_based template uses the
-// specified name. If zero or more than one templates use the name, an error is returned.
+// specified name. If zero templates or more than one template uses the name, an error is returned.
 func (o *Client) GetRackBasedTemplateByName(ctx context.Context, name string) (*TemplateRackBased, error) {
 	t, err := o.getTemplateByTypeAndName(ctx, templateTypeRackBased, name)
 	if err != nil {
@@ -1059,7 +1059,7 @@ func (o *Client) GetAllPodBasedTemplates(ctx context.Context) ([]TemplatePodBase
 }
 
 // GetPodBasedTemplateByName returns *PodBasedTemplate if exactly one pod_based template uses the
-// specified name. If zero or more than one templates use the name, an error is returned.
+// specified name. If zero templates or more than one template uses the name, an error is returned.
 func (o *Client) GetPodBasedTemplateByName(ctx context.Context, name string) (*TemplatePodBased, error) {
 	t, err := o.getTemplateByTypeAndName(ctx, templateTypePodBased, name)
 	if err != nil {
@@ -1100,7 +1100,7 @@ func (o *Client) GetAllL3CollapsedTemplates(ctx context.Context) ([]TemplateL3Co
 }
 
 // GetL3CollapsedTemplateByName returns *L3CollapsedTemplate if exactly one pod_based template uses the
-// specified name. If zero or more than one templates use the name, an error is returned.
+// specified name. If zero templates or more than one template uses the name, an error is returned.
 func (o *Client) GetL3CollapsedTemplateByName(ctx context.Context, name string) (*TemplateL3Collapsed, error) {
 	t, err := o.getTemplateByTypeAndName(ctx, templateTypeL3Collapsed, name)
 	if err != nil {

--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func randString(n int, style string) string {
-	rand.Seed(time.Now().UnixNano())
-
 	var b64Letters = []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-")
 	var hexLetters = []rune("0123456789abcdef")
 	var letters []rune

--- a/apstra/int_pool.go
+++ b/apstra/int_pool.go
@@ -97,7 +97,7 @@ func (o IntRanges) Overlaps(b IntfIntRange) bool {
 type IntPool struct {
 	Id             ObjectId
 	DisplayName    string
-	Ranges         IntRanges // use the named slice type so we can call IndexOf()
+	Ranges         IntRanges // by using the named slice type we can call IndexOf()
 	Tags           []string
 	Status         PoolStatus
 	CreatedAt      time.Time

--- a/apstra/test_helpers.go
+++ b/apstra/test_helpers.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strconv"
 	"testing"
-	"time"
 )
 
 const envSampleSize = "GOAPSTRA_TEST_SAMPLE_MAX"
@@ -20,7 +19,6 @@ func intsFromZero(length int) []int {
 }
 
 func samples(length int) []int {
-	rand.Seed(time.Now().UnixNano())
 	var sampleSizeStr string
 	var sampleSizeInt int
 	var found bool

--- a/apstra/two_stage_l3_clos_mutex_integration_test.go
+++ b/apstra/two_stage_l3_clos_mutex_integration_test.go
@@ -200,7 +200,10 @@ func TestLockBlockUnlockLockUnlockBlueprintMutex(t *testing.T) {
 			delay := 2 * time.Second
 			log.Printf("Unlock scheduled for %s", time.Now().Add(delay))
 			time.Sleep(delay)
-			bpA.Mutex.Unlock(context.Background())
+			err = bpA.Mutex.Unlock(context.Background())
+			if err != nil {
+				t.Error("error unlocking blueprint")
+			}
 		}()
 
 		start := time.Now()

--- a/apstra/two_stage_l3_clos_resources_test.go
+++ b/apstra/two_stage_l3_clos_resources_test.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"sync"
 	"testing"
-	"time"
 )
 
 func TestSetGetResourceAllocation(t *testing.T) {
@@ -19,8 +18,6 @@ func TestSetGetResourceAllocation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	rand.Seed(time.Now().UnixNano())
 
 	poolCount := rand.Intn(5) + 2
 	randStr := randString(5, "hex")

--- a/apstra/two_stage_l3_clos_security_zones.go
+++ b/apstra/two_stage_l3_clos_security_zones.go
@@ -135,7 +135,7 @@ func (o rawSecurityZone) polish() (*SecurityZone, error) {
 
 	var routeTarget *string
 	if o.RouteTarget != "" {
-		rt := string(o.RouteTarget)
+		rt := o.RouteTarget
 		routeTarget = &rt
 	}
 


### PR DESCRIPTION
- remove deprecated `rand.Seed()` calls
- grammar fixes
- eliminate redundant type conversions
- fix unhandled errors