### PR TITLE
Introduce `ErrUncommitted` client error type

### DIFF
--- a/apstra/client.go
+++ b/apstra/client.go
@@ -29,6 +29,7 @@ const (
 	ErrInUse
 	ErrMultipleMatch
 	ErrNotfound
+	ErrUncommitted
 	ErrWrongType
 	ErrReadOnly
 
@@ -1656,7 +1657,7 @@ func (o *Client) GetLastDeployedRevision(ctx context.Context, id ObjectId) (*Blu
 
 	if highestRevPtr == nil {
 		err = ApstraClientErr{
-			errType: ErrNotfound,
+			errType: ErrUncommitted,
 			err:     fmt.Errorf("no commits/deployments of blueprint %q found", id),
 		}
 	}


### PR DESCRIPTION
Prior to this we were using `ErrNotFound` in `GetLastDeployedRevision()` leading to ambiguity between the blueprint *not existing* and the blueprint never having been committed.