### PR TITLE
Resource virtual network support

### DIFF
--- a/apstra/api_blueprints.go
+++ b/apstra/api_blueprints.go
@@ -475,9 +475,14 @@ func (o *Client) runQuery(ctx context.Context, blueprint ObjectId, query *QEQuer
 		apstraUrl.RawQuery = params.Encode()
 	}
 
+	qString, err := query.string()
+	if err != nil {
+		return err
+	}
+
 	apiInput := &struct {
 		Query string `json:"query"`
-	}{Query: query.string()}
+	}{Query: qString}
 
 	err = o.talkToApstra(ctx, &talkToApstraIn{
 		method:         http.MethodPost,

--- a/apstra/api_blueprints.go
+++ b/apstra/api_blueprints.go
@@ -463,26 +463,21 @@ func (o *Client) deleteBlueprint(ctx context.Context, id ObjectId) error {
 	})
 }
 
-func (o *Client) runQuery(ctx context.Context, blueprint ObjectId, query *QEQuery, response interface{}) error {
+func (o *Client) runQuery(ctx context.Context, blueprint ObjectId, query QEQuery, response interface{}) error {
 	apstraUrl, err := url.Parse(fmt.Sprintf(apiUrlBlueprintQueryEngine, blueprint))
 	if err != nil {
 		return err
 	}
 
-	if query.blueprintType != BlueprintTypeNone {
+	if query.getBlueprintType() != BlueprintTypeNone {
 		params := apstraUrl.Query()
-		params.Set(blueprintTypeParam, query.blueprintType.string())
+		params.Set(blueprintTypeParam, query.getBlueprintType().string())
 		apstraUrl.RawQuery = params.Encode()
-	}
-
-	qString, err := query.string()
-	if err != nil {
-		return err
 	}
 
 	apiInput := &struct {
 		Query string `json:"query"`
-	}{Query: qString}
+	}{Query: query.String()}
 
 	err = o.talkToApstra(ctx, &talkToApstraIn{
 		method:         http.MethodPost,

--- a/apstra/client.go
+++ b/apstra/client.go
@@ -1161,8 +1161,8 @@ func (o *Client) DeleteTemplate(ctx context.Context, id ObjectId) error {
 	return o.deleteTemplate(ctx, id)
 }
 
-// NewQuery returns a *QEQuery with embedded *Client
-func (o *Client) NewQuery(blueprint ObjectId) *QEQuery {
+// NewQuery returns a *PathQuery with embedded *Client
+func (o *Client) NewQuery(blueprint ObjectId) *PathQuery {
 	return o.newQuery(blueprint)
 }
 
@@ -1616,13 +1616,12 @@ func (o *Client) BlueprintOverlayControlProtocol(ctx context.Context, id ObjectI
 	}
 
 	query := o.NewQuery(id).
-		SetContext(ctx).
 		Node([]QEEAttribute{
 			{"type", QEStringVal("virtual_network_policy")},
 			{"name", QEStringVal("n_virtual_network_policy")},
 		})
 
-	err := query.Do(&result)
+	err := query.Do(ctx, &result)
 	if err != nil {
 		return 0, fmt.Errorf("error querying blueprint virtual network policy - %w", err)
 	}

--- a/apstra/query_engine.go
+++ b/apstra/query_engine.go
@@ -15,9 +15,6 @@ const (
 
 type QEQuery interface {
 	Do(context.Context, interface{}) error
-	SetBlueprintId(ObjectId) QEQuery
-	SetBlueprintType(BlueprintType) QEQuery
-	SetClient(*Client) QEQuery
 	String() string
 	getBlueprintType() BlueprintType
 }
@@ -68,7 +65,7 @@ func (o *QEElement) getLast() *QEElement {
 	return last
 }
 
-func (o QEElement) String() string {
+func (o *QEElement) String() string {
 	attrsSB := strings.Builder{}
 
 	// add first attribute to string builder without leading separator
@@ -140,17 +137,17 @@ func (o *PathQuery) Do(ctx context.Context, response interface{}) error {
 	return o.client.runQuery(ctx, o.blueprintId, o, response)
 }
 
-func (o *PathQuery) SetBlueprintId(id ObjectId) QEQuery {
+func (o *PathQuery) SetBlueprintId(id ObjectId) *PathQuery {
 	o.blueprintId = id
 	return o
 }
 
-func (o *PathQuery) SetBlueprintType(t BlueprintType) QEQuery {
+func (o *PathQuery) SetBlueprintType(t BlueprintType) *PathQuery {
 	o.blueprintType = t
 	return o
 }
 
-func (o *PathQuery) SetClient(client *Client) QEQuery {
+func (o *PathQuery) SetClient(client *Client) *PathQuery {
 	o.client = client
 	return o
 }
@@ -202,33 +199,33 @@ type MatchQuery struct {
 	match         []PathQuery
 }
 
-func (o MatchQuery) getBlueprintType() BlueprintType {
+func (o *MatchQuery) getBlueprintType() BlueprintType {
 	return o.blueprintType
 }
 
-func (o MatchQuery) Do(ctx context.Context, response interface{}) error {
+func (o *MatchQuery) Do(ctx context.Context, response interface{}) error {
 	if o.client == nil {
 		return errors.New("attempt to execute query without setting client")
 	}
 	return o.client.runQuery(ctx, o.blueprintId, o, response)
 }
 
-func (o MatchQuery) SetBlueprintId(id ObjectId) QEQuery {
+func (o *MatchQuery) SetBlueprintId(id ObjectId) QEQuery {
 	o.blueprintId = id
 	return o
 }
 
-func (o MatchQuery) SetBlueprintType(t BlueprintType) QEQuery {
+func (o *MatchQuery) SetBlueprintType(t BlueprintType) QEQuery {
 	o.blueprintType = t
 	return o
 }
 
-func (o MatchQuery) SetClient(client *Client) QEQuery {
+func (o *MatchQuery) SetClient(client *Client) QEQuery {
 	o.client = client
 	return o
 }
 
-func (o MatchQuery) String() string {
+func (o *MatchQuery) String() string {
 	var sb strings.Builder
 	sb.WriteString("match(")
 	for i := range o.match {

--- a/apstra/query_engine.go
+++ b/apstra/query_engine.go
@@ -13,6 +13,18 @@ const (
 	qEElementAttributeSep      = ","
 )
 
+type QEQuery interface {
+	Do(context.Context, interface{}) error
+	SetBlueprintId(ObjectId) QEQuery
+	SetBlueprintType(BlueprintType) QEQuery
+	SetClient(*Client) QEQuery
+	String() string
+	getBlueprintType() BlueprintType
+}
+
+var _ QEQuery = &PathQuery{}
+var _ QEQuery = &MatchQuery{}
+
 type QEEType int
 
 const (
@@ -105,23 +117,61 @@ func (o QEBoolVal) String() string {
 	return "False"
 }
 
-func (o *Client) newQuery(blueprintId ObjectId) *QEQuery {
-	return &QEQuery{
+func (o *Client) newQuery(blueprintId ObjectId) *PathQuery {
+	return &PathQuery{
 		client:      o,
 		blueprintId: blueprintId,
 	}
 }
 
-type QEQuery struct {
+type PathQuery struct {
 	firstElement  *QEElement
 	client        *Client
 	context       context.Context
 	blueprintId   ObjectId
 	blueprintType BlueprintType
-	match         []QEQuery
 }
 
-func (o *QEQuery) addElement(elementType string, attributes []QEEAttribute) *QEQuery {
+func (o *PathQuery) getBlueprintType() BlueprintType {
+	return o.blueprintType
+}
+
+func (o *PathQuery) Do(ctx context.Context, response interface{}) error {
+	return o.client.runQuery(ctx, o.blueprintId, o, response)
+}
+
+func (o *PathQuery) SetBlueprintId(id ObjectId) QEQuery {
+	o.blueprintId = id
+	return o
+}
+
+func (o *PathQuery) SetBlueprintType(t BlueprintType) QEQuery {
+	o.blueprintType = t
+	return o
+}
+
+func (o *PathQuery) SetClient(client *Client) QEQuery {
+	o.client = client
+	return o
+}
+
+func (o *PathQuery) String() string {
+	sb := strings.Builder{}
+
+	var next *QEElement
+	if o.firstElement != nil {
+		sb.WriteString(o.firstElement.String())
+		next = o.firstElement.getNext()
+	}
+	for next != nil {
+		sb.WriteString(".")
+		sb.WriteString(next.String())
+		next = next.next
+	}
+	return sb.String()
+}
+
+func (o *PathQuery) addElement(elementType string, attributes []QEEAttribute) *PathQuery {
 	newElement := QEElement{
 		qeeType:    elementType,
 		attributes: attributes,
@@ -134,86 +184,62 @@ func (o *QEQuery) addElement(elementType string, attributes []QEEAttribute) *QEQ
 	return o
 }
 
-func (o *QEQuery) Node(attributes []QEEAttribute) *QEQuery {
+func (o *PathQuery) Node(attributes []QEEAttribute) *PathQuery {
 	return o.addElement(qEETypeNode, attributes)
 }
-func (o *QEQuery) Out(attributes []QEEAttribute) *QEQuery {
+func (o *PathQuery) Out(attributes []QEEAttribute) *PathQuery {
 	return o.addElement(qEETypeOut, attributes)
 }
-func (o *QEQuery) In(attributes []QEEAttribute) *QEQuery {
+func (o *PathQuery) In(attributes []QEEAttribute) *PathQuery {
 	return o.addElement(qEETypeIn, attributes)
 }
 
-func (o *QEQuery) SetContext(ctx context.Context) *QEQuery {
-	o.context = ctx
-	return o
+type MatchQuery struct {
+	client        *Client
+	context       context.Context
+	blueprintId   ObjectId
+	blueprintType BlueprintType
+	match         []PathQuery
 }
 
-func (o *QEQuery) SetType(t BlueprintType) *QEQuery {
-	o.blueprintType = t
-	return o
+func (o MatchQuery) getBlueprintType() BlueprintType {
+	return o.blueprintType
 }
 
-func (o *QEQuery) SetBlueprintId(id ObjectId) *QEQuery {
-	o.blueprintId = id
-	return o
-}
-
-func (o *QEQuery) String() (string, error) {
-	return o.string()
-}
-
-func (o *QEQuery) string() (string, error) {
-	if o.firstElement != nil && len(o.match) != 0 {
-		return "", errors.New("cannot stringify QEQuery with both path and match elements")
-	}
-
-	sb := strings.Builder{}
-
-	if o.firstElement != nil {
-		var next *QEElement
-		if o.firstElement != nil {
-			sb.WriteString(o.firstElement.String())
-			next = o.firstElement.getNext()
-		}
-		for next != nil {
-			sb.WriteString(".")
-			sb.WriteString(next.String())
-			next = next.next
-		}
-		return sb.String(), nil
-	}
-
-	if len(o.match) != 0 {
-		sb.WriteString("match(")
-		for i := range o.match {
-			s, err := o.match[i].string()
-			if err != nil {
-				return "", err
-			}
-			sb.WriteString(s + ",")
-		}
-		sb.WriteString(")")
-		return sb.String(), nil
-	}
-
-	return "", errors.New("cannot stringify QEQuery with neither path nor match elements")
-}
-
-func (o *QEQuery) SetClient(client *Client) *QEQuery {
-	o.client = client
-	return o
-}
-
-func (o *QEQuery) Do(response interface{}) error {
-	ctx := o.context
-	if o.context == nil {
-		ctx = context.TODO()
+func (o MatchQuery) Do(ctx context.Context, response interface{}) error {
+	if o.client == nil {
+		return errors.New("attempt to execute query without setting client")
 	}
 	return o.client.runQuery(ctx, o.blueprintId, o, response)
 }
 
-func (o *QEQuery) Match(q *QEQuery) *QEQuery {
+func (o MatchQuery) SetBlueprintId(id ObjectId) QEQuery {
+	o.blueprintId = id
+	return o
+}
+
+func (o MatchQuery) SetBlueprintType(t BlueprintType) QEQuery {
+	o.blueprintType = t
+	return o
+}
+
+func (o MatchQuery) SetClient(client *Client) QEQuery {
+	o.client = client
+	return o
+}
+
+func (o MatchQuery) String() string {
+	var sb strings.Builder
+	sb.WriteString("match(")
+	for i := range o.match {
+		s := o.match[i].String()
+		sb.WriteString(s + ",")
+	}
+
+	return sb.String()[:sb.Len()-1] + ")" // omit the trailing ',' and then tack on the closing ')'
+}
+
+func (o *MatchQuery) Match(q *PathQuery) *MatchQuery {
 	o.match = append(o.match, *q)
 	return o
 }

--- a/apstra/query_engine.go
+++ b/apstra/query_engine.go
@@ -210,17 +210,17 @@ func (o *MatchQuery) Do(ctx context.Context, response interface{}) error {
 	return o.client.runQuery(ctx, o.blueprintId, o, response)
 }
 
-func (o *MatchQuery) SetBlueprintId(id ObjectId) QEQuery {
+func (o *MatchQuery) SetBlueprintId(id ObjectId) *MatchQuery {
 	o.blueprintId = id
 	return o
 }
 
-func (o *MatchQuery) SetBlueprintType(t BlueprintType) QEQuery {
+func (o *MatchQuery) SetBlueprintType(t BlueprintType) *MatchQuery {
 	o.blueprintType = t
 	return o
 }
 
-func (o *MatchQuery) SetClient(client *Client) QEQuery {
+func (o *MatchQuery) SetClient(client *Client) *MatchQuery {
 	o.client = client
 	return o
 }

--- a/apstra/query_engine.go
+++ b/apstra/query_engine.go
@@ -152,6 +152,11 @@ func (o *QEQuery) SetType(t BlueprintType) *QEQuery {
 	return o
 }
 
+func (o *QEQuery) SetBlueprintId(id ObjectId) *QEQuery {
+	o.blueprintId = id
+	return o
+}
+
 func (o *QEQuery) String() string {
 	return o.string()
 }

--- a/apstra/query_engine.go
+++ b/apstra/query_engine.go
@@ -106,8 +106,8 @@ func (o QEBoolVal) String() string {
 
 func (o *Client) newQuery(blueprint ObjectId) *QEQuery {
 	return &QEQuery{
-		client:    o,
-		blueprint: blueprint,
+		client:      o,
+		blueprintId: blueprint,
 	}
 }
 
@@ -115,7 +115,7 @@ type QEQuery struct {
 	firstElement  *QEElement
 	client        *Client
 	context       context.Context
-	blueprint     ObjectId
+	blueprintId   ObjectId
 	blueprintType BlueprintType
 }
 
@@ -175,5 +175,5 @@ func (o *QEQuery) Do(response interface{}) error {
 	if o.context == nil {
 		ctx = context.TODO()
 	}
-	return o.client.runQuery(ctx, o.blueprint, o, response)
+	return o.client.runQuery(ctx, o.blueprintId, o, response)
 }

--- a/apstra/query_engine.go
+++ b/apstra/query_engine.go
@@ -200,6 +200,11 @@ func (o *QEQuery) string() (string, error) {
 	return "", errors.New("cannot stringify QEQuery with neither path nor match elements")
 }
 
+func (o *QEQuery) SetClient(client *Client) *QEQuery {
+	o.client = client
+	return o
+}
+
 func (o *QEQuery) Do(response interface{}) error {
 	ctx := o.context
 	if o.context == nil {

--- a/apstra/query_engine.go
+++ b/apstra/query_engine.go
@@ -104,10 +104,10 @@ func (o QEBoolVal) String() string {
 	return "False"
 }
 
-func (o *Client) newQuery(blueprint ObjectId) *QEQuery {
+func (o *Client) newQuery(blueprintId ObjectId) *QEQuery {
 	return &QEQuery{
 		client:      o,
-		blueprintId: blueprint,
+		blueprintId: blueprintId,
 	}
 }
 

--- a/apstra/query_engine.go
+++ b/apstra/query_engine.go
@@ -229,11 +229,14 @@ func (o *MatchQuery) String() string {
 	var sb strings.Builder
 	sb.WriteString("match(")
 	for i := range o.match {
-		s := o.match[i].String()
-		sb.WriteString(s + ",")
+		if i != 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(o.match[i].String())
 	}
+	sb.WriteString(")")
 
-	return sb.String()[:sb.Len()-1] + ")" // omit the trailing ',' and then tack on the closing ')'
+	return sb.String()
 }
 
 func (o *MatchQuery) Match(q *PathQuery) *MatchQuery {

--- a/apstra/query_engine_test.go
+++ b/apstra/query_engine_test.go
@@ -49,8 +49,8 @@ func TestQEEAttributeString(t *testing.T) {
 }
 
 func TestQueryString(t *testing.T) {
-	x := QEQuery{}
-	y, err := x.Node([]QEEAttribute{
+	x := PathQuery{}
+	y := x.Node([]QEEAttribute{
 		{"type", QEStringVal("system")},
 		{"name", QEStringVal("n_system")},
 		{"system_type", QEStringVal("switch")},
@@ -64,10 +64,7 @@ func TestQueryString(t *testing.T) {
 			{"type", QEStringVal("interface_map")},
 			{"name", QEStringVal("n_interface_map")},
 		}).
-		string()
-	if err != nil {
-		t.Fatal(err)
-	}
+		String()
 	log.Println("\n", y)
 }
 
@@ -116,7 +113,7 @@ func TestParsingQueryInfo(t *testing.T) {
 				{"type", QEStringVal("logical_device")},
 				{"name", QEStringVal("n_logical_device")},
 			}).
-			Do(&qResponse)
+			Do(ctx, &qResponse)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -129,8 +126,9 @@ func TestParsingQueryInfo(t *testing.T) {
 }
 
 func TestQueryMatchString(t *testing.T) {
-	expected := "match(node(type='system',name='n_system',role=is_in(['superspine','spine','leaf']),external=False).in_(type='tag').node(type='tag',label='tag_a',name='n_tag_a'),node(type='system',name='n_system',role=is_in(['superspine','spine','leaf']),external=False).in_(type='tag').node(type='tag',label='tag_b',name='n_tag_b'),)"
-	matchTagA := new(QEQuery).
+	expected := "match(node(type='system',name='n_system',role=is_in(['superspine','spine','leaf']),external=False).in_(type='tag').node(type='tag',label='tag_a',name='n_tag_a'),node(type='system',name='n_system',role=is_in(['superspine','spine','leaf']),external=False).in_(type='tag').node(type='tag',label='tag_b',name='n_tag_b'))"
+
+	queryTagA := new(PathQuery).
 		Node([]QEEAttribute{
 			{"type", QEStringVal("system")},
 			{"name", QEStringVal("n_system")},
@@ -146,7 +144,7 @@ func TestQueryMatchString(t *testing.T) {
 			{"name", QEStringVal("n_tag_a")},
 		})
 
-	matchTagB := new(QEQuery).
+	queryTagB := new(PathQuery).
 		Node([]QEEAttribute{
 			{"type", QEStringVal("system")},
 			{"name", QEStringVal("n_system")},
@@ -162,10 +160,7 @@ func TestQueryMatchString(t *testing.T) {
 			{"name", QEStringVal("n_tag_b")},
 		})
 
-	result, err := new(QEQuery).Match(matchTagA).Match(matchTagB).String()
-	if err != nil {
-		t.Fatal(err)
-	}
+	result := new(MatchQuery).Match(queryTagA).Match(queryTagB).String()
 
 	if result != expected {
 		t.Fatalf("expected %q, got %q\n", expected, result)

--- a/apstra/two_stage_l3_clos_virtual_networks.go
+++ b/apstra/two_stage_l3_clos_virtual_networks.go
@@ -259,9 +259,20 @@ const (
 func (o VnType) String() string {
 	return string(o.raw())
 }
+
 func (o VnType) int() int {
 	return int(o)
 }
+
+func (o *VnType) FromString(s string) error {
+	i, err := vnType(s).parse()
+	if err != nil {
+		return err
+	}
+	*o = VnType(i)
+	return nil
+}
+
 func (o VnType) raw() vnType {
 	switch o {
 	case VnTypeNone:
@@ -291,6 +302,22 @@ func (o vnType) parse() (int, error) {
 		return int(VnTypeVxlan), nil
 	default:
 		return 0, fmt.Errorf(VnTypeUnknown, o)
+	}
+}
+
+// AllVirtualNetworkTypes returns the []VnType representing
+// each supported VnType
+func AllVirtualNetworkTypes() []VnType {
+	i := 0
+	var result []VnType
+	for {
+		var os VnType
+		err := os.FromString(VnType(i).String())
+		if err != nil {
+			return result[:i]
+		}
+		result = append(result, os)
+		i++
 	}
 }
 

--- a/apstra/two_stage_l3_clos_virtual_networks.go
+++ b/apstra/two_stage_l3_clos_virtual_networks.go
@@ -307,16 +307,16 @@ func (o vnType) parse() (int, error) {
 
 // AllVirtualNetworkTypes returns the []VnType representing
 // each supported VnType
-func AllVirtualNetworkTypes() []*VnType {
+func AllVirtualNetworkTypes() []VnType {
 	i := 0
-	var result []*VnType
+	var result []VnType
 	for {
-		var vnt VnType
-		err := vnt.FromString(VnType(i).String())
+		var os VnType
+		err := os.FromString(VnType(i).String())
 		if err != nil {
 			return result[:i]
 		}
-		result = append(result, &vnt)
+		result = append(result, os)
 		i++
 	}
 }

--- a/apstra/two_stage_l3_clos_virtual_networks.go
+++ b/apstra/two_stage_l3_clos_virtual_networks.go
@@ -307,16 +307,16 @@ func (o vnType) parse() (int, error) {
 
 // AllVirtualNetworkTypes returns the []VnType representing
 // each supported VnType
-func AllVirtualNetworkTypes() []VnType {
+func AllVirtualNetworkTypes() []*VnType {
 	i := 0
-	var result []VnType
+	var result []*VnType
 	for {
-		var os VnType
-		err := os.FromString(VnType(i).String())
+		var vnt VnType
+		err := vnt.FromString(VnType(i).String())
 		if err != nil {
 			return result[:i]
 		}
-		result = append(result, os)
+		result = append(result, &vnt)
 		i++
 	}
 }

--- a/apstra/two_stage_l3_clos_virtual_networks_integration_test.go
+++ b/apstra/two_stage_l3_clos_virtual_networks_integration_test.go
@@ -208,14 +208,14 @@ func TestCreateUpdateDeleteVirtualNetwork(t *testing.T) {
 			} `json:"items"`
 		}
 
-		query := client.client.NewQuery(bpClient.Id()).SetContext(ctx).Node([]QEEAttribute{
+		query := client.client.NewQuery(bpClient.Id()).Node([]QEEAttribute{
 			{"type", QEStringVal("system")},
 			{"system_type", QEStringVal("switch")},
 			{"role", QEStringVal("leaf")},
 			{"name", QEStringVal("system")},
 		})
 
-		err = query.Do(&result)
+		err = query.Do(ctx, &result)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This PR introduces changes needed to support Virtual Network objects in Terraform.

!!!! Breaking Change !!!!
`QEQuery` is now an interface. The original object, which fulfills the interface has been renamed `PathQuery`.

!!!! Breaking Change !!!!
The `SetContext()` is method is no longer part of the former `QEQuery` object nor any implementations of the new `QEQuery interface.

!!!! Breaking Change !!!!
The `QEQuery.Do()` method now takes a context (it's no longer "set" in advance, as noted above).

There are new two implementations of the `QEQuery` interface: `PathQuery`, which is the old `QEQuery` object, and `MatchQuery`, which supports the logical AND of multiple queries using the Apstra Query Engine's `match` syntax.

Down the road I'd like to deprecate the `Client.NewQuery()` method because now `QEQuery` objects don't necessarily need `client` and `blueprintId` elements populated (these are handled by the parent query in the `match` case. This PR introduces the `SetBlueprint()` and `SetClient()` methods with that in mind (previously those elements were set in by `NewQuery()` with no way of reaching them.

Finally, this PR introduces some VirtualNetwork iota helper functions which follow the usual pattern.