### PR TITLE
New graph query features: `QEIntVal` and `Where()`

### DIFF
--- a/apstra/query_engine.go
+++ b/apstra/query_engine.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -112,6 +113,12 @@ func (o QEBoolVal) String() string {
 		return "True"
 	}
 	return "False"
+}
+
+type QEIntVal int
+
+func (o QEIntVal) String() string {
+	return strconv.Itoa(o)
 }
 
 func (o *Client) newQuery(blueprintId ObjectId) *PathQuery {

--- a/apstra/query_engine.go
+++ b/apstra/query_engine.go
@@ -118,7 +118,7 @@ func (o QEBoolVal) String() string {
 type QEIntVal int
 
 func (o QEIntVal) String() string {
-	return strconv.Itoa(o)
+	return strconv.Itoa(int(o))
 }
 
 func (o *Client) newQuery(blueprintId ObjectId) *PathQuery {

--- a/apstra/query_engine.go
+++ b/apstra/query_engine.go
@@ -134,6 +134,7 @@ type PathQuery struct {
 	context       context.Context
 	blueprintId   ObjectId
 	blueprintType BlueprintType
+	where         []string
 }
 
 func (o *PathQuery) getBlueprintType() BlueprintType {
@@ -172,7 +173,15 @@ func (o *PathQuery) String() string {
 		sb.WriteString(next.String())
 		next = next.next
 	}
+	for _, where := range o.where {
+		sb.WriteString(".where(" + where + ")")
+	}
 	return sb.String()
+}
+
+func (o *PathQuery) Where(where string) *PathQuery {
+	o.where = append(o.where, where)
+	return o
 }
 
 func (o *PathQuery) addElement(elementType string, attributes []QEEAttribute) *PathQuery {
@@ -238,6 +247,7 @@ type MatchQuery struct {
 	blueprintType BlueprintType
 	match         []PathQuery
 	firstElement  *MatchQueryElement
+	where         []string
 }
 
 //func (o *MatchQuery) Having(v QEAttrVal) *MatchQuery          {} // todo
@@ -312,7 +322,16 @@ func (o *MatchQuery) String() string {
 		next = next.next
 	}
 
+	for _, where := range o.where {
+		sb.WriteString(".where(" + where + ")")
+	}
+
 	return sb.String()
+}
+
+func (o *MatchQuery) Where(where string) *MatchQuery {
+	o.where = append(o.where, where)
+	return o
 }
 
 func (o *MatchQuery) Match(q *PathQuery) *MatchQuery {

--- a/apstra/query_engine_test.go
+++ b/apstra/query_engine_test.go
@@ -9,6 +9,55 @@ import (
 	"testing"
 )
 
+func TestQEAttrValsString(t *testing.T) {
+	type testCase struct {
+		v QEAttrVal
+		e string
+	}
+
+	testCases := []testCase{
+		{
+			v: QEStringVal("foo"),
+			e: "'foo'",
+		},
+		{
+			v: QEStringVal("\"bar\""),
+			e: "'\"bar\"'",
+		},
+		{
+			v: QEStringVal("123"),
+			e: "'123'",
+		},
+		{
+			v: QEStringVal(""),
+			e: "''",
+		},
+		{
+			v: QEStringValIsIn{"foo", "bar"},
+			e: "is_in(['foo','bar'])",
+		},
+		{
+			v: QEStringValNotIn{"foo", "bar"},
+			e: "not_in(['foo','bar'])",
+		},
+		{
+			v: QEIntVal(7),
+			e: "7",
+		},
+		{
+			v: QEIntVal(-7),
+			e: "-7",
+		},
+	}
+
+	for i, tc := range testCases {
+		r := tc.v.String()
+		if tc.e != r {
+			t.Errorf("test case %d expected %q got %q", i, tc.e, r)
+		}
+	}
+}
+
 func TestQEEAttributeString(t *testing.T) {
 	test := []struct {
 		expected string


### PR DESCRIPTION
Terraform datasource `apstra_datacenter_routing_zones` needed two new graph query features:

1. Query by integer values (until now we've only needed to use string and boolean values)
1. The `where()` graph query keyword to implement python lambda filters

## Caveats

### Caveat 1
The `where()` payload is completely unstructured. It's a raw string with some python embedded. When we get a little more experience with the patterns we need, it may be appropriate to write some constructor methods for common filter scenarios (one of, value among, etc...) and rename the current `Where()` to `WhereRaw()` or similar.

### Caveat 2

Right now `where()` is collected as an slice and rendered at the end of `PathQuery` and `MatchQuery` `String()` output.

It may be that we need to do in-path queries:

```node().out().node().where().out().node()```

We can cross that bridge when we come to it. The path-building-by-linked-list scheme already exists, so it shouldn't be too bad to sneak `Where()` in there among `Node()`, `In()` and `Out()`.