### PR TITLE
Change TTL in CT BGP primitives from `int` to `uint8`

### DIFF
--- a/apstra/two_stage_l3_clos_connectivity_template_primitive_attributes.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_primitive_attributes.go
@@ -431,7 +431,7 @@ type ConnectivityTemplatePrimitiveAttributesAttachBgpWithPrefixPeeringForSviOrSu
 	PrefixNeighborIpv6    *net.IPNet
 	SessionAddressingIpv4 bool
 	SessionAddressingIpv6 bool
-	Ttl                   int
+	Ttl                   uint8
 }
 
 func (o *ConnectivityTemplatePrimitiveAttributesAttachBgpWithPrefixPeeringForSviOrSubinterface) raw() (json.RawMessage, error) {
@@ -823,7 +823,7 @@ type rawConnectivityTemplatePrimitiveAttributesAttachBgpWithPrefixPeeringForSviO
 	PrefixNeighborIpv6    *string `json:"prefix_neighbor_ipv6"`
 	SessionAddressingIpv4 bool    `json:"session_addressing_ipv4"`
 	SessionAddressingIpv6 bool    `json:"session_addressing_ipv6"`
-	Ttl                   int     `json:"ttl"`
+	Ttl                   uint8   `json:"ttl"`
 }
 
 func (o rawConnectivityTemplatePrimitiveAttributesAttachBgpWithPrefixPeeringForSviOrSubinterface) polish(t *ConnectivityTemplatePrimitiveAttributesAttachBgpWithPrefixPeeringForSviOrSubinterface) error {


### PR DESCRIPTION
The various CT BGP primitives (IP/Generic/Dynamic) did not have consistent handling of TTL type.

Values 0 - 255 allowed, so `uint8` is the right choice.

This PR normalizes the types.