### PR TITLE
Import Configlets into Blueprints.

### DIFF
--- a/apstra/api_design_configlets.go
+++ b/apstra/api_design_configlets.go
@@ -49,7 +49,7 @@ type rawConfigletData struct {
 }
 
 type rawConfiglet struct {
-	RefArchs       []string                `json:"ref_archs"`
+	RefArchs       []refDesign             `json:"ref_archs"`
 	Generators     []rawConfigletGenerator `json:"generators"`
 	CreatedAt      time.Time               `json:"created_at"`
 	Id             ObjectId                `json:"id,omitempty"`

--- a/apstra/api_design_configlets.go
+++ b/apstra/api_design_configlets.go
@@ -22,11 +22,11 @@ type ConfigletGenerator struct {
 }
 
 type rawConfigletGenerator struct {
-	ConfigStyle          string `json:"config_style"`
-	Section              string `json:"section"`
-	TemplateText         string `json:"template_text"`
-	NegationTemplateText string `json:"negation_template_text"`
-	Filename             string `json:"filename"`
+	ConfigStyle          platformOS       `json:"config_style"`
+	Section              configletSection `json:"section"`
+	TemplateText         string           `json:"template_text"`
+	NegationTemplateText string           `json:"negation_template_text"`
+	Filename             string           `json:"filename"`
 }
 
 type Configlet struct {
@@ -97,11 +97,11 @@ func (o *rawConfigletData) polish() (*ConfigletData, error) {
 }
 
 func (o *rawConfigletGenerator) polish() (*ConfigletGenerator, error) {
-	platform, err := platformOS(o.ConfigStyle).parse()
+	platform, err := o.ConfigStyle.parse()
 	if err != nil {
 		return nil, err
 	}
-	section, err := configletSection(o.Section).parse()
+	section, err := o.Section.parse()
 	if err != nil {
 		return nil, err
 	}
@@ -119,8 +119,8 @@ func (o *ConfigletGenerator) raw() *rawConfigletGenerator {
 	cg.TemplateText = o.TemplateText
 	cg.Filename = o.Filename
 	cg.NegationTemplateText = o.NegationTemplateText
-	cg.ConfigStyle = o.ConfigStyle.raw().string()
-	cg.Section = string(o.Section.raw())
+	cg.ConfigStyle = o.ConfigStyle.raw()
+	cg.Section = o.Section.raw()
 	return &cg
 }
 

--- a/apstra/api_design_configlets.go
+++ b/apstra/api_design_configlets.go
@@ -16,6 +16,7 @@ const (
 type ConfigletGenerator struct {
 	ConfigStyle          PlatformOS
 	Section              ConfigletSection
+	SectionCondition     *string
 	TemplateText         string
 	NegationTemplateText string
 	Filename             string
@@ -24,6 +25,7 @@ type ConfigletGenerator struct {
 type rawConfigletGenerator struct {
 	ConfigStyle          string `json:"config_style"`
 	Section              string `json:"section"`
+	SectionCondition     string `json:"section_condition,omitempty"`
 	TemplateText         string `json:"template_text"`
 	NegationTemplateText string `json:"negation_template_text"`
 	Filename             string `json:"filename"`
@@ -89,6 +91,7 @@ func (o *rawConfigletGenerator) polish() (*ConfigletGenerator, error) {
 	return &ConfigletGenerator{
 		ConfigStyle:          PlatformOS(platform),
 		Section:              ConfigletSection(section),
+		SectionCondition:     &o.SectionCondition,
 		TemplateText:         o.TemplateText,
 		NegationTemplateText: o.NegationTemplateText,
 		Filename:             o.Filename,
@@ -102,7 +105,9 @@ func (o *ConfigletGenerator) raw() *rawConfigletGenerator {
 	cg.NegationTemplateText = o.NegationTemplateText
 	cg.ConfigStyle = o.ConfigStyle.raw().string()
 	cg.Section = string(o.Section.raw())
-
+	if o.SectionCondition != nil {
+		cg.SectionCondition = *o.SectionCondition
+	}
 	return &cg
 }
 

--- a/apstra/api_design_configlets_test.go
+++ b/apstra/api_design_configlets_test.go
@@ -28,7 +28,7 @@ func TestCreateUpdateGetDeleteConfiglet(t *testing.T) {
 
 		refarchs = append(refarchs, RefDesignTwoStageL3Clos)
 
-		id1, err := client.client.CreateConfiglet(context.Background(), &ConfigletRequest{
+		id1, err := client.client.CreateConfiglet(context.Background(), &ConfigletData{
 			DisplayName: Name,
 			RefArchs:    refarchs,
 			Generators:  cg,
@@ -55,7 +55,7 @@ func TestCreateUpdateGetDeleteConfiglet(t *testing.T) {
 		})
 		log.Println("Update Config")
 
-		err = client.client.UpdateConfiglet(context.Background(), id1, &ConfigletRequest{
+		err = client.client.UpdateConfiglet(context.Background(), id1, &ConfigletData{
 			DisplayName: c.Data.DisplayName,
 			RefArchs:    c.Data.RefArchs,
 			Generators:  c.Data.Generators,

--- a/apstra/client.go
+++ b/apstra/client.go
@@ -960,7 +960,7 @@ func (o *Client) DeleteTag(ctx context.Context, id ObjectId) error {
 }
 
 // CreateConfiglet creates a Configlet and returns its ObjectId.
-func (o *Client) CreateConfiglet(ctx context.Context, in *ConfigletRequest) (ObjectId, error) {
+func (o *Client) CreateConfiglet(ctx context.Context, in *ConfigletData) (ObjectId, error) {
 	return o.createConfiglet(ctx, in)
 }
 
@@ -979,7 +979,7 @@ func (o *Client) GetConfiglet(ctx context.Context, in ObjectId) (*Configlet, err
 }
 
 // UpdateConfiglet updates a configlet
-func (o *Client) UpdateConfiglet(ctx context.Context, id ObjectId, in *ConfigletRequest) error {
+func (o *Client) UpdateConfiglet(ctx context.Context, id ObjectId, in *ConfigletData) error {
 	return o.updateConfiglet(ctx, id, in)
 }
 
@@ -1575,10 +1575,10 @@ func (o *Client) DeletePropertySet(ctx context.Context, id ObjectId) error {
 }
 
 // Private method added for Client.ready(), public wrapper not currently needed.
-//// GetTelemetryQuery returns *TelemetryQuery
-//func (o *Client) GetTelemetryQuery(ctx context.Context) (*TelemetryQueryResponse, error){
+// // GetTelemetryQuery returns *TelemetryQuery
+// func (o *Client) GetTelemetryQuery(ctx context.Context) (*TelemetryQueryResponse, error){
 //	return o.getTelemetryQuery(ctx)
-//}
+// }
 
 // DeployBlueprint commits the staging blueprint to the active blueprint
 func (o *Client) DeployBlueprint(ctx context.Context, in *BlueprintDeployRequest) (*BlueprintDeployResponse, error) {

--- a/apstra/two_stage_l3_clos_client.go
+++ b/apstra/two_stage_l3_clos_client.go
@@ -459,7 +459,11 @@ func (o *TwoStageL3ClosClient) GetAllConfigletIds(ctx context.Context) ([]Object
 // GetConfiglet returns *TwoStageL3ClosConfiglet representing the imported
 // configlet with the given ID in the specified blueprint
 func (o *TwoStageL3ClosClient) GetConfiglet(ctx context.Context, id ObjectId) (*TwoStageL3ClosConfiglet, error) {
-	return o.getConfiglet(ctx, id)
+	c, err := o.getConfiglet(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return c.polish()
 }
 
 // GetConfigletByName returns *TwoStageL3ClosConfiglet representing the only
@@ -482,25 +486,23 @@ func (o *TwoStageL3ClosClient) ImportConfigletById(ctx context.Context, cid Obje
 	if err != nil {
 		return "", err
 	}
-	return o.importConfiglet(ctx, TwoStageL3ClosConfigletData{
+	c := TwoStageL3ClosConfigletData{
 		Data:      *cfg.Data,
 		Condition: condition,
 		Label:     label,
-	})
+	}
+	return o.createConfiglet(ctx, c.raw())
 }
 
-// ImportConfiglet imports a configlet described by a ConfigletData structure
-// into a blueprint.
-// condition is a string input that indicates which devices it applies to.
-// label can be used to rename the configlet in the blueprint
-// On success, it returns the id of the imported configlet.
-func (o *TwoStageL3ClosClient) ImportConfiglet(ctx context.Context, c TwoStageL3ClosConfigletData) (ObjectId, error) {
-	return o.importConfiglet(ctx, c)
+// CreateConfiglet creates a configlet described by a TwoStageL3ClosConfigletData structure
+// in a blueprint.
+func (o *TwoStageL3ClosClient) CreateConfiglet(ctx context.Context, c *TwoStageL3ClosConfigletData) (ObjectId, error) {
+	return o.createConfiglet(ctx, c.raw())
 }
 
 // UpdateConfiglet updates a configlet imported into a blueprint.
 func (o *TwoStageL3ClosClient) UpdateConfiglet(ctx context.Context, c *TwoStageL3ClosConfiglet) error {
-	return o.updateConfiglet(ctx, c)
+	return o.updateConfiglet(ctx, c.raw())
 }
 
 // DeleteConfiglet deletes a configlet from the blueprint given the id

--- a/apstra/two_stage_l3_clos_client.go
+++ b/apstra/two_stage_l3_clos_client.go
@@ -434,7 +434,7 @@ func (o *TwoStageL3ClosClient) DeletePropertySet(ctx context.Context, id ObjectI
 
 // GetAllConfiglets returns []TwoStageL3ClosConfiglet representing all
 // configlets imported into a blueprint
-func (o *TwoStageL3ClosClient) GetAllConfiglets(ctx context.Context) ([]TwoStageL3ClosConfiglet, error) {
+func (o *TwoStageL3ClosClient) GetAllConfiglets(ctx context.Context) ([]*TwoStageL3ClosConfiglet, error) {
 	return o.getAllConfiglets(ctx)
 }
 

--- a/apstra/two_stage_l3_clos_client.go
+++ b/apstra/two_stage_l3_clos_client.go
@@ -420,7 +420,47 @@ func (o *TwoStageL3ClosClient) UpdatePropertySet(ctx context.Context, psid Objec
 	return o.updatePropertySet(ctx, psid, keys...)
 }
 
-// DeletePropertySet deletes a property given the id
+// DeletePropertySet deletes a property set given the id
 func (o *TwoStageL3ClosClient) DeletePropertySet(ctx context.Context, id ObjectId) error {
 	return o.deletePropertySet(ctx, id)
+}
+
+// GetAllConfiglets returns []TwoStageL3ClosConfiglet representing all configlets imported into a blueprint
+func (o *TwoStageL3ClosClient) GetAllConfiglets(ctx context.Context) ([]TwoStageL3ClosConfiglet, error) {
+	return o.getAllConfiglets(ctx)
+}
+
+// GetAllConfiglets returns []TwoStageL3ClosConfiglet representing all configlets imported into a blueprint
+func (o *TwoStageL3ClosClient) GetAllConfigletIDs(ctx context.Context) ([]ObjectId, error) {
+	return o.getAllConfigletIds(ctx)
+}
+
+// GetConfiglet returns *TwoStageL3ClosConfiglet representing the imported configlet with the given ID in the specified blueprint
+func (o *TwoStageL3ClosClient) GetConfiglet(ctx context.Context, id ObjectId) (*TwoStageL3ClosConfiglet, error) {
+	return o.getConfiglet(ctx, id)
+}
+
+// GetConfigletByName returns *TwoStageL3ClosConfiglet representing the only configlet with the given label, or an error if no configlet by that name exists
+func (o *TwoStageL3ClosClient) GetConfigletByName(ctx context.Context, in string) (*TwoStageL3ClosConfiglet, error) {
+	return o.getConfigletByName(ctx, in)
+}
+
+// ImportConfiglet imports a configlet into a blueprint. condtion is a string input that indicates which devices it applies to. label can be used to rename the configlet in the blue print On success, it returns the id of the imported configlet.
+func (o *TwoStageL3ClosClient) ImportConfigletByID(ctx context.Context, cid ObjectId, condition string, label string) (ObjectId, error) {
+	return o.importConfigletByID(ctx, cid, condition, label)
+}
+
+// ImportConfiglet imports a configlet into a blueprint. condtion is a string input that indicates which devices it applies to. label can be used to rename the configlet in the blue print On success, it returns the id of the imported configlet.
+func (o *TwoStageL3ClosClient) ImportConfiglet(ctx context.Context, c ConfigletData, condition string, label string) (ObjectId, error) {
+	return o.importConfiglet(ctx, c, condition, label)
+}
+
+// UpdateConfiglet updates a configlet imported into a blueprint. Optionally, a set of keys can be part of the request
+func (o *TwoStageL3ClosClient) UpdateConfiglet(ctx context.Context, cid ObjectId, configlet *TwoStageL3ClosConfiglet) error {
+	return o.updateConfiglet(ctx, configlet)
+}
+
+// DeleteConfiglet deletes a configlet given the id
+func (o *TwoStageL3ClosClient) DeleteConfiglet(ctx context.Context, id ObjectId) error {
+	return o.deleteConfiglet(ctx, id)
 }

--- a/apstra/two_stage_l3_clos_client.go
+++ b/apstra/two_stage_l3_clos_client.go
@@ -395,27 +395,34 @@ func (o *TwoStageL3ClosClient) DeleteRoutingPolicy(ctx context.Context, id Objec
 	return o.deleteRoutingPolicy(ctx, id)
 }
 
-// GetAllPropertySets returns []TwoStageL3ClosPropertySet representing all property sets imported into a blueprint
+// GetAllPropertySets returns []TwoStageL3ClosPropertySet representing
+// all property sets imported into a blueprint
 func (o *TwoStageL3ClosClient) GetAllPropertySets(ctx context.Context) ([]TwoStageL3ClosPropertySet, error) {
 	return o.getAllPropertySets(ctx)
 }
 
-// GetPropertySet returns *TwoStageL3ClosPropertySet representing the imported property set with the given ID in the specified blueprint
+// GetPropertySet returns *TwoStageL3ClosPropertySet representing the
+// imported property set with the given ID in the specified blueprint
 func (o *TwoStageL3ClosClient) GetPropertySet(ctx context.Context, id ObjectId) (*TwoStageL3ClosPropertySet, error) {
 	return o.getPropertySet(ctx, id)
 }
 
-// GetPropertySetByName returns *TwoStageL3ClosPropertySet representing the only property set with the given label, or an error if multiple property sets share the label.
+// GetPropertySetByName returns *TwoStageL3ClosPropertySet representing
+// the only property set with the given label, or an error if multiple
+// property sets share the label.
 func (o *TwoStageL3ClosClient) GetPropertySetByName(ctx context.Context, in string) (*TwoStageL3ClosPropertySet, error) {
 	return o.getPropertySetByName(ctx, in)
 }
 
-// ImportPropertySet imports a property set into a blueprint. On success, it returns the id of the imported property set. Optionally, a set of keys can be part of the request
+// ImportPropertySet imports a property set into a blueprint. On success,
+// it returns the id of the imported property set. Optionally, a set of keys
+// can be part of the request
 func (o *TwoStageL3ClosClient) ImportPropertySet(ctx context.Context, psid ObjectId, keys ...string) (ObjectId, error) {
 	return o.importPropertySet(ctx, psid, keys...)
 }
 
-// UpdatePropertySet updates a property set imported into a blueprint. Optionally, a set of keys can be part of the request
+// UpdatePropertySet updates a property set imported into a blueprint.
+// Optionally, a set of keys can be part of the request
 func (o *TwoStageL3ClosClient) UpdatePropertySet(ctx context.Context, psid ObjectId, keys ...string) error {
 	return o.updatePropertySet(ctx, psid, keys...)
 }
@@ -425,42 +432,54 @@ func (o *TwoStageL3ClosClient) DeletePropertySet(ctx context.Context, id ObjectI
 	return o.deletePropertySet(ctx, id)
 }
 
-// GetAllConfiglets returns []TwoStageL3ClosConfiglet representing all configlets imported into a blueprint
+// GetAllConfiglets returns []TwoStageL3ClosConfiglet representing all
+// configlets imported into a blueprint
 func (o *TwoStageL3ClosClient) GetAllConfiglets(ctx context.Context) ([]TwoStageL3ClosConfiglet, error) {
 	return o.getAllConfiglets(ctx)
 }
 
-// GetAllConfiglets returns []TwoStageL3ClosConfiglet representing all configlets imported into a blueprint
-func (o *TwoStageL3ClosClient) GetAllConfigletIDs(ctx context.Context) ([]ObjectId, error) {
+// GetAllConfigletIds returns Ids of all the configlets imported into a
+// blueprint
+func (o *TwoStageL3ClosClient) GetAllConfigletIds(ctx context.Context) ([]ObjectId, error) {
 	return o.getAllConfigletIds(ctx)
 }
 
-// GetConfiglet returns *TwoStageL3ClosConfiglet representing the imported configlet with the given ID in the specified blueprint
+// GetConfiglet returns *TwoStageL3ClosConfiglet representing the imported
+// configlet with the given ID in the specified blueprint
 func (o *TwoStageL3ClosClient) GetConfiglet(ctx context.Context, id ObjectId) (*TwoStageL3ClosConfiglet, error) {
 	return o.getConfiglet(ctx, id)
 }
 
-// GetConfigletByName returns *TwoStageL3ClosConfiglet representing the only configlet with the given label, or an error if no configlet by that name exists
+// GetConfigletByName returns *TwoStageL3ClosConfiglet representing the only
+// configlet with the given label, or an error if no configlet by that name exists
 func (o *TwoStageL3ClosClient) GetConfigletByName(ctx context.Context, in string) (*TwoStageL3ClosConfiglet, error) {
 	return o.getConfigletByName(ctx, in)
 }
 
-// ImportConfiglet imports a configlet into a blueprint. condtion is a string input that indicates which devices it applies to. label can be used to rename the configlet in the blue print On success, it returns the id of the imported configlet.
-func (o *TwoStageL3ClosClient) ImportConfigletByID(ctx context.Context, cid ObjectId, condition string, label string) (ObjectId, error) {
-	return o.importConfigletByID(ctx, cid, condition, label)
+// ImportConfigletById imports a configlet from the catalog into a blueprint.
+// cid is the Id catalog configlet of the
+// condtion is a string input that indicates which devices it applies to.
+// label can be used to rename the configlet in the blue print
+// On success, it returns the id of the imported configlet.
+func (o *TwoStageL3ClosClient) ImportConfigletById(ctx context.Context, cid ObjectId, condition string, label string) (ObjectId, error) {
+	return o.importConfigletById(ctx, cid, condition, label)
 }
 
-// ImportConfiglet imports a configlet into a blueprint. condtion is a string input that indicates which devices it applies to. label can be used to rename the configlet in the blue print On success, it returns the id of the imported configlet.
+// ImportConfiglet imports a configlet described by a ConfigletData structure
+// into a blueprint.
+// condtion is a string input that indicates which devices it applies to.
+// label can be used to rename the configlet in the blueprint
+// On success, it returns the id of the imported configlet.
 func (o *TwoStageL3ClosClient) ImportConfiglet(ctx context.Context, c ConfigletData, condition string, label string) (ObjectId, error) {
 	return o.importConfiglet(ctx, c, condition, label)
 }
 
-// UpdateConfiglet updates a configlet imported into a blueprint. Optionally, a set of keys can be part of the request
-func (o *TwoStageL3ClosClient) UpdateConfiglet(ctx context.Context, cid ObjectId, configlet *TwoStageL3ClosConfiglet) error {
+// UpdateConfiglet updates a configlet imported into a blueprint.
+func (o *TwoStageL3ClosClient) UpdateConfiglet(ctx context.Context, configlet *TwoStageL3ClosConfiglet) error {
 	return o.updateConfiglet(ctx, configlet)
 }
 
-// DeleteConfiglet deletes a configlet given the id
+// DeleteConfiglet deletes a configlet from the blueprint given the id
 func (o *TwoStageL3ClosClient) DeleteConfiglet(ctx context.Context, id ObjectId) error {
 	return o.deleteConfiglet(ctx, id)
 }

--- a/apstra/two_stage_l3_clos_client.go
+++ b/apstra/two_stage_l3_clos_client.go
@@ -467,7 +467,7 @@ func (o *TwoStageL3ClosClient) ImportConfigletById(ctx context.Context, cid Obje
 
 // ImportConfiglet imports a configlet described by a ConfigletData structure
 // into a blueprint.
-// condtion is a string input that indicates which devices it applies to.
+// condition is a string input that indicates which devices it applies to.
 // label can be used to rename the configlet in the blueprint
 // On success, it returns the id of the imported configlet.
 func (o *TwoStageL3ClosClient) ImportConfiglet(ctx context.Context, c ConfigletData, condition string, label string) (ObjectId, error) {

--- a/apstra/two_stage_l3_clos_configlets.go
+++ b/apstra/two_stage_l3_clos_configlets.go
@@ -1,0 +1,143 @@
+package apstra
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const (
+	apiUrlBlueprintConfiglets       = apiUrlBlueprintById + apiUrlPathDelim + "configlets"
+	apiUrlBlueprintConfigletsPrefix = apiUrlBlueprintConfiglets + apiUrlPathDelim
+	apiUrlBlueprintConfigletsById   = apiUrlBlueprintConfigletsPrefix + "%s"
+)
+
+type TwoStageL3ClosConfiglet struct {
+	Configlet rawConfigletRequest `json:"configlet"`
+	Id        string              `json:"id"`
+	Condition string              `json:"condition"`
+	Label     string              `json:"label"`
+}
+
+func (o *TwoStageL3ClosClient) getAllConfiglets(ctx context.Context) ([]TwoStageL3ClosConfiglet, error) {
+	blueprintconfigleturl := fmt.Sprintf(apiUrlBlueprintConfiglets, o.blueprintId.String())
+	response := &struct {
+		Items []TwoStageL3ClosConfiglet `json:"items"`
+	}{}
+	err := o.client.talkToApstra(ctx, &talkToApstraIn{
+		method:      http.MethodOptions,
+		urlStr:      blueprintconfigleturl,
+		apiResponse: response,
+	})
+	if err != nil {
+		return nil, convertTtaeToAceWherePossible(err)
+	}
+	return response.Items, nil
+}
+
+func (o *TwoStageL3ClosClient) getAllConfigletIds(ctx context.Context) ([]ObjectId, error) {
+	configlets, err := o.getAllConfiglets(ctx)
+	if err != nil {
+		return nil, convertTtaeToAceWherePossible(err)
+	}
+	ids := make([]ObjectId, len(configlets))
+	for i, c := range configlets {
+		ids[i] = ObjectId(c.Id)
+	}
+	return ids, nil
+}
+
+func (o *TwoStageL3ClosClient) getConfiglet(ctx context.Context, id ObjectId) (*TwoStageL3ClosConfiglet, error) {
+	blueprintconfigleturl := fmt.Sprintf(apiUrlBlueprintConfigletsById, o.blueprintId.String(), id.String())
+	response := &TwoStageL3ClosConfiglet{}
+	err := o.client.talkToApstra(ctx, &talkToApstraIn{
+		method:      http.MethodGet,
+		urlStr:      blueprintconfigleturl,
+		apiResponse: response,
+	})
+	if err != nil {
+		return nil, convertTtaeToAceWherePossible(err)
+	}
+	return response, nil
+}
+
+func (o *TwoStageL3ClosClient) getConfigletByName(ctx context.Context, name string) (*TwoStageL3ClosConfiglet, error) {
+	cgs, err := o.getAllConfiglets(ctx)
+	if err != nil {
+		return nil, convertTtaeToAceWherePossible(err)
+	}
+	for _, t := range cgs {
+		if t.Label == name {
+			return &t, nil
+		}
+	}
+	return nil, ApstraClientErr{
+		errType: ErrNotfound,
+		err:     fmt.Errorf(" Configlet with name '%s' not found", name),
+	}
+}
+
+func (o *TwoStageL3ClosClient) importConfiglet(ctx context.Context, c ConfigletData, condition string, label string) (ObjectId, error) {
+	blueprintconfigleturl := fmt.Sprintf(apiUrlBlueprintConfiglets, o.blueprintId.String())
+	response := &objectIdResponse{}
+	raw := (*ConfigletRequest)(&c).raw()
+	in := TwoStageL3ClosConfiglet{
+		Configlet: *raw,
+		Condition: condition,
+		Label:     label,
+	}
+	err := o.client.talkToApstra(ctx, &talkToApstraIn{
+		method:      http.MethodPost,
+		urlStr:      blueprintconfigleturl,
+		apiInput:    in,
+		apiResponse: response,
+	})
+	if err != nil {
+		return "", convertTtaeToAceWherePossible(err)
+	}
+	return response.Id, nil
+}
+func (o *TwoStageL3ClosClient) importConfigletByID(ctx context.Context, id ObjectId, condition string, label string) (ObjectId, error) {
+	blueprintconfigleturl := fmt.Sprintf(apiUrlBlueprintConfiglets, o.blueprintId.String())
+	response := &objectIdResponse{}
+	cfglet, err := o.client.GetConfiglet(ctx, id)
+	cr := (*ConfigletRequest)(cfglet.Data).raw()
+	if len(label) == 0 {
+		label = cr.DisplayName
+	}
+	in := TwoStageL3ClosConfiglet{
+		Configlet: *cr,
+		Condition: condition,
+		Label:     label,
+	}
+	err = o.client.talkToApstra(ctx, &talkToApstraIn{
+		method:      http.MethodPost,
+		urlStr:      blueprintconfigleturl,
+		apiInput:    in,
+		apiResponse: response,
+	})
+	if err != nil {
+		return "", convertTtaeToAceWherePossible(err)
+	}
+	return response.Id, nil
+}
+
+func (o *TwoStageL3ClosClient) updateConfiglet(ctx context.Context, in *TwoStageL3ClosConfiglet) error {
+	blueprintconfigleturl := fmt.Sprintf(apiUrlBlueprintConfigletsById, o.blueprintId.String(), in.Id)
+	err := o.client.talkToApstra(ctx, &talkToApstraIn{
+		method:   http.MethodPut,
+		urlStr:   blueprintconfigleturl,
+		apiInput: in,
+	})
+	if err != nil {
+		return convertTtaeToAceWherePossible(err)
+	}
+	return nil
+}
+
+func (o *TwoStageL3ClosClient) deleteConfiglet(ctx context.Context, id ObjectId) error {
+	return o.client.talkToApstra(ctx, &talkToApstraIn{
+		method: http.MethodDelete,
+		urlStr: fmt.Sprintf(apiUrlBlueprintConfigletsById, o.blueprintId.String(), id.String()),
+	})
+}

--- a/apstra/two_stage_l3_clos_configlets.go
+++ b/apstra/two_stage_l3_clos_configlets.go
@@ -97,7 +97,8 @@ func (o *TwoStageL3ClosClient) importConfiglet(ctx context.Context, c ConfigletD
 	}
 	return response.Id, nil
 }
-func (o *TwoStageL3ClosClient) importConfigletByID(ctx context.Context, id ObjectId, condition string, label string) (ObjectId, error) {
+func (o *TwoStageL3ClosClient) importConfigletById(ctx context.Context, id ObjectId, condition string,
+	label string) (ObjectId, error) {
 	blueprintconfigleturl := fmt.Sprintf(apiUrlBlueprintConfiglets, o.blueprintId.String())
 	response := &objectIdResponse{}
 	cfglet, err := o.client.GetConfiglet(ctx, id)

--- a/apstra/two_stage_l3_clos_configlets.go
+++ b/apstra/two_stage_l3_clos_configlets.go
@@ -137,7 +137,7 @@ func (o *TwoStageL3ClosClient) getConfigletByName(ctx context.Context, name stri
 	}
 	return nil, ApstraClientErr{
 		errType: ErrNotfound,
-		err:     fmt.Errorf(" Configlet with name '%s' not found", name),
+		err:     fmt.Errorf(" no Configlet with name '%s' found", name),
 	}
 }
 

--- a/apstra/two_stage_l3_clos_configlets.go
+++ b/apstra/two_stage_l3_clos_configlets.go
@@ -62,6 +62,9 @@ func (o *rawTwoStageL3ClosConfiglet) polish() (*TwoStageL3ClosConfiglet, error) 
 	c := TwoStageL3ClosConfiglet{}
 	c.Id = ObjectId(o.Id)
 	d, err := o.Data.polish()
+	if err != nil {
+		return nil, err
+	}
 	c.Data = TwoStageL3ClosConfigletData{
 		Data:      *d,
 		Condition: o.Condition,

--- a/apstra/two_stage_l3_clos_configlets.go
+++ b/apstra/two_stage_l3_clos_configlets.go
@@ -26,7 +26,7 @@ type TwoStageL3ClosConfigletData struct {
 
 type rawTwoStageL3ClosConfiglet struct {
 	Data      rawConfigletData `json:"configlet"`
-	Id        string           `json:"id"`
+	Id        ObjectId         `json:"id"`
 	Condition string           `json:"condition"`
 	Label     string           `json:"label"`
 }
@@ -52,7 +52,7 @@ func (o *TwoStageL3ClosConfiglet) raw() *rawTwoStageL3ClosConfiglet {
 			Generators:  d.Data.Generators,
 			DisplayName: d.Data.DisplayName,
 		},
-		Id:        o.Id.String(),
+		Id:        o.Id,
 		Condition: d.Condition,
 		Label:     d.Label,
 	}
@@ -60,7 +60,7 @@ func (o *TwoStageL3ClosConfiglet) raw() *rawTwoStageL3ClosConfiglet {
 
 func (o *rawTwoStageL3ClosConfiglet) polish() (*TwoStageL3ClosConfiglet, error) {
 	c := TwoStageL3ClosConfiglet{}
-	c.Id = ObjectId(o.Id)
+	c.Id = o.Id
 	d, err := o.Data.polish()
 	if err != nil {
 		return nil, err
@@ -95,7 +95,7 @@ func (o *TwoStageL3ClosClient) getAllConfigletIds(ctx context.Context) ([]Object
 	}
 	ids := make([]ObjectId, len(configlets))
 	for i, c := range configlets {
-		ids[i] = ObjectId(c.Id)
+		ids[i] = c.Id
 	}
 	return ids, nil
 }

--- a/apstra/two_stage_l3_clos_configlets_test.go
+++ b/apstra/two_stage_l3_clos_configlets_test.go
@@ -31,7 +31,7 @@ func TestImportGetUpdateGetDeleteConfiglet(t *testing.T) {
 	}
 	ctx := context.TODO()
 	for clientName, client := range clients {
-		//Create Configlet
+		// Create Configlet
 		CatConfId, err := client.client.CreateConfiglet(ctx, &cr)
 		if err != nil {
 			t.Fatal(err)
@@ -48,8 +48,9 @@ func TestImportGetUpdateGetDeleteConfiglet(t *testing.T) {
 			}
 		}()
 
-		log.Printf("testing ImportConfigletByID() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		ips_id, err := bpClient.ImportConfigletByID(ctx, CatConfId, "role in [\"spine\", \"leaf\"]", "")
+		log.Printf("testing ImportConfigletById() against %s %s (%s)", client.clientType, clientName,
+			client.client.ApiVersion())
+		ips_id, err := bpClient.ImportConfigletById(ctx, CatConfId, "role in [\"spine\", \"leaf\"]", "")
 		log.Printf("%s", ips_id)
 		if err != nil {
 			t.Fatal(err)
@@ -87,7 +88,7 @@ func TestImportGetUpdateGetDeleteConfiglet(t *testing.T) {
 		ips.Label = "new name"
 		ips.Condition = "role in [\"spine\"]"
 		log.Printf("testing UpdateConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		err = bpClient.UpdateConfiglet(ctx, ips_id, ips)
+		err = bpClient.UpdateConfiglet(ctx, ips)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/apstra/two_stage_l3_clos_configlets_test.go
+++ b/apstra/two_stage_l3_clos_configlets_test.go
@@ -15,7 +15,7 @@ func TestImportGetUpdateGetDeleteConfiglet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var cr ConfigletRequest
+	var cr ConfigletData
 	var cg []ConfigletGenerator
 	var refarchs []RefDesign
 	cg = append(cg, ConfigletGenerator{
@@ -24,7 +24,7 @@ func TestImportGetUpdateGetDeleteConfiglet(t *testing.T) {
 		TemplateText: "interfaces {\n   {% if 'leaf1' in hostname %}\n    xe-0/0/3 {\n      disable;\n    }\n   {% endif %}\n   {% if 'leaf2' in hostname %}\n    xe-0/0/2 {\n      disable;\n    }\n   {% endif %}\n}",
 	})
 	refarchs = append(refarchs, RefDesignTwoStageL3Clos)
-	cr = ConfigletRequest{
+	cr = ConfigletData{
 		DisplayName: "TestImportConfiglet",
 		RefArchs:    refarchs,
 		Generators:  cg,

--- a/apstra/two_stage_l3_clos_configlets_test.go
+++ b/apstra/two_stage_l3_clos_configlets_test.go
@@ -50,21 +50,21 @@ func TestImportGetUpdateGetDeleteConfiglet(t *testing.T) {
 
 		log.Printf("testing ImportConfigletById() against %s %s (%s)", client.clientType, clientName,
 			client.client.ApiVersion())
-		ips_id, err := bpClient.ImportConfigletById(ctx, CatConfId, "role in [\"spine\", \"leaf\"]", "")
-		log.Printf("%s", ips_id)
+		icfg_id, err := bpClient.ImportConfigletById(ctx, CatConfId, "role in [\"spine\", \"leaf\"]", "")
+		log.Printf("%s", icfg_id)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		log.Printf("testing GetConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		ips, err := bpClient.GetConfiglet(ctx, ips_id)
-		log.Println(ips)
+		icfg, err := bpClient.GetConfiglet(ctx, icfg_id)
+		log.Println(icfg)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		log.Printf("testing DeleteConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		err = bpClient.DeleteConfiglet(ctx, ips_id)
+		err = bpClient.DeleteConfiglet(ctx, icfg_id)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -72,43 +72,48 @@ func TestImportGetUpdateGetDeleteConfiglet(t *testing.T) {
 		// Delete takes time sometimes
 		time.Sleep(3 * time.Second)
 		log.Printf("testing ImportConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		ips_id, err = bpClient.ImportConfiglet(ctx, (ConfigletData)(cr), "role in [\"spine\", \"leaf\"]", "")
-		log.Printf("%s", ips_id)
+		c := TwoStageL3ClosConfigletData{
+			Data:      cr,
+			Condition: "role in [\"spine\", \"leaf\"]",
+			Label:     "",
+		}
+		icfg_id, err = bpClient.ImportConfiglet(ctx, c)
+		log.Printf("%s", icfg_id)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		log.Printf("testing GetConfigletByName() against %s %s (%s)", client.clientType, clientName,
 			client.client.ApiVersion())
-		ips, err = bpClient.GetConfigletByName(ctx, "TestImportConfiglet")
-		log.Println(ips)
+		icfg1, err := bpClient.GetConfigletByName(ctx, "TestImportConfiglet")
+		log.Println(icfg1)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		ips.Label = "new name"
-		ips.Condition = "role in [\"spine\"]"
+		icfg1.Data.Label = "new name"
+		icfg1.Data.Condition = "role in [\"spine\"]"
 		log.Printf("testing UpdateConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		err = bpClient.UpdateConfiglet(ctx, ips)
+		err = bpClient.UpdateConfiglet(ctx, icfg1)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		log.Printf("testing GetConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		ips1, err := bpClient.GetConfiglet(ctx, ips_id)
-		log.Println(ips1)
+		icfg2, err := bpClient.GetConfiglet(ctx, icfg_id)
+		log.Println(icfg2)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if ips1.Label != ips.Label {
+		if icfg1.Data.Label != icfg2.Data.Label {
 			t.Fatal("Name Change Failed")
 		}
-		if ips1.Condition != ips.Condition {
+		if icfg1.Data.Condition != icfg2.Data.Condition {
 			t.Fatal("Condition Change Failed")
 		}
 
 		log.Printf("testing DeleteConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		err = bpClient.DeleteConfiglet(ctx, ips_id)
+		err = bpClient.DeleteConfiglet(ctx, icfg_id)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/apstra/two_stage_l3_clos_configlets_test.go
+++ b/apstra/two_stage_l3_clos_configlets_test.go
@@ -1,0 +1,114 @@
+//go:build integration
+// +build integration
+
+package apstra
+
+import (
+	"context"
+	"log"
+	"testing"
+	"time"
+)
+
+func TestImportGetUpdateGetDeleteConfiglet(t *testing.T) {
+	clients, err := getTestClients(context.Background(), t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cr ConfigletRequest
+	var cg []ConfigletGenerator
+	var refarchs []RefDesign
+	cg = append(cg, ConfigletGenerator{
+		ConfigStyle:  PlatformOSJunos,
+		Section:      ConfigletSectionSystem,
+		TemplateText: "interfaces {\n   {% if 'leaf1' in hostname %}\n    xe-0/0/3 {\n      disable;\n    }\n   {% endif %}\n   {% if 'leaf2' in hostname %}\n    xe-0/0/2 {\n      disable;\n    }\n   {% endif %}\n}",
+	})
+	refarchs = append(refarchs, RefDesignTwoStageL3Clos)
+	cr = ConfigletRequest{
+		DisplayName: "TestImportConfiglet",
+		RefArchs:    refarchs,
+		Generators:  cg,
+	}
+	ctx := context.TODO()
+	for clientName, client := range clients {
+		//Create Configlet
+		CatConfId, err := client.client.CreateConfiglet(ctx, &cr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			client.client.DeleteConfiglet(ctx, CatConfId)
+		}()
+
+		bpClient, bpDel := testBlueprintA(ctx, t, client.client)
+		defer func() {
+			err = bpDel(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		log.Printf("testing ImportConfigletByID() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		ips_id, err := bpClient.ImportConfigletByID(ctx, CatConfId, "role in [\"spine\", \"leaf\"]", "")
+		log.Printf("%s", ips_id)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		log.Printf("testing GetConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		ips, err := bpClient.GetConfiglet(ctx, ips_id)
+		log.Println(ips)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		log.Printf("testing DeleteConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		err = bpClient.DeleteConfiglet(ctx, ips_id)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Delete takes time sometimes
+		time.Sleep(3 * time.Second)
+		log.Printf("testing ImportConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		ips_id, err = bpClient.ImportConfiglet(ctx, (ConfigletData)(cr), "role in [\"spine\", \"leaf\"]", "")
+		log.Printf("%s", ips_id)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		log.Printf("testing GetConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		ips, err = bpClient.GetConfiglet(ctx, ips_id)
+		log.Println(ips)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ips.Label = "new name"
+		ips.Condition = "role in [\"spine\"]"
+		log.Printf("testing UpdateConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		err = bpClient.UpdateConfiglet(ctx, ips_id, ips)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		log.Printf("testing GetConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		ips1, err := bpClient.GetConfiglet(ctx, ips_id)
+		log.Println(ips1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ips1.Label != ips.Label {
+			t.Fatal("Name Change Failed")
+		}
+		if ips1.Condition != ips.Condition {
+			t.Fatal("Condition Change Failed")
+		}
+
+		log.Printf("testing DeleteConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		err = bpClient.DeleteConfiglet(ctx, ips_id)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/apstra/two_stage_l3_clos_configlets_test.go
+++ b/apstra/two_stage_l3_clos_configlets_test.go
@@ -40,13 +40,13 @@ func TestImportGetUpdateGetDeleteConfiglet(t *testing.T) {
 			client.client.DeleteConfiglet(ctx, CatConfId)
 		}()
 
-		bpClient, bpDel := testBlueprintA(ctx, t, client.client)
-		defer func() {
-			err = bpDel(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient, _ := testBlueprintA(ctx, t, client.client)
+		// defer func() {
+		// 	err = bpDel(ctx)
+		// 	if err != nil {
+		// 		t.Fatal(err)
+		// 	}
+		// }()
 
 		log.Printf("testing ImportConfigletById() against %s %s (%s)", client.clientType, clientName,
 			client.client.ApiVersion())
@@ -78,8 +78,9 @@ func TestImportGetUpdateGetDeleteConfiglet(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		log.Printf("testing GetConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		ips, err = bpClient.GetConfiglet(ctx, ips_id)
+		log.Printf("testing GetConfigletByName() against %s %s (%s)", client.clientType, clientName,
+			client.client.ApiVersion())
+		ips, err = bpClient.GetConfigletByName(ctx, "TestImportConfiglet")
 		log.Println(ips)
 		if err != nil {
 			t.Fatal(err)

--- a/apstra/two_stage_l3_clos_configlets_test.go
+++ b/apstra/two_stage_l3_clos_configlets_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"log"
 	"testing"
-	"time"
 )
 
 func TestImportGetUpdateGetDeleteConfiglet(t *testing.T) {
@@ -40,13 +39,13 @@ func TestImportGetUpdateGetDeleteConfiglet(t *testing.T) {
 			client.client.DeleteConfiglet(ctx, CatConfId)
 		}()
 
-		bpClient, _ := testBlueprintA(ctx, t, client.client)
-		// defer func() {
-		// 	err = bpDel(ctx)
-		// 	if err != nil {
-		// 		t.Fatal(err)
-		// 	}
-		// }()
+		bpClient, bpDel := testBlueprintA(ctx, t, client.client)
+		defer func() {
+			err = bpDel(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}()
 
 		log.Printf("testing ImportConfigletById() against %s %s (%s)", client.clientType, clientName,
 			client.client.ApiVersion())
@@ -69,8 +68,7 @@ func TestImportGetUpdateGetDeleteConfiglet(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// Delete takes time sometimes
-		time.Sleep(3 * time.Second)
+		cr.DisplayName = "ImportDirect"
 		log.Printf("testing ImportConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		c := TwoStageL3ClosConfigletData{
 			Data:      cr,
@@ -85,12 +83,11 @@ func TestImportGetUpdateGetDeleteConfiglet(t *testing.T) {
 
 		log.Printf("testing GetConfigletByName() against %s %s (%s)", client.clientType, clientName,
 			client.client.ApiVersion())
-		icfg1, err := bpClient.GetConfigletByName(ctx, "TestImportConfiglet")
+		icfg1, err := bpClient.GetConfigletByName(ctx, "ImportDirect")
 		log.Println(icfg1)
 		if err != nil {
 			t.Fatal(err)
 		}
-
 		icfg1.Data.Label = "new name"
 		icfg1.Data.Condition = "role in [\"spine\"]"
 		log.Printf("testing UpdateConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
@@ -98,7 +95,6 @@ func TestImportGetUpdateGetDeleteConfiglet(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-
 		log.Printf("testing GetConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		icfg2, err := bpClient.GetConfiglet(ctx, icfg_id)
 		log.Println(icfg2)
@@ -111,7 +107,6 @@ func TestImportGetUpdateGetDeleteConfiglet(t *testing.T) {
 		if icfg1.Data.Condition != icfg2.Data.Condition {
 			t.Fatal("Condition Change Failed")
 		}
-
 		log.Printf("testing DeleteConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		err = bpClient.DeleteConfiglet(ctx, icfg_id)
 		if err != nil {

--- a/apstra/two_stage_l3_clos_configlets_test.go
+++ b/apstra/two_stage_l3_clos_configlets_test.go
@@ -75,7 +75,7 @@ func TestImportGetUpdateGetDeleteConfiglet(t *testing.T) {
 			Condition: "role in [\"spine\", \"leaf\"]",
 			Label:     "",
 		}
-		icfg_id, err = bpClient.ImportConfiglet(ctx, c)
+		icfg_id, err = bpClient.CreateConfiglet(ctx, &c)
 		log.Printf("%s", icfg_id)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
This has the code required to import configlets into a blueprint.
Two methods for importing exist. 
One uses the ID of a catalog configlet as a model. The other allows a user to build their own configlet for their blueprint.

This PR also removes ConfigletRequest code, replacing it with ConfigletData