### PR TITLE
task: housekeeping new connectivity template code

### DIFF
--- a/apstra/two_stage_l3_clos_connectivity_template.go
+++ b/apstra/two_stage_l3_clos_connectivity_template.go
@@ -20,10 +20,8 @@ const (
 
 	deleteRecursive = "delete_recursive"
 
-	policyTypeNameBatch      = "batch"
-	policyTypeNamePipeline   = "pipeline"
-	policyTypeBatchSuffix    = " (" + policyTypeNameBatch + ")"
-	policyTypePipelineSuffix = " (" + policyTypeNamePipeline + ")"
+	policyTypeBatchSuffix    = " (" + ctPrimitivePolicyTypeNameBatch + ")"
+	policyTypePipelineSuffix = " (" + ctPrimitivePolicyTypeNamePipeline + ")"
 
 	xInitialPosition = 290
 	yInitialPosition = 80
@@ -189,9 +187,9 @@ func (o *rawConnectivityTemplate) polish(id ObjectId) (*ConnectivityTemplate, er
 	if rootBatch.UserData == nil {
 		return nil, fmt.Errorf("connectivity template root batch has no user data")
 	}
-	if policyTypeNameBatch != rootBatch.PolicyTypeName {
+	if ctPrimitivePolicyTypeNameBatch != rootBatch.PolicyTypeName {
 		return nil, fmt.Errorf("expected policy %q to be type %q, got %q",
-			rootBatch.Id, policyTypeNameBatch, rootBatch.PolicyTypeName)
+			rootBatch.Id, ctPrimitivePolicyTypeNameBatch, rootBatch.PolicyTypeName)
 	}
 
 	delete(policyMap, rootBatch.Id)
@@ -299,8 +297,8 @@ func (o *ConnectivityTemplatePrimitive) rawPipeline() ([]rawConnectivityTemplate
 	pipeline := rawConnectivityTemplatePolicy{
 		Description:    attributes.Description(),
 		Tags:           []string{}, // always empty slice
-		Label:          attributes.Label() + policyTypePipelineSuffix,
-		PolicyTypeName: policyTypeNamePipeline,
+		Label:          attributes.Label() + string(policyTypePipelineSuffix),
+		PolicyTypeName: ctPrimitivePolicyTypeNamePipeline,
 		Attributes:     rawPipelineAttribtes,
 		Id:             *o.PipelineId,
 	}
@@ -450,8 +448,8 @@ func rawBatch(id ObjectId, description, label string, subpolicies []*Connectivit
 	batch := rawConnectivityTemplatePolicy{
 		Description:    description,
 		Tags:           []string{},
-		Label:          label + policyTypeBatchSuffix,
-		PolicyTypeName: policyTypeNameBatch,
+		Label:          label + string(policyTypeBatchSuffix),
+		PolicyTypeName: ctPrimitivePolicyTypeNameBatch,
 		Attributes:     rawAttributes,
 		Id:             id,
 	}
@@ -482,9 +480,9 @@ func parsePrimitiveTreeByPipelineId(pipelineId ObjectId, policyMap map[ObjectId]
 	if pipeline, ok = policyMap[pipelineId]; !ok {
 		return nil, fmt.Errorf("raw policy map doesn't include pipeline policy %q", pipelineId)
 	}
-	if pipeline.PolicyTypeName != policyTypeNamePipeline {
+	if ctPrimitivePolicyTypeNamePipeline != pipeline.PolicyTypeName {
 		return nil, fmt.Errorf("expected policy %q to be type %q, got %q",
-			pipeline.Id, policyTypeNamePipeline, pipeline.PolicyTypeName)
+			pipeline.Id, ctPrimitivePolicyTypeNamePipeline, pipeline.PolicyTypeName)
 	}
 
 	var pipelineAttributes rawPipelineAttributes
@@ -509,10 +507,10 @@ func parsePrimitiveTreeByPipelineId(pipelineId ObjectId, policyMap map[ObjectId]
 		// a batch ID appears in the pipeline
 		if batch, ok = policyMap[*pipelineAttributes.SecondSubpolicy]; ok {
 			// the batch was found in the map
-			if batch.PolicyTypeName != policyTypeNameBatch {
+			if ctPrimitivePolicyTypeNameBatch != batch.PolicyTypeName {
 				// batch ID has wrong policy type (not batch)
 				return nil, fmt.Errorf("expected policy %q to be type %q, got %q",
-					batch.Id, policyTypeNameBatch, batch.PolicyTypeName)
+					batch.Id, ctPrimitivePolicyTypeNameBatch, batch.PolicyTypeName)
 			}
 
 			var batchAttributes rawBatchAttributes

--- a/apstra/two_stage_l3_clos_connectivity_template.go
+++ b/apstra/two_stage_l3_clos_connectivity_template.go
@@ -189,6 +189,10 @@ func (o *rawConnectivityTemplate) polish(id ObjectId) (*ConnectivityTemplate, er
 	if rootBatch.UserData == nil {
 		return nil, fmt.Errorf("connectivity template root batch has no user data")
 	}
+	if policyTypeNameBatch != rootBatch.PolicyTypeName {
+		return nil, fmt.Errorf("expected policy %q to be type %q, got %q",
+			rootBatch.Id, policyTypeNameBatch, rootBatch.PolicyTypeName)
+	}
 
 	delete(policyMap, rootBatch.Id)
 

--- a/apstra/two_stage_l3_clos_connectivity_template.go
+++ b/apstra/two_stage_l3_clos_connectivity_template.go
@@ -375,7 +375,7 @@ func (o rawConnectivityTemplatePolicy) attributes() (ConnectivityTemplatePrimiti
 	switch o.PolicyTypeName {
 	case ctPrimitivePolicyTypeNameAttachSingleVlan:
 		result = new(ConnectivityTemplatePrimitiveAttributesAttachSingleVlan)
-	case ctPrimitivePolicyTypeNameAttachMultipleVLAN:
+	case ctPrimitivePolicyTypeNameAttachMultipleVlan:
 		result = new(ConnectivityTemplatePrimitiveAttributesAttachMultipleVlan)
 	case ctPrimitivePolicyTypeNameAttachLogicalLink:
 		result = new(ConnectivityTemplatePrimitiveAttributesAttachLogicalLink)

--- a/apstra/two_stage_l3_clos_connectivity_template_iota.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_iota.go
@@ -6,9 +6,7 @@ type CtPrimitivePolicyTypeName int
 type ctPrimitivePolicyTypeName string
 
 const (
-	CtPrimitivePolicyTypeNameNone     = CtPrimitivePolicyTypeName(iota)
-	CtPrimitivePolicyTypeNameBatch    // todo - is this needed?
-	CtPrimitivePolicyTypeNamePipeline // todo - is this needed?
+	CtPrimitivePolicyTypeNameNone = CtPrimitivePolicyTypeName(iota)
 	CtPrimitivePolicyTypeNameAttachSingleVlan
 	CtPrimitivePolicyTypeNameAttachMultipleVlan
 	CtPrimitivePolicyTypeNameAttachLogicalLink
@@ -22,8 +20,6 @@ const (
 	CtPrimitivePolicyTypeNameUnknown = "unknown CT primitive policy name %q"
 
 	ctPrimitivePolicyTypeNameNone                                           = ctPrimitivePolicyTypeName("")
-	ctPrimitivePolicyTypeNameBatch                                          = ctPrimitivePolicyTypeName("batch")    // todo - is this needed?
-	ctPrimitivePolicyTypeNamePipeline                                       = ctPrimitivePolicyTypeName("pipeline") // todo - is this needed?
 	ctPrimitivePolicyTypeNameAttachSingleVlan                               = ctPrimitivePolicyTypeName("AttachSingleVLAN")
 	ctPrimitivePolicyTypeNameAttachMultipleVlan                             = ctPrimitivePolicyTypeName("AttachMultipleVLAN")
 	ctPrimitivePolicyTypeNameAttachLogicalLink                              = ctPrimitivePolicyTypeName("AttachLogicalLink")
@@ -45,10 +41,6 @@ func (o CtPrimitivePolicyTypeName) raw() ctPrimitivePolicyTypeName {
 	switch o {
 	case CtPrimitivePolicyTypeNameNone:
 		return ctPrimitivePolicyTypeNameNone
-	case CtPrimitivePolicyTypeNameBatch:
-		return ctPrimitivePolicyTypeNameBatch
-	case CtPrimitivePolicyTypeNamePipeline:
-		return ctPrimitivePolicyTypeNamePipeline
 	case CtPrimitivePolicyTypeNameAttachSingleVlan:
 		return ctPrimitivePolicyTypeNameAttachSingleVlan
 	case CtPrimitivePolicyTypeNameAttachMultipleVlan:
@@ -87,10 +79,6 @@ func (o ctPrimitivePolicyTypeName) parse() (int, error) {
 	switch o {
 	case ctPrimitivePolicyTypeNameNone:
 		return int(CtPrimitivePolicyTypeNameNone), nil
-	case ctPrimitivePolicyTypeNameBatch:
-		return int(CtPrimitivePolicyTypeNameBatch), nil
-	case ctPrimitivePolicyTypeNamePipeline:
-		return int(CtPrimitivePolicyTypeNamePipeline), nil
 	case ctPrimitivePolicyTypeNameAttachSingleVlan:
 		return int(CtPrimitivePolicyTypeNameAttachSingleVlan), nil
 	case ctPrimitivePolicyTypeNameAttachMultipleVlan:

--- a/apstra/two_stage_l3_clos_connectivity_template_iota.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_iota.go
@@ -7,6 +7,8 @@ type ctPrimitivePolicyTypeName string
 
 const (
 	CtPrimitivePolicyTypeNameNone = CtPrimitivePolicyTypeName(iota)
+	CtPrimitivePolicyTypeNameBatch
+	CtPrimitivePolicyTypeNamePipeline
 	CtPrimitivePolicyTypeNameAttachSingleVlan
 	CtPrimitivePolicyTypeNameAttachMultipleVlan
 	CtPrimitivePolicyTypeNameAttachLogicalLink
@@ -20,6 +22,8 @@ const (
 	CtPrimitivePolicyTypeNameUnknown = "unknown CT primitive policy name %q"
 
 	ctPrimitivePolicyTypeNameNone                                           = ctPrimitivePolicyTypeName("")
+	ctPrimitivePolicyTypeNameBatch                                          = ctPrimitivePolicyTypeName("batch")
+	ctPrimitivePolicyTypeNamePipeline                                       = ctPrimitivePolicyTypeName("pipeline")
 	ctPrimitivePolicyTypeNameAttachSingleVlan                               = ctPrimitivePolicyTypeName("AttachSingleVLAN")
 	ctPrimitivePolicyTypeNameAttachMultipleVlan                             = ctPrimitivePolicyTypeName("AttachMultipleVLAN")
 	ctPrimitivePolicyTypeNameAttachLogicalLink                              = ctPrimitivePolicyTypeName("AttachLogicalLink")
@@ -41,6 +45,10 @@ func (o CtPrimitivePolicyTypeName) raw() ctPrimitivePolicyTypeName {
 	switch o {
 	case CtPrimitivePolicyTypeNameNone:
 		return ctPrimitivePolicyTypeNameNone
+	case CtPrimitivePolicyTypeNameBatch:
+		return ctPrimitivePolicyTypeNameBatch
+	case CtPrimitivePolicyTypeNamePipeline:
+		return ctPrimitivePolicyTypeNamePipeline
 	case CtPrimitivePolicyTypeNameAttachSingleVlan:
 		return ctPrimitivePolicyTypeNameAttachSingleVlan
 	case CtPrimitivePolicyTypeNameAttachMultipleVlan:
@@ -79,6 +87,10 @@ func (o ctPrimitivePolicyTypeName) parse() (int, error) {
 	switch o {
 	case ctPrimitivePolicyTypeNameNone:
 		return int(CtPrimitivePolicyTypeNameNone), nil
+	case ctPrimitivePolicyTypeNameBatch:
+		return int(CtPrimitivePolicyTypeNameBatch), nil
+	case ctPrimitivePolicyTypeNamePipeline:
+		return int(CtPrimitivePolicyTypeNamePipeline), nil
 	case ctPrimitivePolicyTypeNameAttachSingleVlan:
 		return int(CtPrimitivePolicyTypeNameAttachSingleVlan), nil
 	case ctPrimitivePolicyTypeNameAttachMultipleVlan:

--- a/apstra/two_stage_l3_clos_connectivity_template_iota.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_iota.go
@@ -10,7 +10,7 @@ const (
 	CtPrimitivePolicyTypeNameBatch    // todo - is this needed?
 	CtPrimitivePolicyTypeNamePipeline // todo - is this needed?
 	CtPrimitivePolicyTypeNameAttachSingleVlan
-	CtPrimitivePolicyTypeNameAttachMultipleVLAN
+	CtPrimitivePolicyTypeNameAttachMultipleVlan
 	CtPrimitivePolicyTypeNameAttachLogicalLink
 	CtPrimitivePolicyTypeNameAttachStaticRoute
 	CtPrimitivePolicyTypeNameAttachCustomStaticRoute
@@ -25,7 +25,7 @@ const (
 	ctPrimitivePolicyTypeNameBatch                                          = ctPrimitivePolicyTypeName("batch")    // todo - is this needed?
 	ctPrimitivePolicyTypeNamePipeline                                       = ctPrimitivePolicyTypeName("pipeline") // todo - is this needed?
 	ctPrimitivePolicyTypeNameAttachSingleVlan                               = ctPrimitivePolicyTypeName("AttachSingleVLAN")
-	ctPrimitivePolicyTypeNameAttachMultipleVLAN                             = ctPrimitivePolicyTypeName("AttachMultipleVLAN")
+	ctPrimitivePolicyTypeNameAttachMultipleVlan                             = ctPrimitivePolicyTypeName("AttachMultipleVLAN")
 	ctPrimitivePolicyTypeNameAttachLogicalLink                              = ctPrimitivePolicyTypeName("AttachLogicalLink")
 	ctPrimitivePolicyTypeNameAttachStaticRoute                              = ctPrimitivePolicyTypeName("AttachStaticRoute")
 	ctPrimitivePolicyTypeNameAttachCustomStaticRoute                        = ctPrimitivePolicyTypeName("AttachCustomStaticRoute")
@@ -51,8 +51,8 @@ func (o CtPrimitivePolicyTypeName) raw() ctPrimitivePolicyTypeName {
 		return ctPrimitivePolicyTypeNamePipeline
 	case CtPrimitivePolicyTypeNameAttachSingleVlan:
 		return ctPrimitivePolicyTypeNameAttachSingleVlan
-	case CtPrimitivePolicyTypeNameAttachMultipleVLAN:
-		return ctPrimitivePolicyTypeNameAttachMultipleVLAN
+	case CtPrimitivePolicyTypeNameAttachMultipleVlan:
+		return ctPrimitivePolicyTypeNameAttachMultipleVlan
 	case CtPrimitivePolicyTypeNameAttachLogicalLink:
 		return ctPrimitivePolicyTypeNameAttachLogicalLink
 	case CtPrimitivePolicyTypeNameAttachStaticRoute:
@@ -93,8 +93,8 @@ func (o ctPrimitivePolicyTypeName) parse() (int, error) {
 		return int(CtPrimitivePolicyTypeNamePipeline), nil
 	case ctPrimitivePolicyTypeNameAttachSingleVlan:
 		return int(CtPrimitivePolicyTypeNameAttachSingleVlan), nil
-	case ctPrimitivePolicyTypeNameAttachMultipleVLAN:
-		return int(CtPrimitivePolicyTypeNameAttachMultipleVLAN), nil
+	case ctPrimitivePolicyTypeNameAttachMultipleVlan:
+		return int(CtPrimitivePolicyTypeNameAttachMultipleVlan), nil
 	case ctPrimitivePolicyTypeNameAttachLogicalLink:
 		return int(CtPrimitivePolicyTypeNameAttachLogicalLink), nil
 	case ctPrimitivePolicyTypeNameAttachStaticRoute:

--- a/apstra/two_stage_l3_clos_connectivity_template_primitive_attributes.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_primitive_attributes.go
@@ -92,7 +92,7 @@ func (o *ConnectivityTemplatePrimitiveAttributesAttachMultipleVlan) raw() (json.
 }
 
 func (o *ConnectivityTemplatePrimitiveAttributesAttachMultipleVlan) PolicyTypeName() CtPrimitivePolicyTypeName {
-	return CtPrimitivePolicyTypeNameAttachMultipleVLAN
+	return CtPrimitivePolicyTypeNameAttachMultipleVlan
 }
 
 func (o *ConnectivityTemplatePrimitiveAttributesAttachMultipleVlan) Label() string {


### PR DESCRIPTION
- Rename `CtPrimitivePolicyTypeNameAttachMultipleVLAN` -> `CtPrimitivePolicyTypeNameAttachMultipleVlan` for consistency with other object names
- ~Remove unused iota value: `CtPrimitivePolicyTypeNameBatch`~ (decided to keep these)
- ~Remove unused iota value: `CtPrimitivePolicyTypeNamePipeline`~ (decided to keep these)
- Add check to ensure that root batch policy has expected policy type (batch)
- eliminate redundant `policyTypeNameBatch` and `policyTypeNamePipeline` constants

Closes #68