### PR TITLE
Make `SetUserData()` return an error

### DIFF
--- a/apstra/two_stage_l3_clos_connectivity_template_assignment_integration_test.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_assignment_integration_test.go
@@ -111,7 +111,10 @@ func TestAssignClearCtToInterface(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		ct.SetUserData()
+		err = ct.SetUserData()
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		log.Printf("testing CreateConnectivityTemplate() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		err = bpClient.CreateConnectivityTemplate(ctx, &ct)

--- a/apstra/two_stage_l3_clos_connectivity_template_integration_test.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_integration_test.go
@@ -234,7 +234,11 @@ func TestCreateGetUpdateDeleteCT(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			tc.ct.SetUserData()
+
+			err = tc.ct.SetUserData()
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			log.Printf("testing CreateConnectivityTemplate(%d) against %s %s (%s)", i, client.clientType, clientName, client.client.ApiVersion())
 			err = bpClient.CreateConnectivityTemplate(ctx, tc.ct)
@@ -265,7 +269,11 @@ func TestCreateGetUpdateDeleteCT(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			u.SetUserData()
+
+			err = u.SetUserData()
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			log.Printf("testing UpdateConnectivityTemplate(%d) against %s %s (%s)", i, client.clientType, clientName, client.client.ApiVersion())
 			err = bpClient.UpdateConnectivityTemplate(ctx, u)
@@ -443,7 +451,11 @@ func TestCtLayout(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		ct.SetUserData()
+
+		err = ct.SetUserData()
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		err = bpClient.CreateConnectivityTemplate(ctx, &ct)
 		if err != nil {

--- a/apstra/two_stage_l3_clos_connectivity_template_unit_test.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_unit_test.go
@@ -16,7 +16,7 @@ func TestBgpOverL3Connectivity(t *testing.T) {
       "visible": true,
       "policy_type_name": "batch",
       "attributes": {
-        "Subpolicies": [
+        "subpolicies": [
           "31e32ddd-98e9-4f74-8fd7-61bbf9501cfd"
         ]
       }
@@ -57,7 +57,7 @@ func TestBgpOverL3Connectivity(t *testing.T) {
       "visible": false,
       "policy_type_name": "batch",
       "attributes": {
-        "Subpolicies": [
+        "subpolicies": [
           "de1474c2-f892-4fa6-bef4-e330ae7f9ac7"
         ]
       }
@@ -106,7 +106,7 @@ func TestBgpOverL3Connectivity(t *testing.T) {
       "visible": false,
       "policy_type_name": "batch",
       "attributes": {
-        "Subpolicies": [
+        "subpolicies": [
           "8c654b0f-3253-45c6-9d8b-88bcc35fb70b"
         ]
       }

--- a/apstra/two_stage_l3_clos_connectivity_template_unit_test.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_unit_test.go
@@ -212,7 +212,11 @@ func TestBgpOverL3Connectivity(t *testing.T) {
 		Label:       "BGP over L3 connectivity",
 		Description: "this is the description",
 	}
-	ct.SetUserData()
+
+	err := ct.SetUserData()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	raw, err := ct.raw()
 	if err != nil {


### PR DESCRIPTION
`ConnectivityTemplate.SetUserData()` builds the JSON string which specifies the layout of Connectivity Template Primitives in the web UI (the `user_data` JSON field).

This data is a map of x/y/z coordinates keyed by the `ObjectId` of each element in the tree.

These `ObjectId`s are set client-side.

Prior to this change, if any `ObjectId` in the tree was un-set, `SetUserData()` would crash due to nil pointer dereference.

It was critical that the caller invoke `SetIds()` before `SetUserData()`.

This change adds a check for `nil` `ObjectId` in `SetUserData()` and it's private methods, and returns an error.

It's a breaking change because of the new function signature.

Closes #62