### PR TITLE
Eliminate `RefDesignDataCenter` alias, use `RefDesignL3Clos` instead

### DIFF
--- a/apstra/api_blueprints.go
+++ b/apstra/api_blueprints.go
@@ -24,12 +24,11 @@ const (
 const (
 	RefDesignTwoStageL3Clos = RefDesign(iota)
 	RefDesignFreeform
-	RefDesignDatacenter = RefDesignTwoStageL3Clos
-	RefDesignUnknown    = "unknown reference design '%s'"
+	RefDesignUnknown = "unknown reference design '%s'"
 
-	refDesignDatacenter = refDesign("two_stage_l3clos")
-	refDesignFreeform   = refDesign("freeform")
-	refDesignUnknown    = refDesign("unknown reference design %d")
+	refDesignTwoStageL3Clos = refDesign("two_stage_l3clos")
+	refDesignFreeform       = refDesign("freeform")
+	refDesignUnknown        = refDesign("unknown reference design %d")
 )
 
 type RefDesign int
@@ -37,8 +36,8 @@ type refDesign string
 
 func (o RefDesign) String() string {
 	switch o {
-	case RefDesignDatacenter:
-		return string(refDesignDatacenter)
+	case RefDesignTwoStageL3Clos:
+		return string(refDesignTwoStageL3Clos)
 	case RefDesignFreeform:
 		return string(refDesignFreeform)
 	default:
@@ -57,8 +56,8 @@ func (o *RefDesign) FromString(s string) error {
 
 func (o refDesign) parse() (RefDesign, error) {
 	switch o {
-	case refDesignDatacenter:
-		return RefDesignDatacenter, nil
+	case refDesignTwoStageL3Clos:
+		return RefDesignTwoStageL3Clos, nil
 	case refDesignFreeform:
 		return RefDesignFreeform, nil
 	default:

--- a/apstra/api_blueprints_integration_test.go
+++ b/apstra/api_blueprints_integration_test.go
@@ -58,7 +58,7 @@ func TestCreateDeleteBlueprint(t *testing.T) {
 		log.Printf("testing createBlueprintFromTemplate() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		name := randString(10, "hex")
 		id, err := client.client.CreateBlueprintFromTemplate(context.TODO(), &CreateBlueprintFromTemplateRequest{
-			RefDesign:  RefDesignDatacenter,
+			RefDesign:  RefDesignTwoStageL3Clos,
 			Label:      name,
 			TemplateId: "L2_Virtual_EVPN",
 		})

--- a/apstra/client.go
+++ b/apstra/client.go
@@ -135,7 +135,7 @@ func (o *Client) NewTwoStageL3ClosClient(ctx context.Context, blueprintId Object
 	if err != nil {
 		return nil, err
 	}
-	if bp.Design != refDesignDatacenter {
+	if bp.Design != refDesignTwoStageL3Clos {
 		return nil, fmt.Errorf("cannot create '%s' client for blueprint '%s' (type '%s')",
 			RefDesignTwoStageL3Clos.String(), blueprintId, bp.Design)
 	}

--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -141,7 +141,7 @@ func TestImmediateTickerSecondTick(t *testing.T) {
 
 func testBlueprintA(ctx context.Context, t *testing.T, client *Client) (*TwoStageL3ClosClient, func(context.Context) error) {
 	bpId, err := client.CreateBlueprintFromTemplate(context.Background(), &CreateBlueprintFromTemplateRequest{
-		RefDesign:  RefDesignDatacenter,
+		RefDesign:  RefDesignTwoStageL3Clos,
 		Label:      randString(5, "hex"),
 		TemplateId: "L3_Collapsed_ESI",
 	})
@@ -163,7 +163,7 @@ func testBlueprintA(ctx context.Context, t *testing.T, client *Client) (*TwoStag
 
 func testBlueprintB(ctx context.Context, t *testing.T, client *Client) (*TwoStageL3ClosClient, func(context.Context) error) {
 	bpId, err := client.CreateBlueprintFromTemplate(context.Background(), &CreateBlueprintFromTemplateRequest{
-		RefDesign:  RefDesignDatacenter,
+		RefDesign:  RefDesignTwoStageL3Clos,
 		Label:      randString(5, "hex"),
 		TemplateId: "L2_Virtual",
 	})
@@ -185,7 +185,7 @@ func testBlueprintB(ctx context.Context, t *testing.T, client *Client) (*TwoStag
 
 func testBlueprintC(ctx context.Context, t *testing.T, client *Client) (*TwoStageL3ClosClient, func(context.Context) error) {
 	bpId, err := client.CreateBlueprintFromTemplate(context.Background(), &CreateBlueprintFromTemplateRequest{
-		RefDesign:  RefDesignDatacenter,
+		RefDesign:  RefDesignTwoStageL3Clos,
 		Label:      randString(5, "hex"),
 		TemplateId: "L2_Virtual_EVPN",
 	})
@@ -207,7 +207,7 @@ func testBlueprintC(ctx context.Context, t *testing.T, client *Client) (*TwoStag
 
 func testBlueprintD(ctx context.Context, t *testing.T, client *Client) (*TwoStageL3ClosClient, func(context.Context) error) {
 	bpId, err := client.CreateBlueprintFromTemplate(context.Background(), &CreateBlueprintFromTemplateRequest{
-		RefDesign:  RefDesignDatacenter,
+		RefDesign:  RefDesignTwoStageL3Clos,
 		Label:      randString(5, "hex"),
 		TemplateId: "L2_Virtual_ESI_2x_Links",
 	})
@@ -261,7 +261,7 @@ func testBlueprintD(ctx context.Context, t *testing.T, client *Client) (*TwoStag
 
 func testBlueprintE(ctx context.Context, t *testing.T, client *Client) (*TwoStageL3ClosClient, func(context.Context) error) {
 	bpId, err := client.CreateBlueprintFromTemplate(context.Background(), &CreateBlueprintFromTemplateRequest{
-		RefDesign:  RefDesignDatacenter,
+		RefDesign:  RefDesignTwoStageL3Clos,
 		Label:      randString(5, "hex"),
 		TemplateId: "L2_ESI_Access",
 	})
@@ -468,7 +468,7 @@ func testBlueprintF(ctx context.Context, t *testing.T, client *Client) (*TwoStag
 	}
 
 	bpId, err := client.CreateBlueprintFromTemplate(context.Background(), &CreateBlueprintFromTemplateRequest{
-		RefDesign:  RefDesignDatacenter,
+		RefDesign:  RefDesignTwoStageL3Clos,
 		Label:      randString(5, "hex"),
 		TemplateId: templateId,
 	})

--- a/apstra/two_stage_l3_clos_lock_status_integration_test.go
+++ b/apstra/two_stage_l3_clos_lock_status_integration_test.go
@@ -19,7 +19,7 @@ func TestGetLockInfo(t *testing.T) {
 		log.Printf("testing createBlueprintFromTemplate() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		name := randString(10, "hex")
 		id, err := client.client.CreateBlueprintFromTemplate(context.TODO(), &CreateBlueprintFromTemplateRequest{
-			RefDesign:  RefDesignDatacenter,
+			RefDesign:  RefDesignTwoStageL3Clos,
 			Label:      name,
 			TemplateId: "L2_Virtual_EVPN",
 		})

--- a/apstra/two_stage_l3_clos_mutex_integration_test.go
+++ b/apstra/two_stage_l3_clos_mutex_integration_test.go
@@ -24,7 +24,7 @@ func TestLockUnlockBlueprintMutex(t *testing.T) {
 	for clientName, client := range clients {
 		log.Printf("testing CreateBlueprintFromTemplate() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		bpId, err := client.client.CreateBlueprintFromTemplate(context.Background(), &CreateBlueprintFromTemplateRequest{
-			RefDesign:  RefDesignDatacenter,
+			RefDesign:  RefDesignTwoStageL3Clos,
 			Label:      bpName,
 			TemplateId: "L3_Collapsed_ESI",
 		})
@@ -76,7 +76,7 @@ func TestLockLockUnlockBlueprintMutex(t *testing.T) {
 	for clientName, client := range clients {
 		log.Printf("testing CreateBlueprintFromTemplate() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		bpId, err := client.client.CreateBlueprintFromTemplate(context.Background(), &CreateBlueprintFromTemplateRequest{
-			RefDesign:  RefDesignDatacenter,
+			RefDesign:  RefDesignTwoStageL3Clos,
 			Label:      bpName,
 			TemplateId: "L3_Collapsed_ESI",
 		})
@@ -156,7 +156,7 @@ func TestLockBlockUnlockLockUnlockBlueprintMutex(t *testing.T) {
 	for clientName, client := range clients {
 		log.Printf("testing CreateBlueprintFromTemplate() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		bpId, err := client.client.CreateBlueprintFromTemplate(context.Background(), &CreateBlueprintFromTemplateRequest{
-			RefDesign:  RefDesignDatacenter,
+			RefDesign:  RefDesignTwoStageL3Clos,
 			Label:      bpName,
 			TemplateId: "L3_Collapsed_ESI",
 		})
@@ -245,7 +245,7 @@ func TestLockTryLockBlueprintMutex(t *testing.T) {
 	for clientName, client := range clients {
 		log.Printf("testing CreateBlueprintFromTemplate() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		bpId, err := client.client.CreateBlueprintFromTemplate(context.Background(), &CreateBlueprintFromTemplateRequest{
-			RefDesign:  RefDesignDatacenter,
+			RefDesign:  RefDesignTwoStageL3Clos,
 			Label:      bpName,
 			TemplateId: "L3_Collapsed_ESI",
 		})
@@ -331,7 +331,7 @@ func TestTryLockTryLockBlueprintMutex(t *testing.T) {
 	for clientName, client := range clients {
 		log.Printf("testing CreateBlueprintFromTemplate() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		bpId, err := client.client.CreateBlueprintFromTemplate(context.Background(), &CreateBlueprintFromTemplateRequest{
-			RefDesign:  RefDesignDatacenter,
+			RefDesign:  RefDesignTwoStageL3Clos,
 			Label:      bpName,
 			TemplateId: "L3_Collapsed_ESI",
 		})
@@ -416,7 +416,7 @@ func TestLockUnlLockTrylockBlueprintMutex(t *testing.T) {
 	for clientName, client := range clients {
 		log.Printf("testing CreateBlueprintFromTemplate() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		bpId, err := client.client.CreateBlueprintFromTemplate(context.Background(), &CreateBlueprintFromTemplateRequest{
-			RefDesign:  RefDesignDatacenter,
+			RefDesign:  RefDesignTwoStageL3Clos,
 			Label:      bpName,
 			TemplateId: "L3_Collapsed_ESI",
 		})
@@ -494,7 +494,7 @@ func TestReadOnlyBlueprintMutex(t *testing.T) {
 	for clientName, client := range clients {
 		log.Printf("testing CreateBlueprintFromTemplate() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		bpId, err := client.client.CreateBlueprintFromTemplate(context.Background(), &CreateBlueprintFromTemplateRequest{
-			RefDesign:  RefDesignDatacenter,
+			RefDesign:  RefDesignTwoStageL3Clos,
 			Label:      bpName,
 			TemplateId: "L3_Collapsed_ESI",
 		})


### PR DESCRIPTION
`RefDesign` is an `iota` type which had two constants with the same value:

```go
RefDesignDatacenter = RefDesignTwoStageL3Clos
```

This PR eliminates `RefDesignDatacenter` along with the private string alias `refDesignDataCenter` for consistency with the rest of the API (don't attempt to emulate the web UI - use API terminology).

This is a BREAKING CHANNGE. SDK consumers will need to remove any uses of `RefDesignDatacenter` and use `RefDesignTwoStageL3Clos` instead.