### PR TITLE
Rename `ApstraClientErr{}` -> `ClientErr{}`

### DIFF
--- a/apstra/api_blueprints.go
+++ b/apstra/api_blueprints.go
@@ -307,7 +307,7 @@ func (o *Client) getBlueprintIdByName(ctx context.Context, name string) (ObjectI
 	for i, bps := range blueprintStatuses {
 		if bps.Label == name {
 			if found > 0 {
-				return "", ApstraClientErr{
+				return "", ClientErr{
 					errType: ErrMultipleMatch,
 					err:     fmt.Errorf("multiple blueprints have name '%s'", name),
 				}
@@ -320,7 +320,7 @@ func (o *Client) getBlueprintIdByName(ctx context.Context, name string) (ObjectI
 	if found >= 0 {
 		return blueprintStatuses[found].Id, nil
 	}
-	return "", ApstraClientErr{
+	return "", ClientErr{
 		errType: ErrNotfound,
 		err:     fmt.Errorf("found %d blueprints but one named '%s' wasn't among them", len(blueprintStatuses), name),
 	}
@@ -369,7 +369,7 @@ func (o *Client) getBlueprintStatus(ctx context.Context, id ObjectId) (*rawBluep
 			return &bps, nil
 		}
 	}
-	return nil, ApstraClientErr{
+	return nil, ClientErr{
 		errType: ErrNotfound,
 		err:     fmt.Errorf("found %d blueprints but one with id '%s' wasn't among them", len(blueprintStatuses), id),
 	}
@@ -403,14 +403,14 @@ func (o *Client) getBlueprintStatusByName(ctx context.Context, desired string) (
 
 	switch len(blueprintStatuses) {
 	case 0:
-		return nil, ApstraClientErr{
+		return nil, ClientErr{
 			errType: ErrNotfound,
 			err:     fmt.Errorf("blueprint with name '%s' not found", desired),
 		}
 	case 1:
 		return &blueprintStatuses[0], nil
 	default:
-		return nil, ApstraClientErr{
+		return nil, ClientErr{
 			errType: ErrMultipleMatch,
 			err:     fmt.Errorf("multiple blueprints with name '%s' found", desired),
 		}

--- a/apstra/api_design_configlets.go
+++ b/apstra/api_design_configlets.go
@@ -196,7 +196,7 @@ func (o *Client) getConfigletByName(ctx context.Context, name string) (*rawConfi
 	for i, configlet := range configlets {
 		if configlet.DisplayName == name {
 			if foundIdx >= 0 {
-				return nil, ApstraClientErr{
+				return nil, ClientErr{
 					errType: ErrMultipleMatch,
 					err:     fmt.Errorf("multiple Configlets have name %q", name),
 				}
@@ -209,7 +209,7 @@ func (o *Client) getConfigletByName(ctx context.Context, name string) (*rawConfi
 		return &configlets[foundIdx], nil
 	}
 
-	return nil, ApstraClientErr{
+	return nil, ClientErr{
 		errType: ErrNotfound,
 		err:     fmt.Errorf("no Configlet with name '%s' found", name),
 	}

--- a/apstra/api_design_interface_maps.go
+++ b/apstra/api_design_interface_maps.go
@@ -348,14 +348,14 @@ func (o *Client) getInterfaceMapByName(ctx context.Context, desired string) (*ra
 	}
 	switch len(interfaceMaps) {
 	case 0:
-		return nil, ApstraClientErr{
+		return nil, ClientErr{
 			errType: ErrNotfound,
 			err:     fmt.Errorf("no interface map named '%s' found", desired),
 		}
 	case 1:
 		return &interfaceMaps[0], nil
 	default:
-		return nil, ApstraClientErr{
+		return nil, ClientErr{
 			errType: ErrMultipleMatch,
 			err:     fmt.Errorf("found multiple interface maps named '%s' found", desired),
 		}

--- a/apstra/api_design_logical_devices.go
+++ b/apstra/api_design_logical_devices.go
@@ -449,7 +449,7 @@ func (o *Client) getLogicalDeviceByName(ctx context.Context, name string) (*Logi
 		_ = foo
 		if ld.Data.DisplayName == name {
 			if found {
-				return nil, ApstraClientErr{
+				return nil, ClientErr{
 					errType: ErrMultipleMatch,
 					err:     fmt.Errorf("found multiple logical devices named '%s' found", name),
 				}
@@ -461,7 +461,7 @@ func (o *Client) getLogicalDeviceByName(ctx context.Context, name string) (*Logi
 	if found {
 		return &result, nil
 	}
-	return nil, ApstraClientErr{
+	return nil, ClientErr{
 		errType: ErrNotfound,
 		err:     fmt.Errorf("no logical device named '%s' found", name),
 	}

--- a/apstra/api_design_logical_devices_test.go
+++ b/apstra/api_design_logical_devices_test.go
@@ -205,7 +205,7 @@ func TestGetLogicalDeviceByName(t *testing.T) {
 			test := logicalDevices[i]
 			log.Printf("testing GetLogicalDeviceByName(%s) against %s %s (%s)", test.Data.DisplayName, client.clientType, clientName, client.client.ApiVersion())
 			logicalDevice, err := client.client.GetLogicalDeviceByName(context.TODO(), test.Data.DisplayName)
-			var ace ApstraClientErr
+			var ace ClientErr
 			if err != nil {
 				if !(errors.As(err, &ace) && ace.Type() == ErrMultipleMatch) {
 					t.Fatal(err)

--- a/apstra/api_design_rack_types.go
+++ b/apstra/api_design_rack_types.go
@@ -1346,7 +1346,7 @@ func (o *Client) getRackTypeByName(ctx context.Context, name string) (*RackType,
 			return &rackType, nil
 		}
 	}
-	return nil, ApstraClientErr{
+	return nil, ClientErr{
 		errType: ErrNotfound,
 		err:     fmt.Errorf("rack type with name '%s' not found", name),
 	}

--- a/apstra/api_design_tags.go
+++ b/apstra/api_design_tags.go
@@ -88,7 +88,7 @@ func (o *Client) getTagByLabel(ctx context.Context, label string) (*rawDesignTag
 		}
 	}
 
-	return nil, ApstraClientErr{
+	return nil, ClientErr{
 		errType: ErrNotfound,
 		err:     fmt.Errorf("tag with label '%s' not found", label),
 	}
@@ -119,7 +119,7 @@ func (o *Client) getTagsByLabels(ctx context.Context, labels []string) ([]rawDes
 		if tag, ok := allTagsMap[requestedLabel]; ok {
 			result = append(result, tag)
 		} else {
-			return nil, ApstraClientErr{
+			return nil, ClientErr{
 				errType: ErrNotfound,
 				err:     fmt.Errorf("tag with label '%s' not found", requestedLabel),
 			}

--- a/apstra/api_design_tags_test.go
+++ b/apstra/api_design_tags_test.go
@@ -110,7 +110,7 @@ func TestCreateTagCollision(t *testing.T) {
 		}
 		_ = client.client.deleteTag(context.Background(), id1)
 
-		var ace ApstraClientErr
+		var ace ClientErr
 		if errors.As(err, &ace) && ace.errType == ErrExists { // this is the error we want
 			continue
 		}

--- a/apstra/api_design_templates.go
+++ b/apstra/api_design_templates.go
@@ -1144,7 +1144,7 @@ func (o *Client) getRackBasedTemplate(ctx context.Context, id ObjectId) (*rawTem
 	}
 
 	if tType != templateTypeRackBased {
-		return nil, ApstraClientErr{
+		return nil, ClientErr{
 			errType: ErrWrongType,
 			err:     fmt.Errorf("template '%s' is of type '%s', not '%s'", id, tType, templateTypeRackBased),
 		}
@@ -1192,7 +1192,7 @@ func (o *Client) getPodBasedTemplate(ctx context.Context, id ObjectId) (*rawTemp
 	}
 
 	if tType != templateTypePodBased {
-		return nil, ApstraClientErr{
+		return nil, ClientErr{
 			errType: ErrWrongType,
 			err:     fmt.Errorf("template '%s' is of type '%s', not '%s'", id, tType, templateTypePodBased),
 		}
@@ -1269,7 +1269,7 @@ func (o *Client) getTemplateByTypeAndName(ctx context.Context, desiredType templ
 		}
 
 		if found != nil { // multiple matches!
-			return nil, ApstraClientErr{
+			return nil, ClientErr{
 				errType: ErrMultipleMatch,
 				err:     fmt.Errorf("found multiple %s templates named '%s'", desiredType, desiredName),
 			}
@@ -1280,7 +1280,7 @@ func (o *Client) getTemplateByTypeAndName(ctx context.Context, desiredType templ
 	}
 
 	if found == nil { // not found!
-		return nil, ApstraClientErr{
+		return nil, ClientErr{
 			errType: ErrNotfound,
 			err:     fmt.Errorf("no %s templates named '%s'", desiredType, desiredName),
 		}
@@ -1301,7 +1301,7 @@ func (o *Client) getL3CollapsedTemplate(ctx context.Context, id ObjectId) (*rawT
 	}
 
 	if tType != templateTypeL3Collapsed {
-		return nil, ApstraClientErr{
+		return nil, ClientErr{
 			errType: ErrWrongType,
 			err:     fmt.Errorf("template '%s' is of type '%s', not '%s'", id, tType, templateTypeL3Collapsed),
 		}
@@ -1701,7 +1701,7 @@ func (o *Client) getTemplateIdTypeByName(ctx context.Context, desired string) (O
 
 	switch len(idToType) {
 	case 0:
-		return "", -1, ApstraClientErr{
+		return "", -1, ClientErr{
 			errType: ErrNotfound,
 			err:     fmt.Errorf("template named '%s' not found", desired),
 		}
@@ -1710,7 +1710,7 @@ func (o *Client) getTemplateIdTypeByName(ctx context.Context, desired string) (O
 			return k, v, nil
 		}
 	}
-	return "", -1, ApstraClientErr{
+	return "", -1, ClientErr{
 		errType: ErrMultipleMatch,
 		err:     fmt.Errorf("found multiple templates named '%s'", desired),
 	}

--- a/apstra/api_device_profiles.go
+++ b/apstra/api_device_profiles.go
@@ -91,7 +91,7 @@ func (o *PortInfo) Transformation(desired int) (*Transformation, error) {
 			return &t, nil
 		}
 	}
-	return nil, ApstraClientErr{
+	return nil, ClientErr{
 		errType: ErrNotfound,
 		err:     fmt.Errorf("transform id %d not found", desired),
 	}
@@ -177,7 +177,7 @@ func (o *Transformation) Interface(desired int) (*TransformInterface, error) {
 			return &intf, nil
 		}
 	}
-	return nil, ApstraClientErr{
+	return nil, ClientErr{
 		errType: ErrNotfound,
 		err:     fmt.Errorf("interface %d not found in transformation", desired),
 	}
@@ -305,14 +305,14 @@ func (o *DeviceProfileData) PortByInterfaceName(desired string) (*PortInfo, erro
 	ports := o.PortsByInterfaceName(desired)
 	switch len(ports) {
 	case 0:
-		return nil, ApstraClientErr{
+		return nil, ClientErr{
 			errType: ErrNotfound,
 			err:     fmt.Errorf("no port matching name '%s' could be found", desired),
 		}
 	case 1:
 		return &ports[0], nil
 	default:
-		return nil, ApstraClientErr{
+		return nil, ClientErr{
 			errType: ErrMultipleMatch,
 			err:     fmt.Errorf("multiple ports matching name '%s' found", desired),
 		}
@@ -325,7 +325,7 @@ func (o *DeviceProfileData) PortById(desired int) (*PortInfo, error) {
 			return &portInfo, nil
 		}
 	}
-	return nil, ApstraClientErr{
+	return nil, ClientErr{
 		errType: ErrNotfound,
 		err:     fmt.Errorf("no port with ID %d found", desired),
 	}
@@ -474,14 +474,14 @@ func (o *Client) getDeviceProfileByName(ctx context.Context, desired string) (*r
 	}
 	switch len(deviceProfiles) {
 	case 0:
-		return nil, ApstraClientErr{
+		return nil, ClientErr{
 			errType: ErrNotfound,
 			err:     fmt.Errorf("no device profile named '%s' found", desired),
 		}
 	case 1:
 		return &deviceProfiles[0], nil
 	default:
-		return nil, ApstraClientErr{
+		return nil, ClientErr{
 			errType: ErrMultipleMatch,
 			err:     fmt.Errorf("found multiple device profiles named '%s'", desired),
 		}

--- a/apstra/api_property_sets.go
+++ b/apstra/api_property_sets.go
@@ -94,7 +94,7 @@ func (o *Client) getPropertySetByLabel(ctx context.Context, label string) (*rawP
 	}
 
 	if len(propertySets) > 1 {
-		return nil, ApstraClientErr{
+		return nil, ClientErr{
 			errType: ErrMultipleMatch,
 			err:     fmt.Errorf("found multiple (%d) property sets with label %q", len(propertySets), label),
 		}
@@ -117,7 +117,7 @@ func (o *Client) getPropertySetsByLabel(ctx context.Context, label string) ([]ra
 	}
 
 	if len(result) == 0 {
-		return nil, ApstraClientErr{
+		return nil, ClientErr{
 			errType: ErrNotfound,
 			err:     fmt.Errorf("property set with label '%s' not found", label),
 		}

--- a/apstra/api_resources_int.go
+++ b/apstra/api_resources_int.go
@@ -77,7 +77,7 @@ func (o *Client) getAsnPoolByName(ctx context.Context, desired string) (*AsnPool
 	for i, pool := range pools {
 		if pool.DisplayName == desired {
 			if found >= 0 {
-				return nil, ApstraClientErr{
+				return nil, ClientErr{
 					errType: ErrMultipleMatch,
 					err:     fmt.Errorf("name '%s' does not uniquely identify an ASN pool", desired),
 				}
@@ -86,7 +86,7 @@ func (o *Client) getAsnPoolByName(ctx context.Context, desired string) (*AsnPool
 		}
 	}
 	if found < 0 {
-		return nil, ApstraClientErr{
+		return nil, ClientErr{
 			errType: ErrNotfound,
 			err:     fmt.Errorf("pool named '%s' not found", desired),
 		}
@@ -131,7 +131,7 @@ func (o *Client) getIntPoolByName(ctx context.Context, desired string) (*rawIntP
 	for i, pool := range pools {
 		if pool.DisplayName == desired {
 			if found >= 0 {
-				return nil, ApstraClientErr{
+				return nil, ClientErr{
 					errType: ErrMultipleMatch,
 					err:     fmt.Errorf("name '%s' does not uniquely identify an Integer Pool", desired),
 				}
@@ -140,7 +140,7 @@ func (o *Client) getIntPoolByName(ctx context.Context, desired string) (*rawIntP
 		}
 	}
 	if found < 0 {
-		return nil, ApstraClientErr{
+		return nil, ClientErr{
 			errType: ErrNotfound,
 			err:     fmt.Errorf("pool named '%s' not found", desired),
 		}
@@ -206,7 +206,7 @@ func (o *Client) getVniPoolByName(ctx context.Context, desired string) (*VniPool
 	for i, pool := range pools {
 		if pool.DisplayName == desired {
 			if found >= 0 {
-				return nil, ApstraClientErr{
+				return nil, ClientErr{
 					errType: ErrMultipleMatch,
 					err:     fmt.Errorf("name '%s' does not uniquely identify an VNI pool", desired),
 				}
@@ -215,7 +215,7 @@ func (o *Client) getVniPoolByName(ctx context.Context, desired string) (*VniPool
 		}
 	}
 	if found < 0 {
-		return nil, ApstraClientErr{
+		return nil, ClientErr{
 			errType: ErrNotfound,
 			err:     fmt.Errorf("pool named '%s' not found", desired),
 		}

--- a/apstra/api_resources_ip.go
+++ b/apstra/api_resources_ip.go
@@ -200,14 +200,14 @@ func (o *Client) getIpPoolByName(ctx context.Context, urlStr string, desired str
 	}
 	switch len(pools) {
 	case 0:
-		return nil, ApstraClientErr{
+		return nil, ClientErr{
 			errType: ErrNotfound,
 			err:     fmt.Errorf("no pool named '%s' found", desired),
 		}
 	case 1:
 		return &pools[0], nil
 	default:
-		return nil, ApstraClientErr{
+		return nil, ClientErr{
 			errType: ErrMultipleMatch,
 			err:     fmt.Errorf("name '%s' does not uniquely identify a single IPv4 pool", desired),
 		}
@@ -361,7 +361,7 @@ func (o *Client) deleteSubnetFromIpPool(ctx context.Context, poolId ObjectId, ta
 
 	if !targetFound {
 		// nothing to do
-		return ApstraClientErr{
+		return ClientErr{
 			errType: ErrNotfound,
 			err:     fmt.Errorf("target '%s' not found in pool '%s'", target.String(), poolId),
 		}

--- a/apstra/api_system_agent_profiles.go
+++ b/apstra/api_system_agent_profiles.go
@@ -142,7 +142,7 @@ func (o *Client) createAgentProfile(ctx context.Context, in *AgentProfileConfig)
 	if err != nil {
 		var ttae TalkToApstraErr
 		if errors.As(err, &ttae) && ttae.Response.StatusCode == http.StatusConflict {
-			return "", ApstraClientErr{
+			return "", ClientErr{
 				errType: ErrConflict,
 				err:     fmt.Errorf("error Agent Profile '%s' likely already exists - %w", in.Label, err),
 			}
@@ -162,7 +162,7 @@ func (o *Client) getAgentProfile(ctx context.Context, id ObjectId) (*AgentProfil
 	if err != nil {
 		var ttae TalkToApstraErr
 		if errors.As(err, &ttae) && ttae.Response.StatusCode == http.StatusNotFound {
-			return nil, ApstraClientErr{
+			return nil, ClientErr{
 				errType: ErrNotfound,
 				err:     err,
 			}
@@ -214,7 +214,7 @@ func (o *Client) deleteAgentProfile(ctx context.Context, id ObjectId) error {
 			var ae apstraErr
 			_ = json.Unmarshal(body, &apstraErr{})
 			if ae.Errors == apstraErrAgentProfileInUse {
-				return ApstraClientErr{
+				return ClientErr{
 					errType: ErrInUse,
 					err:     fmt.Errorf("agent profile '%s' is in use, cannot delete", id),
 				}
@@ -240,7 +240,7 @@ func (o *Client) getAgentProfileByLabel(ctx context.Context, label string) (*Age
 	for i, sap := range response.Items {
 		if sap.Label == label {
 			if found >= 0 {
-				return nil, ApstraClientErr{
+				return nil, ClientErr{
 					errType: ErrMultipleMatch,
 					err:     fmt.Errorf("multiple matches for System Agent Profile with label '%s'", label),
 				}
@@ -250,7 +250,7 @@ func (o *Client) getAgentProfileByLabel(ctx context.Context, label string) (*Age
 	}
 
 	if found < 0 {
-		return nil, ApstraClientErr{
+		return nil, ClientErr{
 			errType: ErrNotfound,
 			err:     fmt.Errorf("no System Agent Profile with label '%s' found", label),
 		}

--- a/apstra/api_system_agents.go
+++ b/apstra/api_system_agents.go
@@ -843,7 +843,7 @@ func (o *Client) getSystemAgentByManagementIp(ctx context.Context, ip string) (*
 			return &a, nil
 		}
 	}
-	return nil, ApstraClientErr{
+	return nil, ClientErr{
 		errType: ErrNotfound,
 		err:     fmt.Errorf("no System Agent with management IP '%s' found", ip),
 	}
@@ -976,7 +976,7 @@ func (o *Client) getSystemAgentJobStatus(ctx context.Context, agentId ObjectId, 
 	}
 
 	// jobId not found - return error
-	return nil, ApstraClientErr{
+	return nil, ClientErr{
 		errType: ErrNotfound,
 		err:     fmt.Errorf("agent '%s' job history does not include job '%d'", agentId, jobId),
 	}
@@ -994,7 +994,7 @@ func (o *Client) systemAgentWaitForJobToExist(ctx context.Context, agentId Objec
 
 		_, err := o.getSystemAgentJobStatus(ctx, agentId, jobId)
 		if err != nil {
-			var ace ApstraClientErr
+			var ace ClientErr
 			if !(errors.As(err, &ace) && ace.Type() == ErrNotfound) {
 				// error other than notfound - stop looking - return error
 				return fmt.Errorf("error getting job status - %w", err)
@@ -1051,7 +1051,7 @@ func (o *Client) systemAgentWaitForConnection(ctx context.Context, agentId Objec
 		case AgentCxnStateConnected:
 			return nil
 		case AgentCxnStateAuthFail:
-			return ApstraClientErr{
+			return ClientErr{
 				errType: ErrAuthFail,
 				err: fmt.Errorf("agent %s connection failure: '%s'",
 					agentId, agentInfo.Status.ConnectionState.String()),
@@ -1059,7 +1059,7 @@ func (o *Client) systemAgentWaitForConnection(ctx context.Context, agentId Objec
 		case AgentCxnStateDisconnected:
 			// go around again
 		default:
-			return ApstraClientErr{
+			return ClientErr{
 				errType: ErrUnknown,
 				err: fmt.Errorf("unknown agent %s connection failure: '%s'",
 					agentId, agentInfo.Status.ConnectionState.String()),

--- a/apstra/api_system_agents_test.go
+++ b/apstra/api_system_agents_test.go
@@ -114,7 +114,7 @@ func TestCreateDeleteSwitchAgent(t *testing.T) {
 				AgentTypeOffbox: testSwitch.platform.offbox(),
 			})
 			if err != nil {
-				ace := &ApstraClientErr{}
+				ace := &ClientErr{}
 				if errors.As(err, ace) && ace.Type() == ErrConflict {
 					log.Printf("skipping switch '%s' because: '%s'", testSwitch.ip, err.Error())
 					continue

--- a/apstra/client.go
+++ b/apstra/client.go
@@ -42,16 +42,16 @@ const (
 	clientApiResourceIpPoolRangeMutex
 )
 
-type ApstraClientErr struct {
+type ClientErr struct {
 	errType int
 	err     error
 }
 
-func (o ApstraClientErr) Error() string {
+func (o ClientErr) Error() string {
 	return o.err.Error()
 }
 
-func (o ApstraClientErr) Type() int {
+func (o ClientErr) Type() int {
 	return o.errType
 }
 
@@ -596,7 +596,7 @@ func (o *Client) DeleteAgentProfile(ctx context.Context, id ObjectId) error {
 
 // GetAgentProfileByLabel returns the Agent Profile with the given
 // label. Apstra doesn't allow label collisions, so this should be a unique
-// match. If no match, an ApstraClientErr with Type ErrNotfound is returned.
+// match. If no match, a ClientErr with Type ErrNotfound is returned.
 func (o *Client) GetAgentProfileByLabel(ctx context.Context, label string) (*AgentProfile, error) {
 	return o.getAgentProfileByLabel(ctx, label)
 }
@@ -624,7 +624,7 @@ func (o *Client) GetSystemAgent(ctx context.Context, id ObjectId) (*SystemAgent,
 // GetSystemAgentByManagementIp returns *SystemAgent representing the
 // Agent with the given "Management Ip" (which in Apstra terms can also
 // be a hostname). Apstra doesn't allow management IP collisions, so this should
-// be a unique match. If no match, an ApstraClientErr with type ErrNotfound is
+// be a unique match. If no match, a ClientErr with type ErrNotfound is
 // returned.
 func (o *Client) GetSystemAgentByManagementIp(ctx context.Context, ip string) (*SystemAgent, error) {
 	return o.getSystemAgentByManagementIp(ctx, ip)
@@ -870,7 +870,7 @@ func (o *Client) AddSubnetToIp4Pool(ctx context.Context, poolId ObjectId, new *n
 }
 
 // DeleteSubnetFromIp4Pool deletes a subnet from an IPv4 resource pool. If the subnet does not exist,
-// an ApstraClientErr with type ErrNotfound will be returned.
+// a ClientErr with type ErrNotfound will be returned.
 func (o *Client) DeleteSubnetFromIp4Pool(ctx context.Context, poolId ObjectId, target *net.IPNet) error {
 	return o.deleteSubnetFromIpPool(ctx, poolId, target)
 }
@@ -942,7 +942,7 @@ func (o *Client) AddSubnetToIp6Pool(ctx context.Context, poolId ObjectId, new *n
 }
 
 // DeleteSubnetFromIp6Pool deletes a subnet from an IPv6 resource pool. If the subnet does not exist,
-// an ApstraClientErr with type ErrNotfound will be returned.
+// a ClientErr with type ErrNotfound will be returned.
 func (o *Client) DeleteSubnetFromIp6Pool(ctx context.Context, poolId ObjectId, target *net.IPNet) error {
 	return o.deleteSubnetFromIpPool(ctx, poolId, target)
 }
@@ -1725,7 +1725,7 @@ func (o *Client) GetRevision(ctx context.Context, id ObjectId, rev int) (*Bluepr
 		}
 	}
 
-	return nil, ApstraClientErr{
+	return nil, ClientErr{
 		errType: ErrNotfound,
 		err:     fmt.Errorf("blueprint %q revision %d not available in rollback history", id, rev),
 	}
@@ -1752,7 +1752,7 @@ func (o *Client) GetLastDeployedRevision(ctx context.Context, id ObjectId) (*Blu
 	}
 
 	if highestRevPtr == nil {
-		err = ApstraClientErr{
+		err = ClientErr{
 			errType: ErrUncommitted,
 			err:     fmt.Errorf("no commits/deployments of blueprint %q found", id),
 		}

--- a/apstra/int_pool.go
+++ b/apstra/int_pool.go
@@ -347,7 +347,7 @@ func (o *Client) createIntPoolRange(ctx context.Context, apiResourcesPoolById st
 	}
 	// we don't expect to find the "new" range in there already
 	if pool.Ranges.IndexOf(newRange) >= 0 {
-		return ApstraClientErr{
+		return ClientErr{
 			errType: ErrExists,
 			err:     fmt.Errorf(" range %d-%d in  pool '%s' already exists, cannot create", newRange.first(), newRange.last(), pool.Id),
 		}
@@ -355,7 +355,7 @@ func (o *Client) createIntPoolRange(ctx context.Context, apiResourcesPoolById st
 
 	// sanity check: the new range shouldn't overlap any existing range (the API will reject it)
 	if pool.Ranges.Overlaps(newRange) {
-		return ApstraClientErr{
+		return ClientErr{
 			errType: ErrRangeOverlap,
 			err: fmt.Errorf("new range %d-%d overlaps with existing range in  Pool '%s'",
 				newRange.first(), newRange.last(), poolId),
@@ -411,7 +411,7 @@ func (o *Client) deleteIntPoolRange(ctx context.Context, apiResourcesPoolById st
 	}
 	deleteIdx := p.Ranges.IndexOf(deleteMe)
 	if deleteIdx < 0 {
-		return ApstraClientErr{
+		return ClientErr{
 			errType: ErrNotfound,
 			err:     fmt.Errorf("range '%d-%d' not found in Int Pool '%s'", deleteMe.first(), deleteMe.last(), poolId),
 		}

--- a/apstra/talk_to_apstra.go
+++ b/apstra/talk_to_apstra.go
@@ -50,29 +50,29 @@ func convertTtaeToAceWherePossible(err error) error {
 	if errors.As(err, &ttae) {
 		switch ttae.Response.StatusCode {
 		case http.StatusNotFound:
-			return ApstraClientErr{errType: ErrNotfound, err: err}
+			return ClientErr{errType: ErrNotfound, err: err}
 		case http.StatusConflict:
-			return ApstraClientErr{errType: ErrConflict, err: errors.New(ttae.Msg)}
+			return ClientErr{errType: ErrConflict, err: errors.New(ttae.Msg)}
 		case http.StatusUnprocessableEntity:
 			switch {
 			case strings.Contains(ttae.Msg, "already exists"):
-				return ApstraClientErr{errType: ErrExists, err: errors.New(ttae.Msg)}
+				return ClientErr{errType: ErrExists, err: errors.New(ttae.Msg)}
 			case strings.Contains(ttae.Msg, "No node with id: "):
-				return ApstraClientErr{errType: ErrNotfound, err: errors.New(ttae.Msg)}
+				return ClientErr{errType: ErrNotfound, err: errors.New(ttae.Msg)}
 			case strings.Contains(ttae.Msg, "No virtual_network with id: "):
-				return ApstraClientErr{errType: ErrNotfound, err: errors.New(ttae.Msg)}
+				return ClientErr{errType: ErrNotfound, err: errors.New(ttae.Msg)}
 			case strings.Contains(ttae.Msg, "Virtual Network name not unique"):
-				return ApstraClientErr{errType: ErrExists, err: errors.New(ttae.Msg)}
+				return ClientErr{errType: ErrExists, err: errors.New(ttae.Msg)}
 			case strings.Contains(ttae.Msg, "Transformation cannot be changed"):
-				return ApstraClientErr{errType: ErrCannotChangeTransform, err: errors.New(ttae.Msg)}
+				return ClientErr{errType: ErrCannotChangeTransform, err: errors.New(ttae.Msg)}
 			case strings.Contains(ttae.Msg, "does not exist"):
-				return ApstraClientErr{errType: ErrNotfound, err: errors.New(ttae.Msg)}
+				return ClientErr{errType: ErrNotfound, err: errors.New(ttae.Msg)}
 			}
 		case http.StatusInternalServerError:
 			switch {
 			case strings.Contains(ttae.Msg, "Error executing facade API GET /obj-policy-export") &&
 				strings.Contains(ttae.Msg, "'NoneType' object has no attribute 'id'"):
-				return ApstraClientErr{errType: ErrNotfound, err: errors.New(ttae.Msg)}
+				return ClientErr{errType: ErrNotfound, err: errors.New(ttae.Msg)}
 			}
 		}
 	}

--- a/apstra/two_stage_l3_clos_client.go
+++ b/apstra/two_stage_l3_clos_client.go
@@ -274,8 +274,8 @@ func (o *TwoStageL3ClosClient) AddPolicyRule(ctx context.Context, rule *PolicyRu
 	return o.addPolicyRule(ctx, rule, position, policyId)
 }
 
-// DeletePolicyRuleById deletes the given rule. If the rule doesn't exist, an
-// ApstraClientErr with ErrNotFound is returned.
+// DeletePolicyRuleById deletes the given rule. If the rule doesn't exist, a
+// ClientErr with ErrNotFound is returned.
 func (o *TwoStageL3ClosClient) DeletePolicyRuleById(ctx context.Context, policyId ObjectId, ruleId ObjectId) error {
 	return o.deletePolicyRuleById(ctx, policyId, ruleId)
 }

--- a/apstra/two_stage_l3_clos_configlet.go
+++ b/apstra/two_stage_l3_clos_configlet.go
@@ -122,7 +122,7 @@ func (o *TwoStageL3ClosClient) getConfigletByName(ctx context.Context, name stri
 			if idx == -1 {
 				idx = i
 			} else { // This is clearly the second occurrence
-				return nil, ApstraClientErr{
+				return nil, ClientErr{
 					errType: ErrMultipleMatch,
 					err:     fmt.Errorf("name '%s' does not uniquely identify a configlet", name),
 				}
@@ -132,7 +132,7 @@ func (o *TwoStageL3ClosClient) getConfigletByName(ctx context.Context, name stri
 	if idx != -1 {
 		return &cgs[idx], nil
 	}
-	return nil, ApstraClientErr{
+	return nil, ClientErr{
 		errType: ErrNotfound,
 		err:     fmt.Errorf("no Configlet with name '%s' found", name),
 	}

--- a/apstra/two_stage_l3_clos_configlet_integration_test.go
+++ b/apstra/two_stage_l3_clos_configlet_integration_test.go
@@ -71,7 +71,7 @@ func TestImportGetUpdateGetDeleteConfiglet(t *testing.T) {
 		if err == nil {
 			t.Fatal("fetch configlet after delete should have produced an error")
 		} else {
-			var ace ApstraClientErr
+			var ace ClientErr
 			if !errors.As(err, &ace) || ace.Type() != ErrNotfound {
 				t.Fatal("fetch configlet after delete should have produced ErrNotFound")
 			}

--- a/apstra/two_stage_l3_clos_connectivity_template_integration_test.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_integration_test.go
@@ -291,7 +291,7 @@ func TestCreateGetUpdateDeleteCT(t *testing.T) {
 			if err == nil {
 				t.Fatal("GetConnectivityTemplate() against deleted ID should have produced an error")
 			}
-			var ace ApstraClientErr
+			var ace ClientErr
 			if !(errors.As(err, &ace) && ace.errType == ErrNotfound) {
 				t.Fatalf("expected ErrNotFound, got %s", err.Error())
 			}
@@ -476,7 +476,7 @@ func TestConnectivityTemplate404(t *testing.T) {
 		if err == nil {
 			t.Fatal("retrieval of bogus CT should have produced an error")
 		} else {
-			var ace ApstraClientErr
+			var ace ClientErr
 			if !errors.As(err, &ace) || ace.Type() != ErrNotfound {
 				t.Fatal("error should have been something 404-ish")
 			}
@@ -486,7 +486,7 @@ func TestConnectivityTemplate404(t *testing.T) {
 		if err == nil {
 			t.Fatal("deletion of bogus CT should have produced an error")
 		} else {
-			var ace ApstraClientErr
+			var ace ClientErr
 			if !errors.As(err, &ace) || ace.Type() != ErrNotfound {
 				t.Fatal("error should have been something 404-ish")
 			}

--- a/apstra/two_stage_l3_clos_interface_transformation.go
+++ b/apstra/two_stage_l3_clos_interface_transformation.go
@@ -91,14 +91,14 @@ func (o *TwoStageL3ClosClient) GetTransformationId(ctx context.Context, interfac
 
 	switch len(queryResponse.Items) {
 	case 0:
-		return -1, ApstraClientErr{
+		return -1, ClientErr{
 			errType: ErrNotfound,
 			err:     fmt.Errorf("no interface map associated with node %q query: %q", interfaceNodeId, query.String()),
 		}
 	case 1:
 		return transformByIfName(queryResponse.Items[0].Interface.IfName, queryResponse.Items[0].InterfaceMap.Interfaces)
 	default:
-		return -1, ApstraClientErr{
+		return -1, ClientErr{
 			errType: ErrMultipleMatch,
 			err:     fmt.Errorf("query %q found %d interface maps, expected 1", query.String(), len(queryResponse.Items)),
 		}
@@ -141,14 +141,14 @@ func (o *TwoStageL3ClosClient) GetTransformationIdByIfName(ctx context.Context, 
 
 	switch len(queryResponse.Items) {
 	case 0:
-		return -1, ApstraClientErr{
+		return -1, ClientErr{
 			errType: ErrNotfound,
 			err:     fmt.Errorf("no interface map associated with node %q query: %q", systemNodeId, query.String()),
 		}
 	case 1:
 		return transformByIfName(ifName, queryResponse.Items[0].InterfaceMap.Interfaces)
 	default:
-		return -1, ApstraClientErr{
+		return -1, ClientErr{
 			errType: ErrMultipleMatch,
 			err:     fmt.Errorf("query %q found %d interface maps, expected 1", query.String(), len(queryResponse.Items)),
 		}
@@ -167,7 +167,7 @@ func transformByIfName(ifName string, in []struct {
 	}
 
 	// getting here means we failed to find a the interface within the mapping
-	return -1, ApstraClientErr{
+	return -1, ClientErr{
 		errType: ErrNotfound,
 		err:     fmt.Errorf("no mapping for interface %q found in interface map", ifName),
 	}

--- a/apstra/two_stage_l3_clos_interface_transformation_integration_test.go
+++ b/apstra/two_stage_l3_clos_interface_transformation_integration_test.go
@@ -144,7 +144,7 @@ func TestGetSetTransformationId(t *testing.T) {
 			}
 
 			if tc.expSetIdErr {
-				var ace ApstraClientErr
+				var ace ClientErr
 				if errors.As(err, &ace) && ace.Type() == ErrCannotChangeTransform {
 					log.Println("got the error we wanted:", err)
 					continue

--- a/apstra/two_stage_l3_clos_links.go
+++ b/apstra/two_stage_l3_clos_links.go
@@ -79,14 +79,14 @@ func (o *TwoStageL3ClosClient) SystemNodeFromLinkIds(ctx context.Context, linkId
 
 	switch len(nodeIds) {
 	case 0:
-		return "", ApstraClientErr{
+		return "", ClientErr{
 			errType: ErrNotfound,
 			err:     fmt.Errorf("no node matches query: %q", query.String()),
 		}
 	case 1:
 		return nodeIds[0], nil
 	default:
-		return "", ApstraClientErr{
+		return "", ClientErr{
 			errType: ErrMultipleMatch,
 			err:     fmt.Errorf("multiple nodes match query: %q", query.String()),
 		}

--- a/apstra/two_stage_l3_clos_mutex.go
+++ b/apstra/two_stage_l3_clos_mutex.go
@@ -28,7 +28,7 @@ func (o *TwoStageL3ClosMutex) GetMessage() string {
 // SetMessage sets the lock message embedded in the mutex
 func (o *TwoStageL3ClosMutex) SetMessage(msg string) error {
 	if o.readOnly {
-		return ApstraClientErr{
+		return ClientErr{
 			errType: ErrReadOnly,
 			err:     errors.New("attempt to set message of a read-only mutex"),
 		}
@@ -113,7 +113,7 @@ func (o *TwoStageL3ClosMutex) lock(ctx context.Context, nonBlocking bool) error 
 	// loop until we acquire the lock or the context deadline (set by caller) expires.
 	tickerB := immediateTicker(lockPollInterval)
 	defer tickerB.Stop()
-	var ace ApstraClientErr
+	var ace ClientErr
 	var tagID ObjectId
 	for tagID == "" {
 		select {
@@ -167,7 +167,7 @@ func (o *TwoStageL3ClosMutex) lock(ctx context.Context, nonBlocking bool) error 
 // Unlock releases the mutex
 func (o *TwoStageL3ClosMutex) Unlock(ctx context.Context) error {
 	if o.readOnly {
-		return ApstraClientErr{
+		return ClientErr{
 			errType: ErrReadOnly,
 			err:     errors.New("attempt to unlock read-only mutex"),
 		}
@@ -175,7 +175,7 @@ func (o *TwoStageL3ClosMutex) Unlock(ctx context.Context) error {
 
 	err := o.client.client.deleteTag(ctx, o.tagId)
 	if err != nil {
-		var ace ApstraClientErr
+		var ace ClientErr
 		if !errors.As(err, &ace) || ace.Type() != ErrNotfound {
 			return err
 		}

--- a/apstra/two_stage_l3_clos_policies.go
+++ b/apstra/two_stage_l3_clos_policies.go
@@ -442,7 +442,7 @@ func (o *TwoStageL3ClosClient) deletePolicyRuleById(ctx context.Context, policyI
 	}
 
 	if ruleIdx < 0 {
-		return ApstraClientErr{
+		return ClientErr{
 			errType: ErrNotfound,
 			err:     fmt.Errorf("rule id '%s' not found in policy '%s'", ruleId, policyId),
 		}

--- a/apstra/two_stage_l3_clos_property_sets.go
+++ b/apstra/two_stage_l3_clos_property_sets.go
@@ -77,7 +77,7 @@ func (o *TwoStageL3ClosClient) getPropertySetByName(ctx context.Context, name st
 			return &t, nil
 		}
 	}
-	return nil, ApstraClientErr{
+	return nil, ClientErr{
 		errType: ErrNotfound,
 		err:     fmt.Errorf("property Set with name '%s' not found", name),
 	}

--- a/apstra/two_stage_l3_clos_routing_policies.go
+++ b/apstra/two_stage_l3_clos_routing_policies.go
@@ -482,7 +482,7 @@ func (o *TwoStageL3ClosClient) getRoutingPolicyByName(ctx context.Context, desir
 		}
 
 		if policyIdx >= 0 {
-			return nil, ApstraClientErr{
+			return nil, ClientErr{
 				errType: ErrMultipleMatch,
 				err:     fmt.Errorf("found multiple routing policies with name %q", desired),
 			}
@@ -492,7 +492,7 @@ func (o *TwoStageL3ClosClient) getRoutingPolicyByName(ctx context.Context, desir
 	}
 
 	if policyIdx < 0 {
-		return nil, ApstraClientErr{
+		return nil, ClientErr{
 			errType: ErrNotfound,
 			err:     fmt.Errorf("routing policy with name %q not found", desired),
 		}
@@ -513,7 +513,7 @@ func (o *TwoStageL3ClosClient) getDefaultRoutingPolicy(ctx context.Context) (*ra
 		}
 	}
 
-	return nil, ApstraClientErr{
+	return nil, ClientErr{
 		errType: ErrNotfound,
 		err: fmt.Errorf("blueprint %q has %d policies, but none have type %q",
 			o.blueprintId, len(policies), dcRoutingPolicyTypeDefault),

--- a/apstra/two_stage_l3_clos_routing_policies_integration_test.go
+++ b/apstra/two_stage_l3_clos_routing_policies_integration_test.go
@@ -430,7 +430,7 @@ func TestRoutingPolicy404(t *testing.T) {
 		if err == nil {
 			t.Fatal("should have gotten an error")
 		} else {
-			var clientErr ApstraClientErr
+			var clientErr ClientErr
 			if !errors.As(err, &clientErr) || clientErr.Type() != ErrNotfound {
 				t.Fatal("error should have been something 404-ish")
 			}
@@ -441,7 +441,7 @@ func TestRoutingPolicy404(t *testing.T) {
 		if err == nil {
 			t.Fatal("should have gotten an error")
 		} else {
-			var clientErr ApstraClientErr
+			var clientErr ClientErr
 			if !errors.As(err, &clientErr) || clientErr.Type() != ErrNotfound {
 				t.Fatal("error should have been something 404-ish")
 			}

--- a/apstra/two_stage_l3_clos_security_zones.go
+++ b/apstra/two_stage_l3_clos_security_zones.go
@@ -194,7 +194,7 @@ func (o *TwoStageL3ClosClient) getSecurityZoneByVrfName(ctx context.Context, vrf
 		}
 	}
 
-	return nil, ApstraClientErr{
+	return nil, ClientErr{
 		errType: ErrNotfound,
 		err:     fmt.Errorf("security zone with vrf name %q not found in blueprint %q", vrfName, o.blueprintId),
 	}

--- a/apstra/two_stage_l3_clos_switch_system_links.go
+++ b/apstra/two_stage_l3_clos_switch_system_links.go
@@ -210,7 +210,7 @@ func (o *TwoStageL3ClosClient) DeleteGenericSystem(ctx context.Context, id Objec
 	}
 
 	if len(response.Items) == 0 {
-		return ApstraClientErr{
+		return ClientErr{
 			errType: ErrNotfound,
 			err:     fmt.Errorf("query %q returned no results", query),
 		}

--- a/apstra/two_stage_l3_clos_virtual_networks_integration_test.go
+++ b/apstra/two_stage_l3_clos_virtual_networks_integration_test.go
@@ -168,7 +168,7 @@ func compareVirtualNetworkData(t *testing.T, a, b *VirtualNetworkData, strict bo
 }
 
 func TestCreateUpdateDeleteVirtualNetwork(t *testing.T) {
-	var ace ApstraClientErr
+	var ace ClientErr
 	ctx := context.Background()
 
 	clients, err := getTestClients(ctx, t)


### PR DESCRIPTION
Applications which consume this library wind up with code like:

```go
var ace apstra.ApstraClientErr
```

Well *of course* it's an *apstra* client error. It came from the *apstra package* after all...

This PR is a breaking change which renames the object to eliminate the redundancy.

Closes #91