### PR TITLE
Return `ErrNotFound` when Connectivity Template does not exist 

### DIFF
--- a/apstra/talk_to_apstra.go
+++ b/apstra/talk_to_apstra.go
@@ -65,6 +65,8 @@ func convertTtaeToAceWherePossible(err error) error {
 				return ApstraClientErr{errType: ErrExists, err: errors.New(ttae.Msg)}
 			case strings.Contains(ttae.Msg, "Transformation cannot be changed"):
 				return ApstraClientErr{errType: ErrCannotChangeTransform, err: errors.New(ttae.Msg)}
+			case strings.Contains(ttae.Msg, "does not exist"):
+				return ApstraClientErr{errType: ErrNotfound, err: errors.New(ttae.Msg)}
 			}
 		case http.StatusInternalServerError:
 			switch {

--- a/apstra/two_stage_l3_clos_connectivity_template_integration_test.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_integration_test.go
@@ -451,3 +451,45 @@ func TestCtLayout(t *testing.T) {
 		}
 	}
 }
+
+func TestConnectivityTemplate404(t *testing.T) {
+	ctx := context.Background()
+
+	clients, err := getTestClients(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, client := range clients {
+		bpClient, bpDel := testBlueprintA(ctx, t, client.client)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			err := bpDel(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		_, err = bpClient.GetConnectivityTemplate(ctx, "bogus")
+		if err == nil {
+			t.Fatal("retrieval of bogus CT should have produced an error")
+		} else {
+			var ace ApstraClientErr
+			if !errors.As(err, &ace) || ace.Type() != ErrNotfound {
+				t.Fatal("error should have been something 404-ish")
+			}
+		}
+
+		err = bpClient.DeleteConnectivityTemplate(ctx, "bogus")
+		if err == nil {
+			t.Fatal("deletion of bogus CT should have produced an error")
+		} else {
+			var ace ApstraClientErr
+			if !errors.As(err, &ace) || ace.Type() != ErrNotfound {
+				t.Fatal("error should have been something 404-ish")
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR uses the same error conversion logic as #96, and adds test cases for:
- `GetConnectivityTemplate()`
- `DeleteConnectivityTemplate()`

Closes #89