### PR TITLE
rename `CreateAgent()` `CreateSystemAgent()`

### DIFF
--- a/apstra/api_system_agents_test.go
+++ b/apstra/api_system_agents_test.go
@@ -103,9 +103,9 @@ func TestCreateDeleteSwitchAgent(t *testing.T) {
 		var agentIds []ObjectId // do not make fixed length -- some switches might not be available
 		var labels []string     // do not make fixed length -- some switches might not be available
 		for _, testSwitch := range switchInfo {
-			log.Printf("testing CreateAgent() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+			log.Printf("testing CreateSystemAgent() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 			label := randString(5, "hex")
-			id, err := client.client.CreateAgent(context.TODO(), &SystemAgentRequest{
+			id, err := client.client.CreateSystemAgent(context.TODO(), &SystemAgentRequest{
 				ManagementIp:    testSwitch.ip,
 				Username:        testSwitch.user,
 				Password:        testSwitch.pass,

--- a/apstra/client.go
+++ b/apstra/client.go
@@ -504,8 +504,8 @@ func (o *Client) GetAgentProfileByLabel(ctx context.Context, label string) (*Age
 	return o.getAgentProfileByLabel(ctx, label)
 }
 
-// CreateAgent creates an Apstra Agent and returns its ID
-func (o *Client) CreateAgent(ctx context.Context, request *SystemAgentRequest) (ObjectId, error) {
+// CreateSystemAgent creates an Apstra System Agent and returns its ID
+func (o *Client) CreateSystemAgent(ctx context.Context, request *SystemAgentRequest) (ObjectId, error) {
 	return o.createSystemAgent(ctx, request)
 }
 


### PR DESCRIPTION
All related functions and objects are named `*SystemAgent`. Renaming the `Create()` method for consistency.

This is a BREAKING CHANGE. SDK clients (the terraform provider) will need to be updated when they bump to this SDK version.