### PR TITLE
Resource virtual network support

### DIFF
--- a/apstra/api_blueprints.go
+++ b/apstra/api_blueprints.go
@@ -24,13 +24,15 @@ const (
 const (
 	NodeTypeNone = NodeType(iota)
 	NodeTypeMetadata
+	NodeTypeRedundancyGroup
 	NodeTypeSystem
 	NodeTypeUnknown = "unknown node type %s"
 
-	nodeTypeNone     = nodeType("")
-	nodeTypeMetadata = nodeType("metadata")
-	nodeTypeSystem   = nodeType("system")
-	nodeTypeUnknown  = "unknown node type %d"
+	nodeTypeNone            = nodeType("")
+	nodeTypeMetadata        = nodeType("metadata")
+	nodeTypeRedundancyGroup = nodeType("redundancy_group")
+	nodeTypeSystem          = nodeType("system")
+	nodeTypeUnknown         = "unknown node type %d"
 )
 
 type NodeType int
@@ -42,6 +44,8 @@ func (o NodeType) String() string {
 		return string(nodeTypeNone)
 	case NodeTypeMetadata:
 		return string(nodeTypeMetadata)
+	case NodeTypeRedundancyGroup:
+		return string(nodeTypeRedundancyGroup)
 	case NodeTypeSystem:
 		return string(nodeTypeSystem)
 	default:

--- a/apstra/two_stage_l3_clos_resources.go
+++ b/apstra/two_stage_l3_clos_resources.go
@@ -53,27 +53,29 @@ const (
 	ResourceGroupNameMlagDomainIp4
 	ResourceGroupNameVtepIp4
 	ResourceGroupNameEvpnL3Vni
+	ResourceGroupNameVirtualNetworkSviIpv4
 	ResourceGroupNameUnknown
 
-	resourceGroupNameNone               = resourceGroupName("")
-	resourceGroupNameSuperspineAsn      = resourceGroupName("superspine_asns")
-	resourceGroupNameSpineAsn           = resourceGroupName("spine_asns")
-	resourceGroupNameLeafAsn            = resourceGroupName("leaf_asns")
-	resourceGroupNameAccessAsn          = resourceGroupName("access_asns")
-	resourceGroupNameSuperspineIp4      = resourceGroupName("superspine_loopback_ips")
-	resourceGroupNameSpineIp4           = resourceGroupName("spine_loopback_ips")
-	resourceGroupNameLeafIp4            = resourceGroupName("leaf_loopback_ips")
-	resourceGroupNameAccessIp4          = resourceGroupName("access_loopback_ips")
-	resourceGroupNameSuperspineSpineIp4 = resourceGroupName("spine_superspine_link_ips")
-	resourceGroupNameSuperspineSpineIp6 = resourceGroupName("ipv6_spine_superspine_link_ips")
-	resourceGroupNameSpineLeafIp4       = resourceGroupName("spine_leaf_link_ips")
-	resourceGroupNameSpineLeafIp6       = resourceGroupName("ipv6_spine_leaf_link_ips")
-	resourceGroupNameLeafLeafIp4        = resourceGroupName("leaf_leaf_link_ips")
-	resourceGroupNameMlagDomainSviIp4   = resourceGroupName("mlag_domain_svi_subnets")
-	resourceGroupNameAccessAccessIp4    = resourceGroupName("access_l3_peer_link_link_ips")
-	resourceGroupNameVtepIp4            = resourceGroupName("vtep_ips")
-	resourceGroupNameEvpnL3Vni          = resourceGroupName("evpn_l3_vnis")
-	resourceGroupNameUnknown            = "group name %d unknown"
+	resourceGroupNameNone                  = resourceGroupName("")
+	resourceGroupNameSuperspineAsn         = resourceGroupName("superspine_asns")
+	resourceGroupNameSpineAsn              = resourceGroupName("spine_asns")
+	resourceGroupNameLeafAsn               = resourceGroupName("leaf_asns")
+	resourceGroupNameAccessAsn             = resourceGroupName("access_asns")
+	resourceGroupNameSuperspineIp4         = resourceGroupName("superspine_loopback_ips")
+	resourceGroupNameSpineIp4              = resourceGroupName("spine_loopback_ips")
+	resourceGroupNameLeafIp4               = resourceGroupName("leaf_loopback_ips")
+	resourceGroupNameAccessIp4             = resourceGroupName("access_loopback_ips")
+	resourceGroupNameSuperspineSpineIp4    = resourceGroupName("spine_superspine_link_ips")
+	resourceGroupNameSuperspineSpineIp6    = resourceGroupName("ipv6_spine_superspine_link_ips")
+	resourceGroupNameSpineLeafIp4          = resourceGroupName("spine_leaf_link_ips")
+	resourceGroupNameSpineLeafIp6          = resourceGroupName("ipv6_spine_leaf_link_ips")
+	resourceGroupNameLeafLeafIp4           = resourceGroupName("leaf_leaf_link_ips")
+	resourceGroupNameMlagDomainSviIp4      = resourceGroupName("mlag_domain_svi_subnets")
+	resourceGroupNameAccessAccessIp4       = resourceGroupName("access_l3_peer_link_link_ips")
+	resourceGroupNameVtepIp4               = resourceGroupName("vtep_ips")
+	resourceGroupNameEvpnL3Vni             = resourceGroupName("evpn_l3_vnis")
+	resourceGroupNameVirtualNetworkSviIpv4 = resourceGroupName("virtual_network_svi_subnets")
+	resourceGroupNameUnknown               = "group name %d unknown"
 )
 
 type ResourceGroupName int
@@ -131,6 +133,8 @@ func (o *ResourceGroupName) Type() ResourceType {
 		return ResourceTypeIp4Pool
 	case ResourceGroupNameEvpnL3Vni:
 		return ResourceTypeVniPool
+	case ResourceGroupNameVirtualNetworkSviIpv4:
+		return ResourceTypeIp4Pool
 	}
 	return ResourceTypeUnknown
 }
@@ -189,6 +193,8 @@ func (o ResourceGroupName) raw() resourceGroupName {
 		return resourceGroupNameVtepIp4
 	case ResourceGroupNameEvpnL3Vni:
 		return resourceGroupNameEvpnL3Vni
+	case ResourceGroupNameVirtualNetworkSviIpv4:
+		return resourceGroupNameVirtualNetworkSviIpv4
 	default:
 		return resourceGroupName(fmt.Sprintf(resourceGroupNameUnknown, o))
 	}
@@ -234,6 +240,8 @@ func (o resourceGroupName) parse() (int, error) {
 		return int(ResourceGroupNameVtepIp4), nil
 	case resourceGroupNameEvpnL3Vni:
 		return int(ResourceGroupNameEvpnL3Vni), nil
+	case resourceGroupNameVirtualNetworkSviIpv4:
+		return int(ResourceGroupNameVirtualNetworkSviIpv4), nil
 	default:
 		return int(ResourceGroupNameUnknown), fmt.Errorf("unknown group name '%s'", o)
 	}

--- a/apstra/two_stage_l3_clos_resources.go
+++ b/apstra/two_stage_l3_clos_resources.go
@@ -54,6 +54,7 @@ const (
 	ResourceGroupNameVtepIp4
 	ResourceGroupNameEvpnL3Vni
 	ResourceGroupNameVirtualNetworkSviIpv4
+	ResourceGroupNameVirtualNetworkSviIpv6
 	ResourceGroupNameUnknown
 
 	resourceGroupNameNone                  = resourceGroupName("")
@@ -75,6 +76,7 @@ const (
 	resourceGroupNameVtepIp4               = resourceGroupName("vtep_ips")
 	resourceGroupNameEvpnL3Vni             = resourceGroupName("evpn_l3_vnis")
 	resourceGroupNameVirtualNetworkSviIpv4 = resourceGroupName("virtual_network_svi_subnets")
+	resourceGroupNameVirtualNetworkSviIpv6 = resourceGroupName("virtual_network_svi_subnets_ipv6")
 	resourceGroupNameUnknown               = "group name %d unknown"
 )
 
@@ -135,6 +137,8 @@ func (o *ResourceGroupName) Type() ResourceType {
 		return ResourceTypeVniPool
 	case ResourceGroupNameVirtualNetworkSviIpv4:
 		return ResourceTypeIp4Pool
+	case ResourceGroupNameVirtualNetworkSviIpv6:
+		return ResourceTypeIp6Pool
 	}
 	return ResourceTypeUnknown
 }
@@ -195,6 +199,8 @@ func (o ResourceGroupName) raw() resourceGroupName {
 		return resourceGroupNameEvpnL3Vni
 	case ResourceGroupNameVirtualNetworkSviIpv4:
 		return resourceGroupNameVirtualNetworkSviIpv4
+	case ResourceGroupNameVirtualNetworkSviIpv6:
+		return resourceGroupNameVirtualNetworkSviIpv6
 	default:
 		return resourceGroupName(fmt.Sprintf(resourceGroupNameUnknown, o))
 	}
@@ -242,6 +248,8 @@ func (o resourceGroupName) parse() (int, error) {
 		return int(ResourceGroupNameEvpnL3Vni), nil
 	case resourceGroupNameVirtualNetworkSviIpv4:
 		return int(ResourceGroupNameVirtualNetworkSviIpv4), nil
+	case resourceGroupNameVirtualNetworkSviIpv6:
+		return int(ResourceGroupNameVirtualNetworkSviIpv6), nil
 	default:
 		return int(ResourceGroupNameUnknown), fmt.Errorf("unknown group name '%s'", o)
 	}

--- a/apstra/two_stage_l3_clos_resources_test.go
+++ b/apstra/two_stage_l3_clos_resources_test.go
@@ -154,6 +154,7 @@ func TestTwoStageL3ClosResourceStrings(t *testing.T) {
 		{stringVal: "mlag_domain_svi_subnets", intType: ResourceGroupNameMlagDomainIp4, stringType: resourceGroupNameMlagDomainSviIp4},
 		{stringVal: "vtep_ips", intType: ResourceGroupNameVtepIp4, stringType: resourceGroupNameVtepIp4},
 		{stringVal: "evpn_l3_vnis", intType: ResourceGroupNameEvpnL3Vni, stringType: resourceGroupNameEvpnL3Vni},
+		{stringVal: "virtual_network_svi_subnets", intType: ResourceGroupNameVirtualNetworkSviIpv4, stringType: resourceGroupNameVirtualNetworkSviIpv4},
 	}
 
 	for i, td := range testData {

--- a/apstra/two_stage_l3_clos_resources_test.go
+++ b/apstra/two_stage_l3_clos_resources_test.go
@@ -155,6 +155,7 @@ func TestTwoStageL3ClosResourceStrings(t *testing.T) {
 		{stringVal: "vtep_ips", intType: ResourceGroupNameVtepIp4, stringType: resourceGroupNameVtepIp4},
 		{stringVal: "evpn_l3_vnis", intType: ResourceGroupNameEvpnL3Vni, stringType: resourceGroupNameEvpnL3Vni},
 		{stringVal: "virtual_network_svi_subnets", intType: ResourceGroupNameVirtualNetworkSviIpv4, stringType: resourceGroupNameVirtualNetworkSviIpv4},
+		{stringVal: "virtual_network_svi_subnets_ipv6", intType: ResourceGroupNameVirtualNetworkSviIpv6, stringType: resourceGroupNameVirtualNetworkSviIpv6},
 	}
 
 	for i, td := range testData {

--- a/apstra/two_stage_l3_clos_virtual_networks.go
+++ b/apstra/two_stage_l3_clos_virtual_networks.go
@@ -547,8 +547,13 @@ func (o *VirtualNetworkData) raw() *rawVirtualNetwork {
 		sviIps[i] = *o.SviIps[i].raw()
 	}
 
-	virtualGatewayIpv4 := o.VirtualGatewayIpv4.String()
-	virtualGatewayIpv6 := o.VirtualGatewayIpv6.String()
+	var virtualGatewayIpv4, virtualGatewayIpv6 string
+	if len(o.VirtualGatewayIpv4.To4()) == net.IPv4len {
+		virtualGatewayIpv4 = o.VirtualGatewayIpv4.String()
+	}
+	if len(o.VirtualGatewayIpv6) == net.IPv6len {
+		virtualGatewayIpv6 = o.VirtualGatewayIpv6.String()
+	}
 
 	var vnId string
 	if o.VnId != nil {

--- a/apstra/two_stage_l3_clos_virtual_networks.go
+++ b/apstra/two_stage_l3_clos_virtual_networks.go
@@ -243,13 +243,11 @@ type VnType int
 type vnType string
 
 const (
-	VnTypeNone = VnType(iota)
-	VnTypeExternal
+	VnTypeExternal = VnType(iota)
 	VnTypeVlan
 	VnTypeVxlan
 	VnTypeUnknown = "unknown VN type '%s'"
 
-	vnTypeNone     = vnType("")
 	vnTypeExternal = vnType("external")
 	vnTypeVlan     = vnType("vlan")
 	vnTypeVxlan    = vnType("vxlan")

--- a/apstra/two_stage_l3_clos_virtual_networks.go
+++ b/apstra/two_stage_l3_clos_virtual_networks.go
@@ -327,13 +327,19 @@ type systemRole string
 const (
 	SystemRoleNone = SystemRole(iota)
 	SystemRoleAccess
+	SystemRoleGeneric
 	SystemRoleLeaf
+	SystemRoleSpine
+	SystemRoleSuperSpine
 	SystemRoleUnknown = "unknown System Role '%s'"
 
-	systemRoleNone    = systemRole("")
-	systemRoleAccess  = systemRole("access")
-	systemRoleLeaf    = systemRole("leaf")
-	systemRoleUnknown = "unknown System Role '%d'"
+	systemRoleNone       = systemRole("")
+	systemRoleAccess     = systemRole("access")
+	systemRoleGeneric    = systemRole("generic")
+	systemRoleLeaf       = systemRole("leaf")
+	systemRoleSpine      = systemRole("spine")
+	systemRoleSuperSpine = systemRole("superspine")
+	systemRoleUnknown    = "unknown System Role '%d'"
 )
 
 func (o SystemRole) String() string {
@@ -350,8 +356,14 @@ func (o SystemRole) raw() systemRole {
 		return systemRoleNone
 	case SystemRoleAccess:
 		return systemRoleAccess
+	case SystemRoleGeneric:
+		return systemRoleGeneric
 	case SystemRoleLeaf:
 		return systemRoleLeaf
+	case SystemRoleSpine:
+		return systemRoleSpine
+	case SystemRoleSuperSpine:
+		return systemRoleSuperSpine
 	default:
 		return systemRole(fmt.Sprintf(systemRoleUnknown, o))
 	}
@@ -376,8 +388,14 @@ func (o systemRole) parse() (int, error) {
 		return int(SystemRoleNone), nil
 	case systemRoleAccess:
 		return int(SystemRoleAccess), nil
+	case systemRoleGeneric:
+		return int(SystemRoleGeneric), nil
 	case systemRoleLeaf:
 		return int(SystemRoleLeaf), nil
+	case systemRoleSpine:
+		return int(SystemRoleSpine), nil
+	case systemRoleSuperSpine:
+		return int(SystemRoleSuperSpine), nil
 	default:
 		return 0, fmt.Errorf(SystemRoleUnknown, o)
 	}

--- a/apstra/two_stage_l3_clos_virtual_networks.go
+++ b/apstra/two_stage_l3_clos_virtual_networks.go
@@ -273,8 +273,6 @@ func (o *VnType) FromString(s string) error {
 
 func (o VnType) raw() vnType {
 	switch o {
-	case VnTypeNone:
-		return vnTypeNone
 	case VnTypeExternal:
 		return vnTypeExternal
 	case VnTypeVlan:
@@ -290,8 +288,6 @@ func (o vnType) string() string {
 }
 func (o vnType) parse() (int, error) {
 	switch o {
-	case vnTypeNone:
-		return int(VnTypeNone), nil
 	case vnTypeExternal:
 		return int(VnTypeExternal), nil
 	case vnTypeVlan:

--- a/apstra/two_stage_l3_clos_virtual_networks.go
+++ b/apstra/two_stage_l3_clos_virtual_networks.go
@@ -339,9 +339,11 @@ const (
 func (o SystemRole) String() string {
 	return string(o.raw())
 }
+
 func (o SystemRole) int() int {
 	return int(o)
 }
+
 func (o SystemRole) raw() systemRole {
 	switch o {
 	case SystemRoleNone:
@@ -354,9 +356,20 @@ func (o SystemRole) raw() systemRole {
 		return systemRole(fmt.Sprintf(systemRoleUnknown, o))
 	}
 }
+
+func (o *SystemRole) FromString(in string) error {
+	i, err := systemRole(in).parse()
+	if err != nil {
+		return err
+	}
+	*o = SystemRole(i)
+	return nil
+}
+
 func (o systemRole) string() string {
 	return string(o)
 }
+
 func (o systemRole) parse() (int, error) {
 	switch o {
 	case systemRoleNone:

--- a/apstra/two_stage_l3_clos_virtual_networks.go
+++ b/apstra/two_stage_l3_clos_virtual_networks.go
@@ -244,16 +244,16 @@ type vnType string
 
 const (
 	VnTypeNone = VnType(iota)
+	VnTypeExternal
 	VnTypeVlan
 	VnTypeVxlan
-	VnTypeOverlay
 	VnTypeUnknown = "unknown VN type '%s'"
 
-	vnTypeNone    = vnType("")
-	vnTypeVlan    = vnType("vlan")
-	vnTypeVxlan   = vnType("vxlan")
-	vnTypeOverlay = vnType("overlay")
-	vnTypeUnknown = "unknown VN type '%d'"
+	vnTypeNone     = vnType("")
+	vnTypeExternal = vnType("external")
+	vnTypeVlan     = vnType("vlan")
+	vnTypeVxlan    = vnType("vxlan")
+	vnTypeUnknown  = "unknown VN type '%d'"
 )
 
 func (o VnType) String() string {
@@ -277,8 +277,8 @@ func (o VnType) raw() vnType {
 	switch o {
 	case VnTypeNone:
 		return vnTypeNone
-	case VnTypeOverlay:
-		return vnTypeOverlay
+	case VnTypeExternal:
+		return vnTypeExternal
 	case VnTypeVlan:
 		return vnTypeVlan
 	case VnTypeVxlan:
@@ -294,8 +294,8 @@ func (o vnType) parse() (int, error) {
 	switch o {
 	case vnTypeNone:
 		return int(VnTypeNone), nil
-	case vnTypeOverlay:
-		return int(VnTypeOverlay), nil
+	case vnTypeExternal:
+		return int(VnTypeExternal), nil
 	case vnTypeVlan:
 		return int(VnTypeVlan), nil
 	case vnTypeVxlan:

--- a/apstra/two_stage_l3_clos_virtual_networks.go
+++ b/apstra/two_stage_l3_clos_virtual_networks.go
@@ -547,13 +547,8 @@ func (o *VirtualNetworkData) raw() *rawVirtualNetwork {
 		sviIps[i] = *o.SviIps[i].raw()
 	}
 
-	var virtualGatewayIpv4, virtualGatewayIpv6 string
-	if len(o.VirtualGatewayIpv4) == 4 {
-		virtualGatewayIpv4 = o.VirtualGatewayIpv4.String()
-	}
-	if len(o.VirtualGatewayIpv6) == 16 {
-		virtualGatewayIpv6 = o.VirtualGatewayIpv6.String()
-	}
+	virtualGatewayIpv4 := o.VirtualGatewayIpv4.String()
+	virtualGatewayIpv6 := o.VirtualGatewayIpv6.String()
 
 	var vnId string
 	if o.VnId != nil {

--- a/apstra/two_stage_l3_clos_virtual_networks_unit_test.go
+++ b/apstra/two_stage_l3_clos_virtual_networks_unit_test.go
@@ -41,7 +41,6 @@ func TestTwoStageL3ClosVirtualNetworkStrings(t *testing.T) {
 		{stringVal: "forced", intType: Ipv6ModeForced, stringType: ipv6ModeForced},
 		{stringVal: "link_local", intType: Ipv6ModeLinkLocal, stringType: ipv6ModeLinkLocal},
 
-		{stringVal: "", intType: VnTypeNone, stringType: vnTypeNone},
 		{stringVal: "vlan", intType: VnTypeVlan, stringType: vnTypeVlan},
 		{stringVal: "vxlan", intType: VnTypeVxlan, stringType: vnTypeVxlan},
 		{stringVal: "external", intType: VnTypeExternal, stringType: vnTypeExternal},

--- a/apstra/two_stage_l3_clos_virtual_networks_unit_test.go
+++ b/apstra/two_stage_l3_clos_virtual_networks_unit_test.go
@@ -44,7 +44,7 @@ func TestTwoStageL3ClosVirtualNetworkStrings(t *testing.T) {
 		{stringVal: "", intType: VnTypeNone, stringType: vnTypeNone},
 		{stringVal: "vlan", intType: VnTypeVlan, stringType: vnTypeVlan},
 		{stringVal: "vxlan", intType: VnTypeVxlan, stringType: vnTypeVxlan},
-		{stringVal: "overlay", intType: VnTypeOverlay, stringType: vnTypeOverlay},
+		{stringVal: "external", intType: VnTypeExternal, stringType: vnTypeExternal},
 
 		{stringVal: "", intType: SystemRoleNone, stringType: systemRoleNone},
 		{stringVal: "access", intType: SystemRoleAccess, stringType: systemRoleAccess},


### PR DESCRIPTION
Features required for virtual network support.

- handful of new iota types
- new `MatchQuery` support for executing parallel / merged graph db queries using the [`match` function](https://www.juniper.net/documentation/us/en/software/apstra4.1/apstra-user-guide/topics/topic-map/graph.html#database_concepts_query_specification)
- `VnTypeOverlay` iota was removed. "overlay" in the Apstra code seems to refer to a hypervisor-managed overlay so isn't relevant to the fabric service virtual networks to which the VnTypeXxx iota is targeted.
- Updated logic for IPv4 / IPv6 detection based on `net.IP.String()`