### PR TITLE
Introduce `TwoStageL3Clos` methods `GetFabricAddressingPolicy()` and `SetFabricAddressingPolicy()`

### DIFF
--- a/apstra/two_stage_l3_clos_fabric_addressing_policy.go
+++ b/apstra/two_stage_l3_clos_fabric_addressing_policy.go
@@ -1,0 +1,47 @@
+package apstra
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const (
+	apiUrlBlueprintFabricAddressingPolicy = apiUrlBlueprintById + apiUrlPathDelim + "fabric-addressing-policy"
+)
+
+type TwoStageL3ClosFabricAddressingPolicy struct {
+	Ipv6Enabled bool  `json:"ipv6_enabled"`
+	EsiMacMsb   uint8 `json:"esi_mac_msb"`
+}
+
+func (o *TwoStageL3ClosClient) GetFabricAddressingPolicy(ctx context.Context) (*TwoStageL3ClosFabricAddressingPolicy, error) {
+	var result TwoStageL3ClosFabricAddressingPolicy
+	err := o.client.talkToApstra(ctx, &talkToApstraIn{
+		method:      http.MethodGet,
+		urlStr:      fmt.Sprintf(apiUrlBlueprintFabricAddressingPolicy, o.blueprintId),
+		apiResponse: &result,
+	})
+	if err != nil {
+		return nil, convertTtaeToAceWherePossible(err)
+	}
+
+	return &result, nil
+}
+
+func (o *TwoStageL3ClosClient) SetFabricAddressingPolicy(ctx context.Context, in *TwoStageL3ClosFabricAddressingPolicy) error {
+	if in.EsiMacMsb%2 != 0 {
+		return fmt.Errorf("fabric addressing policy esi mac msb must be even, got %d", in.EsiMacMsb)
+	}
+
+	err := o.client.talkToApstra(ctx, &talkToApstraIn{
+		method:   http.MethodPatch,
+		urlStr:   fmt.Sprintf(apiUrlBlueprintFabricAddressingPolicy, o.blueprintId),
+		apiInput: in,
+	})
+	if err != nil {
+		return convertTtaeToAceWherePossible(err)
+	}
+
+	return nil
+}

--- a/apstra/two_stage_l3_clos_fabric_addressing_policy_integration_test.go
+++ b/apstra/two_stage_l3_clos_fabric_addressing_policy_integration_test.go
@@ -1,0 +1,77 @@
+//go:build integration
+// +build integration
+
+package apstra
+
+import (
+	"context"
+	"log"
+	"math/rand"
+	"testing"
+)
+
+const (
+	defaultEsiMacMsb = 2
+)
+
+func TestGetSetGetFAP(t *testing.T) {
+	ctx := context.Background()
+
+	clients, err := getTestClients(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for clientName, client := range clients {
+		bpClient, bpDel := testBlueprintA(ctx, t, client.client)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			err := bpDel(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		log.Printf("testing GetFabricAddressingPolicy() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		fap, err := bpClient.GetFabricAddressingPolicy(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if fap.EsiMacMsb != defaultEsiMacMsb {
+			t.Fatalf("expected mac msb to be %d (apstra default?) got %d", defaultEsiMacMsb, fap.EsiMacMsb)
+		}
+
+		if fap.Ipv6Enabled {
+			t.Fatal("expected ipv6 to be disabled")
+		}
+
+		newMsb := uint8(rand.Intn(100) + 100) // value 100 - 199
+		newMsb = newMsb + newMsb%2            // make it even
+
+		log.Printf("testing SetFabricAddressingPolicy() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		err = bpClient.SetFabricAddressingPolicy(ctx, &TwoStageL3ClosFabricAddressingPolicy{
+			EsiMacMsb:   newMsb,
+			Ipv6Enabled: true,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		log.Printf("testing GetFabricAddressingPolicy() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		fap, err = bpClient.GetFabricAddressingPolicy(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if newMsb != fap.EsiMacMsb {
+			t.Fatalf("new fabric addressing policy mac msb: expected %d got %d", newMsb, fap.EsiMacMsb)
+		}
+
+		if !fap.Ipv6Enabled {
+			t.Fatal("enabling ipv6 in the fabric addressing policy failed")
+		}
+	}
+}


### PR DESCRIPTION
Needed by terraform provider.

Closes #64