### PR TITLE
Support for agent lookup terraform data source

### DIFF
--- a/apstra/api_ready.go
+++ b/apstra/api_ready.go
@@ -26,7 +26,7 @@ func (o *Client) ready(ctx context.Context) error {
 		return fmt.Errorf("error listing Blueprints - %w", err)
 	}
 
-	_, err = o.getAllAgentsInfo(ctx)
+	_, err = o.getAllSystemAgents(ctx)
 	if err != nil {
 		return fmt.Errorf("error getting System Agents - %w", err)
 	}

--- a/apstra/api_system_agents.go
+++ b/apstra/api_system_agents.go
@@ -789,7 +789,7 @@ type jobIdResponse struct {
 	Id JobId `json:"id"`
 }
 
-func (o *Client) listAgents(ctx context.Context) ([]ObjectId, error) {
+func (o *Client) listSystemAgents(ctx context.Context) ([]ObjectId, error) {
 	response := &optionsAgentsResponse{}
 	err := o.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodOptions,
@@ -815,7 +815,7 @@ func (o *Client) getSystemAgent(ctx context.Context, id ObjectId) (*SystemAgent,
 	return response.polish(), nil
 }
 
-func (o *Client) getAllAgentsInfo(ctx context.Context) ([]SystemAgent, error) {
+func (o *Client) getAllSystemAgents(ctx context.Context) ([]SystemAgent, error) {
 	response := &getAgentsResponse{}
 	err := o.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodGet,
@@ -834,7 +834,7 @@ func (o *Client) getAllAgentsInfo(ctx context.Context) ([]SystemAgent, error) {
 }
 
 func (o *Client) getSystemAgentByManagementIp(ctx context.Context, ip string) (*SystemAgent, error) {
-	asa, err := o.getAllAgentsInfo(ctx)
+	asa, err := o.getAllSystemAgents(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -849,7 +849,7 @@ func (o *Client) getSystemAgentByManagementIp(ctx context.Context, ip string) (*
 	}
 }
 
-func (o *Client) createAgent(ctx context.Context, request *SystemAgentRequest) (ObjectId, error) {
+func (o *Client) createSystemAgent(ctx context.Context, request *SystemAgentRequest) (ObjectId, error) {
 	response := &objectIdResponse{}
 	err := o.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodPost,

--- a/apstra/api_system_agents_test.go
+++ b/apstra/api_system_agents_test.go
@@ -25,8 +25,8 @@ func TestGetSystemAgent(t *testing.T) {
 
 	skipMsg := make(map[string]string)
 	for clientName, client := range clients {
-		log.Printf("testing listAgents() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		list, err := client.client.listAgents(context.TODO())
+		log.Printf("testing listSystemAgents() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		list, err := client.client.listSystemAgents(context.TODO())
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/apstra/client.go
+++ b/apstra/client.go
@@ -482,7 +482,17 @@ func (o *Client) GetAgentProfileByLabel(ctx context.Context, label string) (*Age
 
 // CreateAgent creates an Apstra Agent and returns its ID
 func (o *Client) CreateAgent(ctx context.Context, request *SystemAgentRequest) (ObjectId, error) {
-	return o.createAgent(ctx, request)
+	return o.createSystemAgent(ctx, request)
+}
+
+// ListSystemAgents returns []ObjectId representing all Managed Device System Agents
+func (o *Client) ListSystemAgents(ctx context.Context) ([]ObjectId, error) {
+	return o.listSystemAgents(ctx)
+}
+
+// GetAllSystemAgents returns a SystemAgent structure representing the supplied ID
+func (o *Client) GetAllSystemAgents(ctx context.Context) ([]SystemAgent, error) {
+	return o.getAllSystemAgents(ctx)
 }
 
 // GetSystemAgent returns a SystemAgent structure representing the supplied ID


### PR DESCRIPTION
- New public methods for existing private methods:
  - `ListSystemAgents()`
  - `GetAllSystemAgents()`
- Make naming consitent: `*SystemAgent*` rather than `*Agent*`