### PR TITLE
Add methods for assigning connectivity templates

### DIFF
--- a/apstra/query_node.go
+++ b/apstra/query_node.go
@@ -4,6 +4,9 @@ import "fmt"
 
 const (
 	NodeTypeNone = NodeType(iota)
+	NodeTypeEpApplicationInstance
+	NodeTypeEpEndpointPolicy
+	NodeTypeEpGroup
 	NodeTypeInterface
 	NodeTypeInterfaceMap
 	NodeTypeLink
@@ -19,21 +22,24 @@ const (
 	NodeTypeVirtualNetwork
 	NodeTypeUnknown = "unknown node type %s"
 
-	nodeTypeNone            = nodeType("")
-	nodeTypeInterface       = nodeType("interface")
-	nodeTypeInterfaceMap    = nodeType("interface_map")
-	nodeTypeLink            = nodeType("link")
-	nodeTypeLogicalDevice   = nodeType("logical_device")
-	nodeTypeMetadata        = nodeType("metadata")
-	nodeTypePolicy          = nodeType("policy")
-	nodeTypeRack            = nodeType("rack")
-	nodeTypeRedundancyGroup = nodeType("redundancy_group")
-	nodeTypeRoutingPolicy   = nodeType("routing_policy")
-	nodeTypeSecurityZone    = nodeType("security_zone")
-	nodeTypeSystem          = nodeType("system")
-	nodeTypeTag             = nodeType("tag")
-	nodeTypeVirtualNetwork  = nodeType("virtual_network")
-	nodeTypeUnknown         = "unknown node type %d"
+	nodeTypeNone                  = nodeType("")
+	nodeTypeEpApplicationInstance = nodeType("ep_application_instance")
+	nodeTypeEpEndpointPolicy      = nodeType("ep_endpoint_policy")
+	nodeTypeEpGroup               = nodeType("ep_group")
+	nodeTypeInterface             = nodeType("interface")
+	nodeTypeInterfaceMap          = nodeType("interface_map")
+	nodeTypeLink                  = nodeType("link")
+	nodeTypeLogicalDevice         = nodeType("logical_device")
+	nodeTypeMetadata              = nodeType("metadata")
+	nodeTypePolicy                = nodeType("policy")
+	nodeTypeRack                  = nodeType("rack")
+	nodeTypeRedundancyGroup       = nodeType("redundancy_group")
+	nodeTypeRoutingPolicy         = nodeType("routing_policy")
+	nodeTypeSecurityZone          = nodeType("security_zone")
+	nodeTypeSystem                = nodeType("system")
+	nodeTypeTag                   = nodeType("tag")
+	nodeTypeVirtualNetwork        = nodeType("virtual_network")
+	nodeTypeUnknown               = "unknown node type %d"
 )
 
 type NodeType int
@@ -43,6 +49,12 @@ func (o NodeType) String() string {
 	switch o {
 	case NodeTypeNone:
 		return string(nodeTypeNone)
+	case NodeTypeEpApplicationInstance:
+		return string(nodeTypeEpApplicationInstance)
+	case NodeTypeEpEndpointPolicy:
+		return string(nodeTypeEpEndpointPolicy)
+	case NodeTypeEpGroup:
+		return string(nodeTypeEpGroup)
 	case NodeTypeInterface:
 		return string(nodeTypeInterface)
 	case NodeTypeInterfaceMap:

--- a/apstra/query_relationship.go
+++ b/apstra/query_relationship.go
@@ -6,6 +6,10 @@ const (
 	RelationshipTypeNone = RelationshipType(iota)
 	RelationshipTypeComposedOfSystems
 	RelationshipTypeDeviceProfile
+	RelationshipTypeEpAffectedBy
+	RelationshipTypeEpMemberOf
+	RelationshipTypeEpNested
+	RelationshipTypeEpTopLevel
 	RelationshipTypeHostedInterfaces
 	RelationshipTypeInterfaceMap
 	RelationshipTypeLink
@@ -17,6 +21,10 @@ const (
 	relationshipTypeNone              = relationshipType("")
 	relationshipTypeComposedOfSystems = relationshipType("composed_of_systems")
 	relationshipTypeDeviceProfile     = relationshipType("device_profile")
+	relationshipTypeEpAffectedBy      = relationshipType("ep_affected_by")
+	relationshipTypeEpMemberOf        = relationshipType("ep_member_of")
+	relationshipTypeEpNested          = relationshipType("ep_nested")
+	relationshipTypeEpTopLevel        = relationshipType("ep_top_level")
 	relationshipTypeHostedInterfaces  = relationshipType("hosted_interfaces")
 	relationshipTypeInterfaceMap      = relationshipType("interface_map")
 	relationshipTypeLink              = relationshipType("link")
@@ -37,6 +45,14 @@ func (o RelationshipType) String() string {
 		return string(relationshipTypeComposedOfSystems)
 	case RelationshipTypeDeviceProfile:
 		return string(relationshipTypeDeviceProfile)
+	case RelationshipTypeEpAffectedBy:
+		return string(relationshipTypeEpAffectedBy)
+	case RelationshipTypeEpMemberOf:
+		return string(relationshipTypeEpMemberOf)
+	case RelationshipTypeEpNested:
+		return string(relationshipTypeEpNested)
+	case RelationshipTypeEpTopLevel:
+		return string(relationshipTypeEpTopLevel)
 	case RelationshipTypeHostedInterfaces:
 		return string(relationshipTypeHostedInterfaces)
 	case RelationshipTypeInterfaceMap:

--- a/apstra/query_relationship.go
+++ b/apstra/query_relationship.go
@@ -4,6 +4,7 @@ import "fmt"
 
 const (
 	RelationshipTypeNone = RelationshipType(iota)
+	RelationshipTypeComposedOf
 	RelationshipTypeComposedOfSystems
 	RelationshipTypeDeviceProfile
 	RelationshipTypeEpAffectedBy
@@ -19,6 +20,7 @@ const (
 	RelationshipTypeUnknown = "unknown node type %s"
 
 	relationshipTypeNone              = relationshipType("")
+	relationshipTypeComposedOf        = relationshipType("composed_of")
 	relationshipTypeComposedOfSystems = relationshipType("composed_of_systems")
 	relationshipTypeDeviceProfile     = relationshipType("device_profile")
 	relationshipTypeEpAffectedBy      = relationshipType("ep_affected_by")
@@ -41,6 +43,8 @@ func (o RelationshipType) String() string {
 	switch o {
 	case RelationshipTypeNone:
 		return string(relationshipTypeNone)
+	case RelationshipTypeComposedOf:
+		return string(relationshipTypeComposedOf)
 	case RelationshipTypeComposedOfSystems:
 		return string(relationshipTypeComposedOfSystems)
 	case RelationshipTypeDeviceProfile:

--- a/apstra/two_stage_l3_clos_connectivity_template_assignment.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_assignment.go
@@ -1,0 +1,167 @@
+package apstra
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const (
+	apiUrlBlueprintEndpointPolicyBatchApply = apiUrlBlueprintById + apiUrlPathDelim + "obj-policy-batch-apply"
+)
+
+// GetAllInterfacesConnectivityTemplates returns a map of ConnectivityTemplate
+// IDs keyed by Interface (switch port) ID.
+func (o *TwoStageL3ClosClient) GetAllInterfacesConnectivityTemplates(ctx context.Context) (map[ObjectId][]ObjectId, error) {
+	queryResponse := new(struct {
+		Items []struct {
+			Interface struct {
+				Id ObjectId `json:"id"`
+			} `json:"interface"`
+			EndpointPolicy struct {
+				Id ObjectId `json:"id"`
+			} `json:"ep_endpoint_policy"`
+		} `json:"items"`
+	})
+
+	query := new(PathQuery).
+		SetBlueprintId(o.blueprintId).
+		SetBlueprintType(BlueprintTypeStaging).
+		SetClient(o.client).
+		Node([]QEEAttribute{
+			NodeTypeInterface.QEEAttribute(),
+			{Key: "name", Value: QEStringVal(NodeTypeInterface.String())},
+		}).
+		Out([]QEEAttribute{RelationshipTypeEpMemberOf.QEEAttribute()}).
+		Node([]QEEAttribute{NodeTypeEpGroup.QEEAttribute()}).
+		In([]QEEAttribute{RelationshipTypeEpAffectedBy.QEEAttribute()}).
+		Node([]QEEAttribute{NodeTypeEpApplicationInstance.QEEAttribute()}).
+		Out([]QEEAttribute{RelationshipTypeEpTopLevel.QEEAttribute()}).
+		Node([]QEEAttribute{
+			NodeTypeEpEndpointPolicy.QEEAttribute(),
+			{Key: "visible", Value: QEBoolVal(true)},
+			{Key: "name", Value: QEStringVal(NodeTypeEpEndpointPolicy.String())},
+		})
+
+	err := query.Do(ctx, queryResponse)
+	if err != nil {
+		return nil, convertTtaeToAceWherePossible(err)
+	}
+
+	intermediateResult := make(map[ObjectId]map[ObjectId]struct{})
+	for _, item := range queryResponse.Items {
+		if _, ok := intermediateResult[item.Interface.Id]; !ok {
+			intermediateResult[item.Interface.Id] = make(map[ObjectId]struct{})
+		}
+		intermediateResult[item.Interface.Id][item.EndpointPolicy.Id] = struct{}{}
+	}
+
+	result := make(map[ObjectId][]ObjectId)
+	for interfaceId, ctIds := range intermediateResult {
+		for ctId := range ctIds {
+			result[interfaceId] = append(result[interfaceId], ctId)
+		}
+	}
+
+	return result, nil
+}
+
+func (o *TwoStageL3ClosClient) GetInterfaceConnectivityTemplates(ctx context.Context, intfId ObjectId) ([]ObjectId, error) {
+	allMap, err := o.GetAllInterfacesConnectivityTemplates(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if ctIds, ok := allMap[intfId]; ok {
+		return ctIds, nil
+	}
+
+	// at this point it's unclear whether interface 'intfId' doesn't exist, or
+	// merely has no CTs assigned. Returning a nil slice, along with the error
+	// returned by GetNode will clear that up.
+	return nil, o.client.GetNode(ctx, o.blueprintId, intfId, &struct{}{})
+}
+
+// SetInterfaceConnectivityTemplates assigns the listed ConnectivityTemplate IDs
+// to the interface specified by intfId.
+func (o *TwoStageL3ClosClient) SetInterfaceConnectivityTemplates(ctx context.Context, intfId ObjectId, ctIds []ObjectId) error {
+	type policyInfo struct {
+		PolicyId ObjectId `json:"policy"`
+		Used     bool     `json:"used"`
+	}
+
+	type applicationPoints struct {
+		InterfaceId ObjectId     `json:"id"`
+		PolicyInfo  []policyInfo `json:"policies"`
+	}
+
+	appPoints := applicationPoints{
+		InterfaceId: intfId,
+		PolicyInfo:  make([]policyInfo, len(ctIds)),
+	}
+	for i, ctId := range ctIds {
+		appPoints.PolicyInfo[i] = policyInfo{
+			PolicyId: ctId,
+			Used:     true,
+		}
+	}
+
+	apiInput := struct {
+		ApplicationPoints []applicationPoints `json:"application_points"`
+	}{
+		ApplicationPoints: []applicationPoints{appPoints},
+	}
+
+	err := o.client.talkToApstra(ctx, &talkToApstraIn{
+		method:   http.MethodPatch,
+		urlStr:   fmt.Sprintf(apiUrlBlueprintEndpointPolicyBatchApply, o.blueprintId),
+		apiInput: &apiInput,
+	})
+	if err != nil {
+		return convertTtaeToAceWherePossible(err)
+	}
+
+	return nil
+}
+
+// DelInterfaceConnectivityTemplates removes the listed ConnectivityTemplate IDs
+// from the interface specified by intfId.
+func (o *TwoStageL3ClosClient) DelInterfaceConnectivityTemplates(ctx context.Context, intfId ObjectId, ctIds []ObjectId) error {
+	type policyInfo struct {
+		PolicyId ObjectId `json:"policy"`
+		Used     bool     `json:"used"`
+	}
+
+	type applicationPoints struct {
+		InterfaceId ObjectId     `json:"id"`
+		PolicyInfo  []policyInfo `json:"policies"`
+	}
+
+	appPoints := applicationPoints{
+		InterfaceId: intfId,
+		PolicyInfo:  make([]policyInfo, len(ctIds)),
+	}
+	for i, ctId := range ctIds {
+		appPoints.PolicyInfo[i] = policyInfo{
+			PolicyId: ctId,
+			Used:     false,
+		}
+	}
+
+	apiInput := struct {
+		ApplicationPoints []applicationPoints `json:"application_points"`
+	}{
+		ApplicationPoints: []applicationPoints{appPoints},
+	}
+
+	err := o.client.talkToApstra(ctx, &talkToApstraIn{
+		method:   http.MethodPatch,
+		urlStr:   fmt.Sprintf(apiUrlBlueprintEndpointPolicyBatchApply, o.blueprintId),
+		apiInput: &apiInput,
+	})
+	if err != nil {
+		return convertTtaeToAceWherePossible(err)
+	}
+
+	return nil
+}

--- a/apstra/two_stage_l3_clos_connectivity_template_assignment_integration_test.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_assignment_integration_test.go
@@ -6,6 +6,7 @@ package apstra
 import (
 	"context"
 	"log"
+	"strings"
 	"testing"
 )
 
@@ -31,6 +32,7 @@ func TestAssignClearCtToInterface(t *testing.T) {
 
 		var systems struct {
 			Nodes map[ObjectId]struct {
+				Label      string     `json:"label"`
 				SystemType string     `json:"system_type"`
 				Role       systemRole `json:"role"`
 			} `json:"nodes"`
@@ -59,6 +61,17 @@ func TestAssignClearCtToInterface(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		vrf := randString(5, "hex")
+		szId, err := bpClient.CreateSecurityZone(ctx, &SecurityZoneData{
+			Label:   vrf,
+			SzType:  SecurityZoneTypeEVPN,
+			VrfName: vrf,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		log.Printf("testing CreateVirtualNetwork() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		vnId, err := bpClient.CreateVirtualNetwork(ctx, &VirtualNetworkData{
 			DhcpService:               false,
 			Ipv4Enabled:               false,
@@ -69,7 +82,7 @@ func TestAssignClearCtToInterface(t *testing.T) {
 			ReservedVlanId:            nil,
 			RouteTarget:               "",
 			RtPolicy:                  nil,
-			SecurityZoneId:            "",
+			SecurityZoneId:            szId,
 			SviIps:                    nil,
 			VirtualGatewayIpv4:        nil,
 			VirtualGatewayIpv6:        nil,
@@ -77,13 +90,109 @@ func TestAssignClearCtToInterface(t *testing.T) {
 			VirtualGatewayIpv6Enabled: false,
 			VnBindings:                bindings,
 			VnId:                      nil,
-			VnType:                    VnTypeVlan,
+			VnType:                    VnTypeVxlan,
 			VirtualMac:                nil,
 		})
 		if err != nil {
 			t.Fatal(err)
 		}
-		log.Println(vnId)
+
+		ct := ConnectivityTemplate{
+			Label: randString(5, "hex"),
+			Subpolicies: []*ConnectivityTemplatePrimitive{{
+				Attributes: &ConnectivityTemplatePrimitiveAttributesAttachSingleVlan{
+					VnNodeId: &vnId,
+				},
+			}},
+		}
+
+		err = ct.SetIds()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ct.SetUserData()
+
+		log.Printf("testing CreateConnectivityTemplate() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		err = bpClient.CreateConnectivityTemplate(ctx, &ct)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var leaf1Id *ObjectId
+		for id, system := range systems.Nodes {
+			if system.SystemType != "switch" || system.Role != systemRoleLeaf {
+				continue
+			}
+			if strings.HasSuffix(system.Label, "leaf1") {
+				leaf1Id = &id
+				break
+			}
+		}
+
+		if leaf1Id == nil {
+			t.Fatal("failed to find leaf 1")
+		}
+
+		query := new(PathQuery).
+			SetBlueprintType(BlueprintTypeStaging).
+			SetBlueprintId(bpClient.blueprintId).
+			SetClient(bpClient.client).
+			Node([]QEEAttribute{{"id", QEStringVal(leaf1Id.String())}}).
+			Out([]QEEAttribute{RelationshipTypeHostedInterfaces.QEEAttribute()}).
+			Node([]QEEAttribute{
+				NodeTypeInterface.QEEAttribute(),
+				{"if_name", QEStringVal("ae1")},
+			}).
+			In([]QEEAttribute{RelationshipTypeComposedOf.QEEAttribute()}).
+			Node([]QEEAttribute{
+				NodeTypeInterface.QEEAttribute(),
+				{"name", QEStringVal("n_interface")},
+			})
+
+		var queryResponse struct {
+			Items []struct {
+				Interface struct {
+					Id ObjectId `json:"id"`
+				} `json:"n_interface"`
+			} `json:"items"`
+		}
+
+		err = query.Do(ctx, &queryResponse)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(queryResponse.Items) != 1 {
+			t.Fatalf("expected 1 item, got %d items", len(queryResponse.Items))
+		}
+		interfaceId := queryResponse.Items[0].Interface.Id
+
+		ctsToAssign := []ObjectId{*ct.Id}
+		err = bpClient.SetInterfaceConnectivityTemplates(ctx, interfaceId, ctsToAssign)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assignedCts, err := bpClient.GetInterfaceConnectivityTemplates(ctx, interfaceId)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		compareSlices(t, ctsToAssign, assignedCts, "assigned slices do not match intent")
+
+		err = bpClient.DelInterfaceConnectivityTemplates(ctx, interfaceId, ctsToAssign)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assignedCts, err = bpClient.GetInterfaceConnectivityTemplates(ctx, interfaceId)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(assignedCts) != 0 {
+			t.Fatalf("expected 0 interfaces assigned to interface, got %d", len(assignedCts))
+		}
 	}
 
 }

--- a/apstra/two_stage_l3_clos_connectivity_template_assignment_integration_test.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_assignment_integration_test.go
@@ -1,0 +1,89 @@
+//go:build integration
+// +build integration
+
+package apstra
+
+import (
+	"context"
+	"log"
+	"testing"
+)
+
+func TestAssignClearCtToInterface(t *testing.T) {
+	ctx := context.Background()
+
+	clients, err := getTestClients(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for clientName, client := range clients {
+		bpClient, bpDel := testBlueprintA(ctx, t, client.client)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			err := bpDel(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		var systems struct {
+			Nodes map[ObjectId]struct {
+				SystemType string     `json:"system_type"`
+				Role       systemRole `json:"role"`
+			} `json:"nodes"`
+		}
+
+		log.Printf("testing GetNodes() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		err = bpClient.GetNodes(ctx, NodeTypeSystem, &systems)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// create assignments for the leaf switch nodes
+		assignments := make(SystemIdToInterfaceMapAssignment)
+		var bindings []VnBinding
+		for k, v := range systems.Nodes {
+			if v.SystemType != "switch" || v.Role != systemRoleLeaf {
+				continue
+			}
+			assignments[k.String()] = "Juniper_vQFX__AOS-7x10-Leaf"
+			bindings = append(bindings, VnBinding{SystemId: k})
+		}
+
+		log.Printf("testing SetInterfaceMapAssignments() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		err = bpClient.SetInterfaceMapAssignments(ctx, assignments)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		vnId, err := bpClient.CreateVirtualNetwork(ctx, &VirtualNetworkData{
+			DhcpService:               false,
+			Ipv4Enabled:               false,
+			Ipv4Subnet:                nil,
+			Ipv6Enabled:               false,
+			Ipv6Subnet:                nil,
+			Label:                     randString(6, "hex"),
+			ReservedVlanId:            nil,
+			RouteTarget:               "",
+			RtPolicy:                  nil,
+			SecurityZoneId:            "",
+			SviIps:                    nil,
+			VirtualGatewayIpv4:        nil,
+			VirtualGatewayIpv6:        nil,
+			VirtualGatewayIpv4Enabled: false,
+			VirtualGatewayIpv6Enabled: false,
+			VnBindings:                bindings,
+			VnId:                      nil,
+			VnType:                    VnTypeVlan,
+			VirtualMac:                nil,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		log.Println(vnId)
+	}
+
+}

--- a/apstra/two_stage_l3_clos_connectivity_template_primitive_attributes.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_primitive_attributes.go
@@ -431,7 +431,7 @@ type ConnectivityTemplatePrimitiveAttributesAttachBgpWithPrefixPeeringForSviOrSu
 	PrefixNeighborIpv6    *net.IPNet
 	SessionAddressingIpv4 bool
 	SessionAddressingIpv6 bool
-	Ttl                   int
+	Ttl                   uint8
 }
 
 func (o *ConnectivityTemplatePrimitiveAttributesAttachBgpWithPrefixPeeringForSviOrSubinterface) raw() (json.RawMessage, error) {
@@ -823,7 +823,7 @@ type rawConnectivityTemplatePrimitiveAttributesAttachBgpWithPrefixPeeringForSviO
 	PrefixNeighborIpv6    *string `json:"prefix_neighbor_ipv6"`
 	SessionAddressingIpv4 bool    `json:"session_addressing_ipv4"`
 	SessionAddressingIpv6 bool    `json:"session_addressing_ipv6"`
-	Ttl                   int     `json:"ttl"`
+	Ttl                   uint8   `json:"ttl"`
 }
 
 func (o rawConnectivityTemplatePrimitiveAttributesAttachBgpWithPrefixPeeringForSviOrSubinterface) polish(t *ConnectivityTemplatePrimitiveAttributesAttachBgpWithPrefixPeeringForSviOrSubinterface) error {


### PR DESCRIPTION
This PR introduces:
- New `Node` and `Relationship` constants for use in queries
- `GetAllInterfacesConnectivityTemplates()`
- `GetInterfaceConnectivityTemplates()`
- `SetInterfaceConnectivityTemplates()`
- `DelInterfaceConnectivityTemplates()`
- Tests