### PR TITLE
New resource pool allocation role

### DIFF
--- a/apstra/two_stage_l3_clos_resources.go
+++ b/apstra/two_stage_l3_clos_resources.go
@@ -57,7 +57,7 @@ const (
 	ResourceGroupNameVirtualNetworkSviIpv4
 	ResourceGroupNameVirtualNetworkSviIpv6
 	ResourceGroupNameVxlanVnIds
-	ResourceGroupNameUnknown
+	ResourceGroupNameUnknown = "unknown group name %q"
 
 	resourceGroupNameNone                  = resourceGroupName("")
 	resourceGroupNameSuperspineAsn         = resourceGroupName("superspine_asns")
@@ -267,7 +267,7 @@ func (o resourceGroupName) parse() (int, error) {
 	case resourceGroupNameVxlanVnIds:
 		return int(ResourceGroupNameVxlanVnIds), nil
 	default:
-		return int(ResourceGroupNameUnknown), fmt.Errorf("unknown group name '%s'", o)
+		return 0, fmt.Errorf(ResourceGroupNameUnknown, o)
 	}
 }
 

--- a/apstra/two_stage_l3_clos_resources.go
+++ b/apstra/two_stage_l3_clos_resources.go
@@ -57,6 +57,7 @@ const (
 	ResourceGroupNameVirtualNetworkSviIpv4
 	ResourceGroupNameVirtualNetworkSviIpv6
 	ResourceGroupNameVxlanVnIds
+	ResourceGroupNameToGenericLinkIps
 	ResourceGroupNameUnknown = "unknown group name %q"
 
 	resourceGroupNameNone                  = resourceGroupName("")
@@ -81,6 +82,7 @@ const (
 	resourceGroupNameVirtualNetworkSviIpv4 = resourceGroupName("virtual_network_svi_subnets")
 	resourceGroupNameVirtualNetworkSviIpv6 = resourceGroupName("virtual_network_svi_subnets_ipv6")
 	resourceGroupNameVxlanVnIds            = resourceGroupName("vxlan_vn_ids")
+	resourceGroupNameToGenericLinkIps      = resourceGroupName("to_generic_link_ips")
 	resourceGroupNameUnknown               = "group name %d unknown"
 )
 
@@ -136,6 +138,8 @@ func (o *ResourceGroupName) Type() ResourceType {
 	case ResourceGroupNameLeafL3PeerLinkLinkIps:
 		return ResourceTypeIp4Pool
 	case ResourceGroupNameMlagDomainIp4:
+		return ResourceTypeIp4Pool
+	case ResourceGroupNameToGenericLinkIps:
 		return ResourceTypeIp4Pool
 	case ResourceGroupNameVtepIp4:
 		return ResourceTypeIp4Pool
@@ -213,6 +217,8 @@ func (o ResourceGroupName) raw() resourceGroupName {
 		return resourceGroupNameVirtualNetworkSviIpv6
 	case ResourceGroupNameVxlanVnIds:
 		return resourceGroupNameVxlanVnIds
+	case ResourceGroupNameToGenericLinkIps:
+		return resourceGroupNameToGenericLinkIps
 	default:
 		return resourceGroupName(fmt.Sprintf(resourceGroupNameUnknown, o))
 	}
@@ -266,6 +272,8 @@ func (o resourceGroupName) parse() (int, error) {
 		return int(ResourceGroupNameVirtualNetworkSviIpv6), nil
 	case resourceGroupNameVxlanVnIds:
 		return int(ResourceGroupNameVxlanVnIds), nil
+	case resourceGroupNameToGenericLinkIps:
+		return int(ResourceGroupNameToGenericLinkIps), nil
 	default:
 		return 0, fmt.Errorf(ResourceGroupNameUnknown, o)
 	}

--- a/apstra/two_stage_l3_clos_resources_test.go
+++ b/apstra/two_stage_l3_clos_resources_test.go
@@ -158,6 +158,7 @@ func TestTwoStageL3ClosResourceStrings(t *testing.T) {
 		{stringVal: "virtual_network_svi_subnets", intType: ResourceGroupNameVirtualNetworkSviIpv4, stringType: resourceGroupNameVirtualNetworkSviIpv4},
 		{stringVal: "virtual_network_svi_subnets_ipv6", intType: ResourceGroupNameVirtualNetworkSviIpv6, stringType: resourceGroupNameVirtualNetworkSviIpv6},
 		{stringVal: "vxlan_vn_ids", intType: ResourceGroupNameVxlanVnIds, stringType: resourceGroupNameVxlanVnIds},
+		{stringVal: "to_generic_link_ips", intType: ResourceGroupNameToGenericLinkIps, stringType: resourceGroupNameToGenericLinkIps},
 	}
 
 	for i, td := range testData {


### PR DESCRIPTION
I expected there would be more missing roles, but so far can only find `to_generic_link_ips`.

Additionally, moved the "unknown group name %s" message to the `ResourceGroupNameUnknown` constant for consistency with other iota types.

Closes #58