### PR TITLE
Add `Optional()` method to `MatchQuery`

### DIFF
--- a/apstra/query_engine.go
+++ b/apstra/query_engine.go
@@ -169,6 +169,7 @@ type PathQuery struct {
 	blueprintId   ObjectId
 	blueprintType BlueprintType
 	where         []string
+	optional      bool
 }
 
 func (o *PathQuery) getBlueprintType() BlueprintType {
@@ -210,6 +211,11 @@ func (o *PathQuery) String() string {
 	for _, where := range o.where {
 		sb.WriteString(".where(" + where + ")")
 	}
+
+	if o.optional {
+		return "optional(" + sb.String() + ")"
+	}
+
 	return sb.String()
 }
 
@@ -370,5 +376,12 @@ func (o *MatchQuery) Where(where string) *MatchQuery {
 
 func (o *MatchQuery) Match(q *PathQuery) *MatchQuery {
 	o.match = append(o.match, *q)
+	return o
+}
+
+func (o *MatchQuery) Optional(q *PathQuery) *MatchQuery {
+	optional := *q
+	optional.optional = true
+	o.match = append(o.match, optional)
 	return o
 }

--- a/apstra/query_engine.go
+++ b/apstra/query_engine.go
@@ -69,16 +69,17 @@ func (o *QEElement) getLast() *QEElement {
 func (o *QEElement) String() string {
 	attrsSB := strings.Builder{}
 
-	// add first attribute to string builder without leading separator
 	if len(o.attributes) > 0 {
+		// add first attribute to string builder without leading separator
 		attrsSB.WriteString(o.attributes[0].String())
+
+		// remaining attributes added with leading separator
+		for _, a := range o.attributes[1:] {
+			attrsSB.WriteString(qEElementAttributeSep)
+			attrsSB.WriteString(a.String())
+		}
 	}
 
-	// remaining attributes added with leading separator
-	for _, a := range o.attributes[1:] {
-		attrsSB.WriteString(qEElementAttributeSep)
-		attrsSB.WriteString(a.String())
-	}
 	return fmt.Sprintf("%s(%s)", o.qeeType, attrsSB.String())
 }
 

--- a/apstra/query_engine.go
+++ b/apstra/query_engine.go
@@ -18,6 +18,7 @@ type QEQuery interface {
 	Do(context.Context, interface{}) error
 	String() string
 	getBlueprintType() BlueprintType
+	setOptional()
 }
 
 var _ QEQuery = &PathQuery{}
@@ -176,6 +177,10 @@ func (o *PathQuery) getBlueprintType() BlueprintType {
 	return o.blueprintType
 }
 
+func (o *PathQuery) setOptional() {
+	o.optional = true
+}
+
 func (o *PathQuery) Do(ctx context.Context, response interface{}) error {
 	return o.client.runQuery(ctx, o.blueprintId, o, response)
 }
@@ -285,9 +290,10 @@ type MatchQuery struct {
 	context       context.Context
 	blueprintId   ObjectId
 	blueprintType BlueprintType
-	match         []PathQuery
+	match         []QEQuery
 	firstElement  *MatchQueryElement
 	where         []string
+	optional      bool
 }
 
 //func (o *MatchQuery) Having(v QEAttrVal) *MatchQuery          {} // todo
@@ -315,6 +321,10 @@ func (o *MatchQuery) addElement(t string, v QEAttrVal) *MatchQuery {
 
 func (o *MatchQuery) getBlueprintType() BlueprintType {
 	return o.blueprintType
+}
+
+func (o *MatchQuery) setOptional() {
+	o.optional = true
 }
 
 func (o *MatchQuery) Do(ctx context.Context, response interface{}) error {
@@ -374,14 +384,13 @@ func (o *MatchQuery) Where(where string) *MatchQuery {
 	return o
 }
 
-func (o *MatchQuery) Match(q *PathQuery) *MatchQuery {
-	o.match = append(o.match, *q)
+func (o *MatchQuery) Match(q QEQuery) *MatchQuery {
+	o.match = append(o.match, q)
 	return o
 }
 
-func (o *MatchQuery) Optional(q *PathQuery) *MatchQuery {
-	optional := *q
-	optional.optional = true
-	o.match = append(o.match, optional)
+func (o *MatchQuery) Optional(q QEQuery) *MatchQuery {
+	q.setOptional()
+	o.match = append(o.match, q)
 	return o
 }

--- a/apstra/query_engine_test.go
+++ b/apstra/query_engine_test.go
@@ -415,3 +415,33 @@ func TestMatchQueryWhere(t *testing.T) {
 		}
 	}
 }
+
+func TestQueryMatchOptional(t *testing.T) {
+	expected := "" +
+		"match(" +
+		"" + "node(type='system',system_type='switch').out().node(type='interface').out().node(type='link',name='n_link')," +
+		"" + "optional(" +
+		"" + "" + "node(type='link',name='n_link').in_().node(type='tag',name='n_tag')" +
+		"" + ")" +
+		")"
+	q1 := new(PathQuery).
+		Node([]QEEAttribute{NodeTypeSystem.QEEAttribute(), {Key: "system_type", Value: QEStringVal("switch")}}).
+		Out([]QEEAttribute{}).
+		Node([]QEEAttribute{NodeTypeInterface.QEEAttribute()}).
+		Out([]QEEAttribute{}).
+		Node([]QEEAttribute{NodeTypeLink.QEEAttribute(), {Key: "name", Value: QEStringVal("n_link")}})
+
+	q2 := new(PathQuery).
+		Node([]QEEAttribute{NodeTypeLink.QEEAttribute(), {Key: "name", Value: QEStringVal("n_link")}}).
+		In([]QEEAttribute{}).
+		Node([]QEEAttribute{NodeTypeTag.QEEAttribute(), {Key: "name", Value: QEStringVal("n_tag")}})
+
+	result := new(MatchQuery).
+		Match(q1).
+		Optional(q2).
+		String()
+
+	if expected != result {
+		t.Fatalf("expected: %q, got %q", expected, result)
+	}
+}

--- a/apstra/two_stage_l3_clos_connectivity_template_integration_test.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_integration_test.go
@@ -366,8 +366,8 @@ func TestCtLayout(t *testing.T) {
 								SessionAddressingIpv4: true,
 							},
 							Subpolicies: []*ConnectivityTemplatePrimitive{
-								{Attributes: &ConnectivityTemplatePrimitiveAttributesAttachExistingRoutingPolicy{&rp.Id}},
-								{Attributes: &ConnectivityTemplatePrimitiveAttributesAttachExistingRoutingPolicy{&rp.Id}},
+								{Attributes: &ConnectivityTemplatePrimitiveAttributesAttachExistingRoutingPolicy{RpToAttach: &rp.Id}},
+								{Attributes: &ConnectivityTemplatePrimitiveAttributesAttachExistingRoutingPolicy{RpToAttach: &rp.Id}},
 							},
 						},
 						{
@@ -376,8 +376,8 @@ func TestCtLayout(t *testing.T) {
 								SessionAddressingIpv6: true,
 							},
 							Subpolicies: []*ConnectivityTemplatePrimitive{
-								{Attributes: &ConnectivityTemplatePrimitiveAttributesAttachExistingRoutingPolicy{&rp.Id}},
-								{Attributes: &ConnectivityTemplatePrimitiveAttributesAttachExistingRoutingPolicy{&rp.Id}},
+								{Attributes: &ConnectivityTemplatePrimitiveAttributesAttachExistingRoutingPolicy{RpToAttach: &rp.Id}},
+								{Attributes: &ConnectivityTemplatePrimitiveAttributesAttachExistingRoutingPolicy{RpToAttach: &rp.Id}},
 							},
 						},
 						{
@@ -413,8 +413,8 @@ func TestCtLayout(t *testing.T) {
 								SessionAddressingIpv4: true,
 							},
 							Subpolicies: []*ConnectivityTemplatePrimitive{
-								{Attributes: &ConnectivityTemplatePrimitiveAttributesAttachExistingRoutingPolicy{&rp.Id}},
-								{Attributes: &ConnectivityTemplatePrimitiveAttributesAttachExistingRoutingPolicy{&rp.Id}},
+								{Attributes: &ConnectivityTemplatePrimitiveAttributesAttachExistingRoutingPolicy{RpToAttach: &rp.Id}},
+								{Attributes: &ConnectivityTemplatePrimitiveAttributesAttachExistingRoutingPolicy{RpToAttach: &rp.Id}},
 							},
 						},
 						{
@@ -423,8 +423,8 @@ func TestCtLayout(t *testing.T) {
 								SessionAddressingIpv6: true,
 							},
 							Subpolicies: []*ConnectivityTemplatePrimitive{
-								{Attributes: &ConnectivityTemplatePrimitiveAttributesAttachExistingRoutingPolicy{&rp.Id}},
-								{Attributes: &ConnectivityTemplatePrimitiveAttributesAttachExistingRoutingPolicy{&rp.Id}},
+								{Attributes: &ConnectivityTemplatePrimitiveAttributesAttachExistingRoutingPolicy{RpToAttach: &rp.Id}},
+								{Attributes: &ConnectivityTemplatePrimitiveAttributesAttachExistingRoutingPolicy{RpToAttach: &rp.Id}},
 							},
 						},
 						{


### PR DESCRIPTION
- Bugfix slice out-of-bound terror (lol typo) when a path query element has no attributes: `node()` would crash, but `node(type='system', label='foo')` was okay
- Eliminate use of positional struct elements in test. This probably broke in #103. These are the changes in `apstra/two_stage_l3_clos_connectivity_template_integration_test.go`.
- Add `optional` element to `PathQuery` and `MatchQuery` structs, so they know how to string-ify in match+optional context
- Change `MatchQuery` to it receives `QEQuery` implementations rather than only `PathQuery` objects. Now we can write queries with `match(match())`
- Introduce `MatchQuery.Optional()`, which sets the `optional` flag on child queries
- Test