### PR TITLE
bug/42: `ManagedSystemInfo` struct tags and private function signature change

### DIFF
--- a/apstra/api_systems_test.go
+++ b/apstra/api_systems_test.go
@@ -35,13 +35,13 @@ func TestGetAllSystems(t *testing.T) {
 
 	for clientName, client := range clients {
 		log.Printf("testing listSystems() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		systemIds, err := client.client.listSystems(context.TODO())
+		systemIds, err := client.client.ListSystems(context.TODO())
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		log.Printf("testing getAllSystemsInfo() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		systems, err := client.client.getAllSystemsInfo(context.TODO())
+		systems, err := client.client.GetAllSystemsInfo(context.TODO())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -67,7 +67,7 @@ func TestGetSystems(t *testing.T) {
 
 		for _, s := range systems {
 			log.Printf("testing getSystemInfo() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-			system, err := client.client.getSystemInfo(context.TODO(), s)
+			system, err := client.client.GetSystemInfo(context.TODO(), s)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/apstra/client.go
+++ b/apstra/client.go
@@ -568,12 +568,31 @@ func (o *Client) ListSystems(ctx context.Context) ([]SystemId, error) {
 // GetAllSystemsInfo returns []ManagedSystemInfo representing all systems
 // configured on the Apstra server.
 func (o *Client) GetAllSystemsInfo(ctx context.Context) ([]ManagedSystemInfo, error) {
-	return o.getAllSystemsInfo(ctx)
+	rawSlice, err := o.getAllSystemsInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]ManagedSystemInfo, len(rawSlice))
+	for i, raw := range rawSlice {
+		polished, err := raw.polish()
+		if err != nil {
+			return nil, err
+		}
+		result[i] = *polished
+	}
+
+	return result, nil
 }
 
 // GetSystemInfo returns a *ManagedSystemInfo representing the requested SystemId
 func (o *Client) GetSystemInfo(ctx context.Context, id SystemId) (*ManagedSystemInfo, error) {
-	return o.getSystemInfo(ctx, id)
+	raw, err := o.getSystemInfo(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return raw.polish()
 }
 
 // UpdateSystem deletes the supplied SystemId


### PR DESCRIPTION
- remove superflous struct tags from `ManagedSystemInfo`
- change function signature of `getSystemInfo()` and `getAllSystemInfo()` to return private object
- move `polish()` call to public method in `client.go`