### PR TITLE
Replace 'interface' references with 'application point' as appropriate

### DIFF
--- a/apstra/two_stage_l3_clos_connectivity_template_assignment.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_assignment.go
@@ -82,22 +82,22 @@ func (o *TwoStageL3ClosClient) GetInterfaceConnectivityTemplates(ctx context.Con
 	return nil, o.client.GetNode(ctx, o.blueprintId, intfId, &struct{}{})
 }
 
-// SetInterfaceConnectivityTemplates assigns the listed ConnectivityTemplate IDs
-// to the interface specified by intfId.
-func (o *TwoStageL3ClosClient) SetInterfaceConnectivityTemplates(ctx context.Context, intfId ObjectId, ctIds []ObjectId) error {
+// SetApplicationPointConnectivityTemplates assigns the listed
+// ConnectivityTemplate IDs to the application point specified by apId
+func (o *TwoStageL3ClosClient) SetApplicationPointConnectivityTemplates(ctx context.Context, apId ObjectId, ctIds []ObjectId) error {
 	type policyInfo struct {
 		PolicyId ObjectId `json:"policy"`
 		Used     bool     `json:"used"`
 	}
 
 	type applicationPoints struct {
-		InterfaceId ObjectId     `json:"id"`
-		PolicyInfo  []policyInfo `json:"policies"`
+		ApplicationPointId ObjectId     `json:"id"`
+		PolicyInfo         []policyInfo `json:"policies"`
 	}
 
 	appPoints := applicationPoints{
-		InterfaceId: intfId,
-		PolicyInfo:  make([]policyInfo, len(ctIds)),
+		ApplicationPointId: apId,
+		PolicyInfo:         make([]policyInfo, len(ctIds)),
 	}
 	for i, ctId := range ctIds {
 		appPoints.PolicyInfo[i] = policyInfo{
@@ -124,34 +124,34 @@ func (o *TwoStageL3ClosClient) SetInterfaceConnectivityTemplates(ctx context.Con
 	return nil
 }
 
-// DelInterfaceConnectivityTemplates removes the listed ConnectivityTemplate IDs
-// from the interface specified by intfId.
-func (o *TwoStageL3ClosClient) DelInterfaceConnectivityTemplates(ctx context.Context, intfId ObjectId, ctIds []ObjectId) error {
+// DelApplicationPointConnectivityTemplates removes the listed
+// ConnectivityTemplate IDs from the application point specified by apId
+func (o *TwoStageL3ClosClient) DelApplicationPointConnectivityTemplates(ctx context.Context, apId ObjectId, ctIds []ObjectId) error {
 	type policyInfo struct {
 		PolicyId ObjectId `json:"policy"`
 		Used     bool     `json:"used"`
 	}
 
-	type applicationPoints struct {
-		InterfaceId ObjectId     `json:"id"`
-		PolicyInfo  []policyInfo `json:"policies"`
+	type applicationPoint struct {
+		ApplicationPointId ObjectId     `json:"id"`
+		PolicyInfo         []policyInfo `json:"policies"`
 	}
 
-	appPoints := applicationPoints{
-		InterfaceId: intfId,
-		PolicyInfo:  make([]policyInfo, len(ctIds)),
+	appPoint := applicationPoint{
+		ApplicationPointId: apId,
+		PolicyInfo:         make([]policyInfo, len(ctIds)),
 	}
 	for i, ctId := range ctIds {
-		appPoints.PolicyInfo[i] = policyInfo{
+		appPoint.PolicyInfo[i] = policyInfo{
 			PolicyId: ctId,
 			Used:     false,
 		}
 	}
 
 	apiInput := struct {
-		ApplicationPoints []applicationPoints `json:"application_points"`
+		ApplicationPoints []applicationPoint `json:"application_points"`
 	}{
-		ApplicationPoints: []applicationPoints{appPoints},
+		ApplicationPoints: []applicationPoint{appPoint},
 	}
 
 	err := o.client.talkToApstra(ctx, &talkToApstraIn{

--- a/apstra/two_stage_l3_clos_connectivity_template_assignment_integration_test.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_assignment_integration_test.go
@@ -168,7 +168,7 @@ func TestAssignClearCtToInterface(t *testing.T) {
 		interfaceId := queryResponse.Items[0].Interface.Id
 
 		ctsToAssign := []ObjectId{*ct.Id}
-		err = bpClient.SetInterfaceConnectivityTemplates(ctx, interfaceId, ctsToAssign)
+		err = bpClient.SetApplicationPointConnectivityTemplates(ctx, interfaceId, ctsToAssign)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -180,7 +180,7 @@ func TestAssignClearCtToInterface(t *testing.T) {
 
 		compareSlices(t, ctsToAssign, assignedCts, "assigned slices do not match intent")
 
-		err = bpClient.DelInterfaceConnectivityTemplates(ctx, interfaceId, ctsToAssign)
+		err = bpClient.DelApplicationPointConnectivityTemplates(ctx, interfaceId, ctsToAssign)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -194,5 +194,4 @@ func TestAssignClearCtToInterface(t *testing.T) {
 			t.Fatalf("expected 0 interfaces assigned to interface, got %d", len(assignedCts))
 		}
 	}
-
 }


### PR DESCRIPTION
It turns out that Connectivity Templates can be applied to SVIs, systems, individual VLAN tags on trunk links...

Stuff other than interfaces.

Closes #84