### PR TITLE
Remove `Client.NewQuery()`

### DIFF
--- a/apstra/client.go
+++ b/apstra/client.go
@@ -1215,11 +1215,6 @@ func (o *Client) DeleteTemplate(ctx context.Context, id ObjectId) error {
 	return o.deleteTemplate(ctx, id)
 }
 
-// NewQuery returns a *PathQuery with embedded *Client
-func (o *Client) NewQuery(blueprint ObjectId) *PathQuery {
-	return o.newQuery(blueprint)
-}
-
 // ListAllInterfaceMapIds returns []ObjectId representing all interface maps
 func (o *Client) ListAllInterfaceMapIds(ctx context.Context) ([]ObjectId, error) {
 	return o.listAllInterfaceMapIds(ctx)
@@ -1674,7 +1669,9 @@ func (o *Client) BlueprintOverlayControlProtocol(ctx context.Context, id ObjectI
 		} `json:"items"`
 	}
 
-	query := o.NewQuery(id).
+	query := new(PathQuery).
+		SetBlueprintId(id).
+		SetClient(o).
 		Node([]QEEAttribute{
 			{"type", QEStringVal("virtual_network_policy")},
 			{"name", QEStringVal("n_virtual_network_policy")},

--- a/apstra/query_engine.go
+++ b/apstra/query_engine.go
@@ -154,13 +154,6 @@ func (o QENone) String() string {
 	return "not_none()"
 }
 
-func (o *Client) newQuery(blueprintId ObjectId) *PathQuery {
-	return &PathQuery{
-		client:      o,
-		blueprintId: blueprintId,
-	}
-}
-
 type PathQuery struct {
 	firstElement  *QEElement
 	client        *Client

--- a/apstra/query_engine_test.go
+++ b/apstra/query_engine_test.go
@@ -171,8 +171,10 @@ func TestParsingQueryInfo(t *testing.T) {
 				} `json:"n_system"`
 			} `json:"items"`
 		}
-		log.Printf("testing NewQuery() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		err = client.client.NewQuery(bpClient.Id()).
+		log.Printf("testing PathQuery.Do() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		err = new(PathQuery).
+			SetClient(bpClient.client).
+			SetBlueprintId(bpClient.Id()).
 			Node([]QEEAttribute{
 				{"type", QEStringVal("system")},
 				{"name", QEStringVal("n_system")},

--- a/apstra/two_stage_l3_clos_virtual_networks_integration_test.go
+++ b/apstra/two_stage_l3_clos_virtual_networks_integration_test.go
@@ -208,12 +208,15 @@ func TestCreateUpdateDeleteVirtualNetwork(t *testing.T) {
 			} `json:"items"`
 		}
 
-		query := client.client.NewQuery(bpClient.Id()).Node([]QEEAttribute{
-			{"type", QEStringVal("system")},
-			{"system_type", QEStringVal("switch")},
-			{"role", QEStringVal("leaf")},
-			{"name", QEStringVal("system")},
-		})
+		query := new(PathQuery).
+			SetClient(client.client).
+			SetBlueprintId(bpClient.Id()).
+			Node([]QEEAttribute{
+				{"type", QEStringVal("system")},
+				{"system_type", QEStringVal("switch")},
+				{"role", QEStringVal("leaf")},
+				{"name", QEStringVal("system")},
+			})
 
 		err = query.Do(ctx, &result)
 		if err != nil {


### PR DESCRIPTION
`Client.NewQuery()` was written when Chris understood graph queries less well than he does now. In particular, before he understood that there are different types of query structures:
- path queries (those which start with `node()`
- match queries (those which start with `match()`
- possibly others?

`Client.NewQuery()` returns a `PathQuery` primed with a client and a blueprint ID.

All uses of `NewQuery()` in the terraform provider have been replaced with one of these:
- `new(PathQuery).SetBlueprintId().SetClient()`
- `new(MatchQuery).SetBlueprintId().SetClient()`

This PR:
- Removes `Client.NewQuery()` and `Client.newQuery()`
- Converts uses of those methods to use the type-specific query instantiations cited above.

Closes #21