### PR TITLE
Add `RawQuery{}` implementation of `QEQuery`

### DIFF
--- a/apstra/query_engine.go
+++ b/apstra/query_engine.go
@@ -387,3 +387,51 @@ func (o *MatchQuery) Optional(q QEQuery) *MatchQuery {
 	o.match = append(o.match, q)
 	return o
 }
+
+type RawQuery struct {
+	query         string
+	client        *Client
+	blueprintId   ObjectId
+	blueprintType BlueprintType
+	optional      bool
+}
+
+func (o *RawQuery) getBlueprintType() BlueprintType {
+	return o.blueprintType
+}
+
+func (o *RawQuery) setOptional() {
+	o.optional = true
+}
+
+func (o *RawQuery) Do(ctx context.Context, response interface{}) error {
+	return o.client.runQuery(ctx, o.blueprintId, o, response)
+}
+
+func (o *RawQuery) SetBlueprintId(id ObjectId) *RawQuery {
+	o.blueprintId = id
+	return o
+}
+
+func (o *RawQuery) SetBlueprintType(t BlueprintType) *RawQuery {
+	o.blueprintType = t
+	return o
+}
+
+func (o *RawQuery) SetClient(client *Client) *RawQuery {
+	o.client = client
+	return o
+}
+
+func (o *RawQuery) SetQuery(query string) *RawQuery {
+	o.query = query
+	return o
+}
+
+func (o *RawQuery) String() string {
+	if o.optional {
+		return o.query
+	}
+
+	return o.query
+}

--- a/apstra/query_engine_test.go
+++ b/apstra/query_engine_test.go
@@ -447,3 +447,32 @@ func TestQueryMatchOptional(t *testing.T) {
 		t.Fatalf("expected: %q, got %q", expected, result)
 	}
 }
+
+func TestRawQuery(t *testing.T) {
+	type testCase struct {
+		query                string
+		expected             string
+		expectedWithOptional string
+	}
+
+	testCases := []testCase{
+		{
+			query:                "node()",
+			expected:             "node()",
+			expectedWithOptional: "optional(node())",
+		},
+	}
+
+	for i, tc := range testCases {
+		q := new(RawQuery).SetQuery(tc.query)
+		qs := q.String()
+		if tc.expected != qs {
+			t.Fatalf("test %d without optional expected %q, got %q", i, tc.expected, qs)
+		}
+		q.setOptional()
+		qo := q.String()
+		if tc.expected != qs {
+			t.Fatalf("test %d with optional expected %q, got %q", i, tc.expectedWithOptional, qo)
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a new implementation of `QEQuery` which facilitates running queries from arbitrary text strings.

The goal is to be able to give terraform users an arbitrary `query` data source (a DIY data source).

We should endeavor to not write our own queries this way, but stick with `PathQuery`, `MatchQuery` and any future enhancements which turn out to be appropriate.

Closes #17