### PR TITLE
Configlet review

### DIFF
--- a/apstra/api_design_configlets.go
+++ b/apstra/api_design_configlets.go
@@ -43,7 +43,7 @@ type ConfigletData struct {
 }
 
 type rawConfigletData struct {
-	RefArchs    []string                `json:"ref_archs"`
+	RefArchs    []refDesign             `json:"ref_archs"`
 	Generators  []rawConfigletGenerator `json:"generators"`
 	DisplayName string                  `json:"display_name"`
 }
@@ -58,17 +58,21 @@ type rawConfiglet struct {
 }
 
 func (o *ConfigletData) raw() *rawConfigletData {
-	rawcr := rawConfigletData{}
-	rawcr.DisplayName = o.DisplayName
-	rawcr.RefArchs = make([]string, len(o.RefArchs))
-	rawcr.Generators = make([]rawConfigletGenerator, len(o.Generators))
+	refArchs := make([]refDesign, len(o.RefArchs))
 	for i, j := range o.RefArchs {
-		rawcr.RefArchs[i] = j.String()
+		refArchs[i] = refDesign(j.String())
 	}
+
+	generators := make([]rawConfigletGenerator, len(o.Generators))
 	for i, j := range o.Generators {
-		rawcr.Generators[i] = *j.raw()
+		generators[i] = *j.raw()
 	}
-	return &rawcr
+
+	return &rawConfigletData{
+		DisplayName: o.DisplayName,
+		RefArchs:    make([]refDesign, len(o.RefArchs)),
+		Generators:  make([]rawConfigletGenerator, len(o.Generators)),
+	}
 }
 
 func (o *rawConfigletData) polish() (*ConfigletData, error) {
@@ -115,13 +119,13 @@ func (o *rawConfigletGenerator) polish() (*ConfigletGenerator, error) {
 }
 
 func (o *ConfigletGenerator) raw() *rawConfigletGenerator {
-	cg := rawConfigletGenerator{}
-	cg.TemplateText = o.TemplateText
-	cg.Filename = o.Filename
-	cg.NegationTemplateText = o.NegationTemplateText
-	cg.ConfigStyle = o.ConfigStyle.raw()
-	cg.Section = o.Section.raw()
-	return &cg
+	return &rawConfigletGenerator{
+		TemplateText:         o.TemplateText,
+		Filename:             o.Filename,
+		NegationTemplateText: o.NegationTemplateText,
+		ConfigStyle:          o.ConfigStyle.raw(),
+		Section:              o.Section.raw(),
+	}
 }
 
 func (o *rawConfiglet) polish() (*Configlet, error) {
@@ -183,20 +187,31 @@ func (o *Client) getConfiglet(ctx context.Context, id ObjectId) (*rawConfiglet, 
 }
 
 func (o *Client) getConfigletByName(ctx context.Context, name string) (*rawConfiglet, error) {
-	cgs, err := o.getAllConfiglets(ctx)
+	configlets, err := o.getAllConfiglets(ctx)
 	if err != nil {
 		return nil, convertTtaeToAceWherePossible(err)
 	}
 
-	for _, t := range cgs {
-		if t.DisplayName == name {
-			return &t, nil
+	foundIdx := -1
+	for i, configlet := range configlets {
+		if configlet.DisplayName == name {
+			if foundIdx >= 0 {
+				return nil, ApstraClientErr{
+					errType: ErrMultipleMatch,
+					err:     fmt.Errorf("multiple Configlets have name %q", name),
+				}
+			}
+			foundIdx = i
 		}
+	}
+
+	if foundIdx >= 0 {
+		return &configlets[foundIdx], nil
 	}
 
 	return nil, ApstraClientErr{
 		errType: ErrNotfound,
-		err:     fmt.Errorf(" Configlet with name '%s' not found", name),
+		err:     fmt.Errorf("no Configlet with name '%s' found", name),
 	}
 }
 

--- a/apstra/api_design_configlets.go
+++ b/apstra/api_design_configlets.go
@@ -215,15 +215,13 @@ func (o *Client) getAllConfiglets(ctx context.Context) ([]rawConfiglet, error) {
 	return response.Items, nil
 }
 
-func (o *Client) createConfiglet(ctx context.Context, in *ConfigletData) (ObjectId, error) {
-
-	cr := in.raw()
+func (o *Client) createConfiglet(ctx context.Context, in *rawConfigletData) (ObjectId, error) {
 	response := &objectIdResponse{}
 
 	err := o.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodPost,
 		urlStr:      apiUrlDesignConfiglets,
-		apiInput:    cr,
+		apiInput:    in,
 		apiResponse: response,
 	})
 	if err != nil {
@@ -232,13 +230,11 @@ func (o *Client) createConfiglet(ctx context.Context, in *ConfigletData) (Object
 	return response.Id, nil
 }
 
-func (o *Client) updateConfiglet(ctx context.Context, id ObjectId, in *ConfigletData) error {
-	cr := in.raw()
-
+func (o *Client) updateConfiglet(ctx context.Context, id ObjectId, in *rawConfigletData) error {
 	err := o.talkToApstra(ctx, &talkToApstraIn{
 		method:   http.MethodPut,
 		urlStr:   fmt.Sprintf(apiUrlDesignConfigletsById, id),
-		apiInput: cr,
+		apiInput: in,
 	})
 	if err != nil {
 		return convertTtaeToAceWherePossible(err)

--- a/apstra/client.go
+++ b/apstra/client.go
@@ -961,7 +961,7 @@ func (o *Client) DeleteTag(ctx context.Context, id ObjectId) error {
 
 // CreateConfiglet creates a Configlet and returns its ObjectId.
 func (o *Client) CreateConfiglet(ctx context.Context, in *ConfigletData) (ObjectId, error) {
-	return o.createConfiglet(ctx, in)
+	return o.createConfiglet(ctx, in.raw())
 }
 
 // DeleteConfiglet deletes a configlet.
@@ -980,7 +980,7 @@ func (o *Client) GetConfiglet(ctx context.Context, in ObjectId) (*Configlet, err
 
 // UpdateConfiglet updates a configlet
 func (o *Client) UpdateConfiglet(ctx context.Context, id ObjectId, in *ConfigletData) error {
-	return o.updateConfiglet(ctx, id, in)
+	return o.updateConfiglet(ctx, id, in.raw())
 }
 
 // GetAllConfiglets returns []Configlet representing all configlets


### PR DESCRIPTION
- use `refDesign` instead of `string` in `rawConfigletData`
- rewrite a couple of object creates for less copying (compiler may moot this) and better readability
- catch multiple matches in `getConfigletByName()`
- move `raw()` calls to public methods