### PR TITLE
Add Graph query property matchers for null and inequality, node types, relationship types

### DIFF
--- a/apstra/query_engine.go
+++ b/apstra/query_engine.go
@@ -121,6 +121,39 @@ func (o QEIntVal) String() string {
 	return strconv.Itoa(int(o))
 }
 
+type QEIntGreater int
+
+func (o QEIntGreater) String() string {
+	return "gt(" + strconv.Itoa(int(o)) + ")"
+}
+
+type QEIntGreaterEqual int
+
+func (o QEIntGreaterEqual) String() string {
+	return "ge(" + strconv.Itoa(int(o)) + ")"
+}
+
+type QEIntLessThan int
+
+func (o QEIntLessThan) String() string {
+	return "lt(" + strconv.Itoa(int(o)) + ")"
+}
+
+type QEIntLessThanEqual int
+
+func (o QEIntLessThanEqual) String() string {
+	return "le(" + strconv.Itoa(int(o)) + ")"
+}
+
+type QENone bool
+
+func (o QENone) String() string {
+	if o {
+		return "is_none()"
+	}
+	return "not_none()"
+}
+
 func (o *Client) newQuery(blueprintId ObjectId) *PathQuery {
 	return &PathQuery{
 		client:      o,

--- a/apstra/query_engine_test.go
+++ b/apstra/query_engine_test.go
@@ -48,6 +48,30 @@ func TestQEAttrValsString(t *testing.T) {
 			v: QEIntVal(-7),
 			e: "-7",
 		},
+		{
+			v: QENone(true),
+			e: "is_none()",
+		},
+		{
+			v: QENone(false),
+			e: "not_none()",
+		},
+		{
+			v: QEIntGreater(4),
+			e: "gt(4)",
+		},
+		{
+			v: QEIntGreaterEqual(4),
+			e: "ge(4)",
+		},
+		{
+			v: QEIntLessThan(4),
+			e: "lt(4)",
+		},
+		{
+			v: QEIntLessThanEqual(4),
+			e: "le(4)",
+		},
 	}
 
 	for i, tc := range testCases {

--- a/apstra/query_node.go
+++ b/apstra/query_node.go
@@ -17,23 +17,25 @@ const (
 	NodeTypeSystem
 	NodeTypeTag
 	NodeTypeVirtualNetwork
+	NodeTypeVirtualNetworkInstance
 	NodeTypeUnknown = "unknown node type %s"
 
-	nodeTypeNone            = nodeType("")
-	nodeTypeInterface       = nodeType("interface")
-	nodeTypeInterfaceMap    = nodeType("interface_map")
-	nodeTypeLink            = nodeType("link")
-	nodeTypeLogicalDevice   = nodeType("logical_device")
-	nodeTypeMetadata        = nodeType("metadata")
-	nodeTypePolicy          = nodeType("policy")
-	nodeTypeRack            = nodeType("rack")
-	nodeTypeRedundancyGroup = nodeType("redundancy_group")
-	nodeTypeRoutingPolicy   = nodeType("routing_policy")
-	nodeTypeSecurityZone    = nodeType("security_zone")
-	nodeTypeSystem          = nodeType("system")
-	nodeTypeTag             = nodeType("tag")
-	nodeTypeVirtualNetwork  = nodeType("virtual_network")
-	nodeTypeUnknown         = "unknown node type %d"
+	nodeTypeNone                   = nodeType("")
+	nodeTypeInterface              = nodeType("interface")
+	nodeTypeInterfaceMap           = nodeType("interface_map")
+	nodeTypeLink                   = nodeType("link")
+	nodeTypeLogicalDevice          = nodeType("logical_device")
+	nodeTypeMetadata               = nodeType("metadata")
+	nodeTypePolicy                 = nodeType("policy")
+	nodeTypeRack                   = nodeType("rack")
+	nodeTypeRedundancyGroup        = nodeType("redundancy_group")
+	nodeTypeRoutingPolicy          = nodeType("routing_policy")
+	nodeTypeSecurityZone           = nodeType("security_zone")
+	nodeTypeSystem                 = nodeType("system")
+	nodeTypeTag                    = nodeType("tag")
+	nodeTypeVirtualNetwork         = nodeType("virtual_network")
+	nodeTypeVirtualNetworkInstance = nodeType("vn_instance")
+	nodeTypeUnknown                = "unknown node type %d"
 )
 
 type NodeType int
@@ -69,6 +71,8 @@ func (o NodeType) String() string {
 		return string(nodeTypeTag)
 	case NodeTypeVirtualNetwork:
 		return string(nodeTypeVirtualNetwork)
+	case NodeTypeVirtualNetworkInstance:
+		return string(nodeTypeVirtualNetworkInstance)
 	default:
 		return fmt.Sprintf(nodeTypeUnknown, o)
 	}

--- a/apstra/query_relationship.go
+++ b/apstra/query_relationship.go
@@ -8,8 +8,10 @@ const (
 	RelationshipTypeDeviceProfile
 	RelationshipTypeHostedInterfaces
 	RelationshipTypeInterfaceMap
+	RelationshipTypeInstantiates
 	RelationshipTypeLink
 	RelationshipTypeLogicalDevice
+	RelationshipTypeMemberVNs
 	RelationshipTypePartOfRack
 	RelationshipTypeTag
 	RelationshipTypeUnknown = "unknown node type %s"
@@ -19,8 +21,10 @@ const (
 	relationshipTypeDeviceProfile     = relationshipType("device_profile")
 	relationshipTypeHostedInterfaces  = relationshipType("hosted_interfaces")
 	relationshipTypeInterfaceMap      = relationshipType("interface_map")
+	relationshipTypeInstantiates      = relationshipType("instantiates")
 	relationshipTypeLink              = relationshipType("link")
 	relationshipTypeLogicalDevice     = relationshipType("logical_device")
+	relationshipTypeMemberVNs         = relationshipType("member_vns")
 	relationshipTypePartOfRack        = relationshipType("part_of_rack")
 	relationshipTypeTag               = relationshipType("tag")
 	relationshipTypeUnknown           = "unknown node type %d"
@@ -41,10 +45,14 @@ func (o RelationshipType) String() string {
 		return string(relationshipTypeHostedInterfaces)
 	case RelationshipTypeInterfaceMap:
 		return string(relationshipTypeInterfaceMap)
+	case RelationshipTypeInstantiates:
+		return string(relationshipTypeInstantiates)
 	case RelationshipTypeLink:
 		return string(relationshipTypeLink)
 	case RelationshipTypeLogicalDevice:
 		return string(relationshipTypeLogicalDevice)
+	case RelationshipTypeMemberVNs:
+		return string(relationshipTypeMemberVNs)
 	case RelationshipTypePartOfRack:
 		return string(relationshipTypePartOfRack)
 	case RelationshipTypeTag:

--- a/apstra/query_relationship.go
+++ b/apstra/query_relationship.go
@@ -8,6 +8,7 @@ const (
 	RelationshipTypeDeviceProfile
 	RelationshipTypeHostedInterfaces
 	RelationshipTypeInterfaceMap
+	RelationshipTypeInstantiatedBy
 	RelationshipTypeInstantiates
 	RelationshipTypeLink
 	RelationshipTypeLogicalDevice
@@ -21,6 +22,7 @@ const (
 	relationshipTypeDeviceProfile     = relationshipType("device_profile")
 	relationshipTypeHostedInterfaces  = relationshipType("hosted_interfaces")
 	relationshipTypeInterfaceMap      = relationshipType("interface_map")
+	relationshipTypeInstantiatedBy    = relationshipType("instantiated_by")
 	relationshipTypeInstantiates      = relationshipType("instantiates")
 	relationshipTypeLink              = relationshipType("link")
 	relationshipTypeLogicalDevice     = relationshipType("logical_device")
@@ -45,6 +47,8 @@ func (o RelationshipType) String() string {
 		return string(relationshipTypeHostedInterfaces)
 	case RelationshipTypeInterfaceMap:
 		return string(relationshipTypeInterfaceMap)
+	case RelationshipTypeInstantiatedBy:
+		return string(relationshipTypeInstantiatedBy)
 	case RelationshipTypeInstantiates:
 		return string(relationshipTypeInstantiates)
 	case RelationshipTypeLink:


### PR DESCRIPTION
Add query property matchers:
- `type QEIntGreater int`
- `type QEIntGreaterEqual int`
- `type QEIntLessThan int`
- `type QEIntLessThanEqual int`
- `type QENone bool`

Add query node types:
- `NodeTypeVirtualNetworkInstance`

Add query relationship types:
- `RelationshipTypeInstantiatedBy`
- `RelationshipTypeInstantiates`
- `RelationshipTypeMemberVNs`
