### PR TITLE
Improve Connectivity Template layout

### DIFF
--- a/apstra/two_stage_l3_clos_connectivity_template_primitive_attributes.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_primitive_attributes.go
@@ -491,7 +491,7 @@ func (o *ConnectivityTemplatePrimitiveAttributesAttachBgpWithPrefixPeeringForSvi
 var _ ConnectivityTemplatePrimitiveAttributes = &ConnectivityTemplatePrimitiveAttributesAttachExistingRoutingPolicy{}
 
 type ConnectivityTemplatePrimitiveAttributesAttachExistingRoutingPolicy struct {
-	RpToAttach *string `json:"rp_to_attach"`
+	RpToAttach *ObjectId
 }
 
 func (o *ConnectivityTemplatePrimitiveAttributesAttachExistingRoutingPolicy) fromRawJson(in json.RawMessage) error {
@@ -527,7 +527,7 @@ func (o *ConnectivityTemplatePrimitiveAttributesAttachExistingRoutingPolicy) Des
 var _ ConnectivityTemplatePrimitiveAttributes = &ConnectivityTemplatePrimitiveAttributesAttachRoutingZoneConstraint{}
 
 type ConnectivityTemplatePrimitiveAttributesAttachRoutingZoneConstraint struct {
-	RoutingZoneConstraint *string
+	RoutingZoneConstraint *ObjectId
 }
 
 func (o *ConnectivityTemplatePrimitiveAttributesAttachRoutingZoneConstraint) raw() (json.RawMessage, error) {
@@ -861,7 +861,7 @@ func (o rawConnectivityTemplatePrimitiveAttributesAttachBgpWithPrefixPeeringForS
 }
 
 type rawConnectivityTemplatePrimitiveAttributesAttachExistingRoutingPolicy struct {
-	RpToAttach *string `json:"rp_to_attach"`
+	RpToAttach *ObjectId `json:"rp_to_attach"`
 }
 
 func (o rawConnectivityTemplatePrimitiveAttributesAttachExistingRoutingPolicy) polish(t *ConnectivityTemplatePrimitiveAttributesAttachExistingRoutingPolicy) error {
@@ -871,7 +871,7 @@ func (o rawConnectivityTemplatePrimitiveAttributesAttachExistingRoutingPolicy) p
 }
 
 type rawConnectivityTemplatePrimitiveAttributesAttachRoutingZoneConstraint struct {
-	RoutingZoneConstraint *string `json:"routing_zone_constraint"`
+	RoutingZoneConstraint *ObjectId `json:"routing_zone_constraint"`
 }
 
 func (o rawConnectivityTemplatePrimitiveAttributesAttachRoutingZoneConstraint) polish(t *ConnectivityTemplatePrimitiveAttributesAttachRoutingZoneConstraint) error {

--- a/apstra/two_stage_l3_clos_connectivity_template_unit_test.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_unit_test.go
@@ -140,7 +140,7 @@ func TestBgpOverL3Connectivity(t *testing.T) {
 
 	expectedUserData := "{\"isSausage\":true,\"positions\":{\"bac16090-88ff-4f8b-9ee6-79b31078e123\":[290,80,1],\"498b2502-e062-414b-b401-4e88a08ae8c5\":[290,150,1],\"49f36469-7f10-4b10-9102-83654f3fe6a6\":[290,220,1]}}"
 
-	rpId := "o-ob0kv9g1yniFpiTco"
+	rpId := ObjectId("o-ob0kv9g1yniFpiTco")
 	attachExistingRoutingPolicy := ConnectivityTemplatePrimitiveAttributesAttachExistingRoutingPolicy{
 		RpToAttach: &rpId,
 	}


### PR DESCRIPTION
This PR improves the CT layout by ensuring that no two primitives ever attempt to occupy the same X,Y coordinate.

Additionally, bug fix by changing the ID field in Routing Policy and Routing Zone Constraint primitives from `*string` to `*ObjectId`