### PR TITLE
Introduce support for blueprint anomalies

### DIFF
--- a/apstra/api_anomalies.go
+++ b/apstra/api_anomalies.go
@@ -247,7 +247,7 @@ func (o *Client) getAnomalies(ctx context.Context) ([]Anomaly, error) {
 //   PROBE_ANOMALY_SCHEMA = t.Object(BASE_ANOMALY_SCHEMA, {               // node
 
 type BlueprintAnomaly struct {
-	Id             string     `json:"id"`               // part of base schema
+	Id             ObjectId   `json:"id"`               // part of base schema
 	LastModifiedAt *time.Time `json:"last_modified_at"` // part of base schema
 	Severity       string     `json:"severity"`         // part of base schema
 	AnomalyType    string     `json:"anomaly_type"`     // part of base schema
@@ -273,9 +273,9 @@ type BlueprintServiceAnomalyCount struct {
 //               'all']
 
 type BlueprintNodeAnomalyCounts struct {
-	Node     string `json:"node"`
-	SystemId string `json:"system_id"`
-	All      int    `json:"all"`
+	Node     string   `json:"node"`
+	SystemId ObjectId `json:"system_id"`
+	All      int      `json:"all"`
 
 	Arp                int `json:"arp"`
 	Bgp                int `json:"bgp"`

--- a/apstra/api_anomalies.go
+++ b/apstra/api_anomalies.go
@@ -11,7 +11,10 @@ import (
 )
 
 const (
-	apiUrlAnomalies = "/api/anomalies"
+	apiUrlAnomalies                   = "/api/anomalies"
+	apiUrlBlueprintAnomalies          = apiUrlBlueprintById + apiUrlPathDelim + "anomalies"
+	apiUrlBlueprintAnomaliesByNode    = apiUrlBlueprintById + apiUrlPathDelim + "anomalies_nodes_count"
+	apiUrlBlueprintAnomaliesByService = apiUrlBlueprintById + apiUrlPathDelim + "anomalies_services_count"
 )
 
 type AnomalyProperty struct {
@@ -223,4 +226,114 @@ func (o *Client) getAnomalies(ctx context.Context) ([]Anomaly, error) {
 		result = append(result, *a)
 	}
 	return result, nil
+}
+
+// also available in scotch/schemas/alerts.py:
+//   BGP_ANOMALY_SCHEMA = t.Object(BASE_ANOMALY_SCHEMA, {                 // node
+//   BLUEPRINT_RENDERING_ANOMALY_SCHEMA = t.Object(BASE_ANOMALY_SCHEMA, { // node
+//   CABLING_ANOMALY_SCHEMA = t.Object(BASE_ANOMALY_SCHEMA, {             // node
+//   CONFIG_ANOMALY_SCHEMA = t.Object(BASE_ANOMALY_SCHEMA, {              // node
+//   CONFIG_MISMATCH_ANOMALY_SCHEMA = t.Object(BASE_ANOMALY_SCHEMA, {     // node
+//   DEPLOYMENT_ANOMALY_SCHEMA = t.Object(BASE_ANOMALY_SCHEMA, {          // node
+//   EXTENSIBLE_ANOMALY_SCHEMA = t.Object(BASE_ANOMALY_SCHEMA, {          // ?
+//   HOSTNAME_ANOMALY_SCHEMA = t.Object(BASE_ANOMALY_SCHEMA, {            // node
+//   INTERFACE_ANOMALY_SCHEMA = t.Object(BASE_ANOMALY_SCHEMA, {           // node
+//   LAG_ANOMALY_SCHEMA = t.Object(BASE_ANOMALY_SCHEMA, {                 // ?
+//   LIVENESS_ANOMALY_SCHEMA = t.Object(BASE_ANOMALY_SCHEMA, {            // node
+//   MAC_ANOMALY_SCHEMA = t.Object(BASE_ANOMALY_SCHEMA, {                 // ?
+//   MLAG_ANOMALY_SCHEMA = t.Object(BASE_ANOMALY_SCHEMA, {                // ?
+//   ROUTE_ANOMALY_SCHEMA = t.Object(BASE_ANOMALY_SCHEMA, {               // node
+//   STREAMING_ANOMALY_SCHEMA = t.Object(BASE_ANOMALY_SCHEMA, {           // ?
+//   PROBE_ANOMALY_SCHEMA = t.Object(BASE_ANOMALY_SCHEMA, {               // node
+
+type TwoStageL3ClosAnomaly struct {
+	Id             string     `json:"id"`               // part of base schema
+	LastModifiedAt *time.Time `json:"last_modified_at"` // part of base schema
+	Severity       string     `json:"severity"`         // part of base schema
+	AnomalyType    string     `json:"anomaly_type"`     // part of base schema
+
+	Actual    json.RawMessage `json:"actual"`    // universal (near universal?)
+	Expected  json.RawMessage `json:"expected"`  // universal (near universal?)
+	Identity  json.RawMessage `json:"identity"`  // universal (near universal?)
+	Role      *string         `json:"role"`      // near universal
+	Anomalous json.RawMessage `json:"anomalous"` // probe
+}
+
+type TwoStageL3ClosServiceAnomalyCount struct {
+	AnomalyType string `json:"type"`
+	Role        string `json:"role"`
+	Count       int    `json:"count"`
+}
+
+// per JP Senior: I think the a reliable list is aos.reference_design.two_stage_l3clos.__init__.py's alert_types list:
+// aos/reference_design/two_stage_l3clos/__init__.py:
+// alert_types = ['bgp', 'cabling', 'counter', 'interface', 'hostname', 'liveness',
+//               'route', 'config', 'deployment', 'blueprint_rendering', 'probe',
+//               'streaming', 'mac', 'arp', 'lag', 'mlag', 'series',
+//               'all']
+
+type TwoStageL3ClosNodeAnomalyCounts struct {
+	Node     string `json:"node"`
+	SystemId string `json:"system_id"`
+	All      int    `json:"all"`
+
+	Arp                int `json:"arp"`
+	Bgp                int `json:"bgp"`
+	BlueprintRendering int `json:"blueprint_rendering"`
+	Cabling            int `json:"cabling"`
+	Config             int `json:"config"`
+	Counter            int `json:"counter"`
+	Deployment         int `json:"deployment"`
+	Hostname           int `json:"hostname"`
+	Interface          int `json:"interface"`
+	Lag                int `json:"lag"`
+	Liveness           int `json:"liveness"`
+	Mac                int `json"mac"`
+	Mlag               int `json"mlag"`
+	Probe              int `json:"probe"`
+	Route              int `json:"route"`
+	Series             int `json:"series"`
+	Streaming          int `json:"streaming"`
+}
+
+func (o *Client) getBlueprintAnomalies(ctx context.Context, blueprintId ObjectId) ([]TwoStageL3ClosAnomaly, error) {
+	var apiResonse struct {
+		Items []TwoStageL3ClosAnomaly
+	}
+
+	err := o.talkToApstra(ctx, &talkToApstraIn{
+		method:         http.MethodGet,
+		urlStr:         fmt.Sprintf(apiUrlBlueprintAnomalies, blueprintId),
+		apiResponse:    &apiResonse,
+		unsynchronized: true,
+	})
+	return apiResonse.Items, convertTtaeToAceWherePossible(err)
+}
+
+func (o *Client) getBlueprintNodeAnomalyCounts(ctx context.Context, blueprintId ObjectId) ([]TwoStageL3ClosNodeAnomalyCounts, error) {
+	var apiResonse struct {
+		Items []TwoStageL3ClosNodeAnomalyCounts
+	}
+
+	err := o.talkToApstra(ctx, &talkToApstraIn{
+		method:         http.MethodGet,
+		urlStr:         fmt.Sprintf(apiUrlBlueprintAnomaliesByNode, blueprintId),
+		apiResponse:    &apiResonse,
+		unsynchronized: true,
+	})
+	return apiResonse.Items, convertTtaeToAceWherePossible(err)
+}
+
+func (o *Client) getBlueprintServiceAnomalyCounts(ctx context.Context, blueprintId ObjectId) ([]TwoStageL3ClosServiceAnomalyCount, error) {
+	var apiResonse struct {
+		Items []TwoStageL3ClosServiceAnomalyCount
+	}
+
+	err := o.talkToApstra(ctx, &talkToApstraIn{
+		method:         http.MethodGet,
+		urlStr:         fmt.Sprintf(apiUrlBlueprintAnomaliesByService, blueprintId),
+		apiResponse:    &apiResonse,
+		unsynchronized: true,
+	})
+	return apiResonse.Items, convertTtaeToAceWherePossible(err)
 }

--- a/apstra/api_anomalies.go
+++ b/apstra/api_anomalies.go
@@ -288,8 +288,8 @@ type TwoStageL3ClosNodeAnomalyCounts struct {
 	Interface          int `json:"interface"`
 	Lag                int `json:"lag"`
 	Liveness           int `json:"liveness"`
-	Mac                int `json"mac"`
-	Mlag               int `json"mlag"`
+	Mac                int `json:"mac"`
+	Mlag               int `json:"mlag"`
 	Probe              int `json:"probe"`
 	Route              int `json:"route"`
 	Series             int `json:"series"`

--- a/apstra/api_anomalies.go
+++ b/apstra/api_anomalies.go
@@ -246,7 +246,7 @@ func (o *Client) getAnomalies(ctx context.Context) ([]Anomaly, error) {
 //   STREAMING_ANOMALY_SCHEMA = t.Object(BASE_ANOMALY_SCHEMA, {           // ?
 //   PROBE_ANOMALY_SCHEMA = t.Object(BASE_ANOMALY_SCHEMA, {               // node
 
-type TwoStageL3ClosAnomaly struct {
+type BlueprintAnomaly struct {
 	Id             string     `json:"id"`               // part of base schema
 	LastModifiedAt *time.Time `json:"last_modified_at"` // part of base schema
 	Severity       string     `json:"severity"`         // part of base schema
@@ -259,7 +259,7 @@ type TwoStageL3ClosAnomaly struct {
 	Anomalous json.RawMessage `json:"anomalous"` // probe
 }
 
-type TwoStageL3ClosServiceAnomalyCount struct {
+type BlueprintServiceAnomalyCount struct {
 	AnomalyType string `json:"type"`
 	Role        string `json:"role"`
 	Count       int    `json:"count"`
@@ -272,7 +272,7 @@ type TwoStageL3ClosServiceAnomalyCount struct {
 //               'streaming', 'mac', 'arp', 'lag', 'mlag', 'series',
 //               'all']
 
-type TwoStageL3ClosNodeAnomalyCounts struct {
+type BlueprintNodeAnomalyCounts struct {
 	Node     string `json:"node"`
 	SystemId string `json:"system_id"`
 	All      int    `json:"all"`
@@ -296,9 +296,9 @@ type TwoStageL3ClosNodeAnomalyCounts struct {
 	Streaming          int `json:"streaming"`
 }
 
-func (o *Client) getBlueprintAnomalies(ctx context.Context, blueprintId ObjectId) ([]TwoStageL3ClosAnomaly, error) {
+func (o *Client) getBlueprintAnomalies(ctx context.Context, blueprintId ObjectId) ([]BlueprintAnomaly, error) {
 	var apiResonse struct {
-		Items []TwoStageL3ClosAnomaly
+		Items []BlueprintAnomaly
 	}
 
 	err := o.talkToApstra(ctx, &talkToApstraIn{
@@ -310,9 +310,9 @@ func (o *Client) getBlueprintAnomalies(ctx context.Context, blueprintId ObjectId
 	return apiResonse.Items, convertTtaeToAceWherePossible(err)
 }
 
-func (o *Client) getBlueprintNodeAnomalyCounts(ctx context.Context, blueprintId ObjectId) ([]TwoStageL3ClosNodeAnomalyCounts, error) {
+func (o *Client) getBlueprintNodeAnomalyCounts(ctx context.Context, blueprintId ObjectId) ([]BlueprintNodeAnomalyCounts, error) {
 	var apiResonse struct {
-		Items []TwoStageL3ClosNodeAnomalyCounts
+		Items []BlueprintNodeAnomalyCounts
 	}
 
 	err := o.talkToApstra(ctx, &talkToApstraIn{
@@ -324,9 +324,9 @@ func (o *Client) getBlueprintNodeAnomalyCounts(ctx context.Context, blueprintId 
 	return apiResonse.Items, convertTtaeToAceWherePossible(err)
 }
 
-func (o *Client) getBlueprintServiceAnomalyCounts(ctx context.Context, blueprintId ObjectId) ([]TwoStageL3ClosServiceAnomalyCount, error) {
+func (o *Client) getBlueprintServiceAnomalyCounts(ctx context.Context, blueprintId ObjectId) ([]BlueprintServiceAnomalyCount, error) {
 	var apiResonse struct {
-		Items []TwoStageL3ClosServiceAnomalyCount
+		Items []BlueprintServiceAnomalyCount
 	}
 
 	err := o.talkToApstra(ctx, &talkToApstraIn{

--- a/apstra/api_anomalies_integration_test.go
+++ b/apstra/api_anomalies_integration_test.go
@@ -1,0 +1,108 @@
+//go:build integration
+// +build integration
+
+package apstra
+
+import (
+	"context"
+	"log"
+	"testing"
+)
+
+func TestGetAnomalies(t *testing.T) {
+	clients, err := getTestClients(context.Background(), t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for clientName, client := range clients {
+		log.Printf("testing getAnomalies() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+
+		anomalies, err := client.client.GetAnomalies(context.TODO())
+		if err != nil {
+			t.Fatal(err)
+		}
+		log.Printf("%d anomalies retrieved", len(anomalies))
+	}
+}
+
+func TestGetBlueprintAnomalies(t *testing.T) {
+	ctx := context.Background()
+
+	clients, err := getTestClients(context.Background(), t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for clientName, client := range clients {
+		bpClient, bpDelete := testBlueprintB(ctx, t, client.client)
+		defer func() {
+			err := bpDelete(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		log.Printf("testing GetBlueprintAnomalies() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		anomalies, err := client.client.GetBlueprintAnomalies(ctx, bpClient.Id())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		log.Printf("%d blueprint anomalies retrieved", len(anomalies))
+	}
+}
+
+func TestGetBlueprintNodeAnomalyCounts(t *testing.T) {
+	ctx := context.Background()
+
+	clients, err := getTestClients(context.Background(), t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for clientName, client := range clients {
+		bpClient, bpDelete := testBlueprintB(ctx, t, client.client)
+		defer func() {
+			err := bpDelete(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		log.Printf("testing GetBlueprintAnomalies() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		anomalies, err := client.client.GetBlueprintNodeAnomalyCounts(ctx, bpClient.Id())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		log.Printf("%d node anomaly counts retrieved", len(anomalies))
+	}
+}
+
+func TestGetBlueprintServiceAnomalyCounts(t *testing.T) {
+	ctx := context.Background()
+
+	clients, err := getTestClients(context.Background(), t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for clientName, client := range clients {
+		bpClient, bpDelete := testBlueprintB(ctx, t, client.client)
+		defer func() {
+			err := bpDelete(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		log.Printf("testing GetBlueprintAnomalies() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		anomalies, err := client.client.GetBlueprintServiceAnomalyCounts(ctx, bpClient.Id())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		log.Printf("%d service anomaly counts retrieved", len(anomalies))
+	}
+}

--- a/apstra/api_anomalies_unit_test.go
+++ b/apstra/api_anomalies_unit_test.go
@@ -1,11 +1,6 @@
-//go:build integration
-// +build integration
-
 package apstra
 
 import (
-	"context"
-	"log"
 	"testing"
 )
 
@@ -69,21 +64,4 @@ func TestUnpackAnomaly(t *testing.T) {
 		t.Fatal(err)
 	}
 	_ = a
-}
-
-func TestGetAnomalies(t *testing.T) {
-	clients, err := getTestClients(context.Background(), t)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for clientName, client := range clients {
-		log.Printf("testing getAnomalies() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-
-		anomalies, err := client.client.GetAnomalies(context.TODO())
-		if err != nil {
-			t.Fatal(err)
-		}
-		log.Printf("%d anomalies retrieved", len(anomalies))
-	}
 }

--- a/apstra/client.go
+++ b/apstra/client.go
@@ -327,11 +327,11 @@ func (o *Client) GetBlueprintAnomalies(ctx context.Context, blueprintId ObjectId
 	return o.getBlueprintAnomalies(ctx, blueprintId)
 }
 
-// GetBlueprintNodeAnomalyCounts returns []TwoStageL3ClosNodeAnomalyCounts
+// GetBlueprintNodeAnomalyCounts returns []BlueprintNodeAnomalyCounts
 // which summarize current anomalies on a per-node basis in the blueprint.
 // Nodes which are not currently experiencing an anomaly are not represented in
 // the returned slice.
-func (o *Client) GetBlueprintNodeAnomalyCounts(ctx context.Context, blueprintId ObjectId) ([]TwoStageL3ClosNodeAnomalyCounts, error) {
+func (o *Client) GetBlueprintNodeAnomalyCounts(ctx context.Context, blueprintId ObjectId) ([]BlueprintNodeAnomalyCounts, error) {
 	return o.getBlueprintNodeAnomalyCounts(ctx, blueprintId)
 }
 

--- a/apstra/client.go
+++ b/apstra/client.go
@@ -321,9 +321,9 @@ func (o *Client) GetAnomalies(ctx context.Context) ([]Anomaly, error) {
 	return result, nil
 }
 
-// GetBlueprintAnomalies returns []TwoStageL3ClosAnomaly representing all anomalies in
+// GetBlueprintAnomalies returns []BlueprintAnomaly representing all anomalies in
 // the blueprint.
-func (o *Client) GetBlueprintAnomalies(ctx context.Context, blueprintId ObjectId) ([]TwoStageL3ClosAnomaly, error) {
+func (o *Client) GetBlueprintAnomalies(ctx context.Context, blueprintId ObjectId) ([]BlueprintAnomaly, error) {
 	return o.getBlueprintAnomalies(ctx, blueprintId)
 }
 
@@ -335,11 +335,11 @@ func (o *Client) GetBlueprintNodeAnomalyCounts(ctx context.Context, blueprintId 
 	return o.getBlueprintNodeAnomalyCounts(ctx, blueprintId)
 }
 
-// GetBlueprintServiceAnomalyCounts returns []TwoStageL3ClosServiceAnomalyCount
+// GetBlueprintServiceAnomalyCounts returns []BlueprintServiceAnomalyCount
 // which summarize current anomalies on a per-service basis in the blueprint.
 // Services which are not currently experiencing an anomaly are not represented
 // in the returned slice.
-func (o *Client) GetBlueprintServiceAnomalyCounts(ctx context.Context, blueprintId ObjectId) ([]TwoStageL3ClosServiceAnomalyCount, error) {
+func (o *Client) GetBlueprintServiceAnomalyCounts(ctx context.Context, blueprintId ObjectId) ([]BlueprintServiceAnomalyCount, error) {
 	return o.getBlueprintServiceAnomalyCounts(ctx, blueprintId)
 }
 

--- a/apstra/client.go
+++ b/apstra/client.go
@@ -321,6 +321,28 @@ func (o *Client) GetAnomalies(ctx context.Context) ([]Anomaly, error) {
 	return result, nil
 }
 
+// GetBlueprintAnomalies returns []TwoStageL3ClosAnomaly representing all anomalies in
+// the blueprint.
+func (o *Client) GetBlueprintAnomalies(ctx context.Context, blueprintId ObjectId) ([]TwoStageL3ClosAnomaly, error) {
+	return o.getBlueprintAnomalies(ctx, blueprintId)
+}
+
+// GetBlueprintNodeAnomalyCounts returns []TwoStageL3ClosNodeAnomalyCounts
+// which summarize current anomalies on a per-node basis in the blueprint.
+// Nodes which are not currently experiencing an anomaly are not represented in
+// the returned slice.
+func (o *Client) GetBlueprintNodeAnomalyCounts(ctx context.Context, blueprintId ObjectId) ([]TwoStageL3ClosNodeAnomalyCounts, error) {
+	return o.getBlueprintNodeAnomalyCounts(ctx, blueprintId)
+}
+
+// GetBlueprintServiceAnomalyCounts returns []TwoStageL3ClosServiceAnomalyCount
+// which summarize current anomalies on a per-service basis in the blueprint.
+// Services which are not currently experiencing an anomaly are not represented
+// in the returned slice.
+func (o *Client) GetBlueprintServiceAnomalyCounts(ctx context.Context, blueprintId ObjectId) ([]TwoStageL3ClosServiceAnomalyCount, error) {
+	return o.getBlueprintServiceAnomalyCounts(ctx, blueprintId)
+}
+
 // GetAsnPools returns ASN pools configured on Apstra
 func (o *Client) GetAsnPools(ctx context.Context) ([]AsnPool, error) {
 	return o.getAsnPools(ctx)

--- a/apstra/two_stage_l3_clos_leaf_server_bonding_integration_test.go
+++ b/apstra/two_stage_l3_clos_leaf_server_bonding_integration_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package apstra
 
 import (


### PR DESCRIPTION
This PR introduces structs and methods for:

- in-blueprint anomalies
- per-node anomaly counts
-  per-service anomaly counts

fixes #47 
fixes #49
