### PR TITLE
Add support for `/api/blueprints/{id}/experience/web/system-info` API endpoint

### DIFF
--- a/apstra/api_design_rack_types.go
+++ b/apstra/api_design_rack_types.go
@@ -67,19 +67,19 @@ const (
 	featureSwitchUnknown  = "unknown feature switch state '%d'"
 )
 
-type GenericSystemManagementLevel int
-type genericSystemManagementLevel string
+type SystemManagementLevel int
+type systemManagementLevel string
 
 const (
-	GenericSystemUnmanaged = GenericSystemManagementLevel(iota)
-	GenericSystemTelemetryOnly
-	GenericSystemFullControl
-	GenericSystemUnknown = "unknown generic system management level '%s'"
+	SystemManagementLevelUnmanaged = SystemManagementLevel(iota)
+	SystemManagementLevelTelemetryOnly
+	SystemManagementLevelFullControl
+	SystemManagementLevelUnknown = "unknown generic system management level '%s'"
 
-	genericSystemUnmanaged     = genericSystemManagementLevel("unmanaged")
-	genericSystemTelemetryOnly = genericSystemManagementLevel("telemetry_only")
-	genericSystemFullControl   = genericSystemManagementLevel("full_control")
-	genericSystemUnknown       = "unknown generic system management level '%d'"
+	systemManagementLevelUnmanaged     = systemManagementLevel("unmanaged")
+	systemManagementLevelTelemetryOnly = systemManagementLevel("telemetry_only")
+	systemManagementLevelFullControl   = systemManagementLevel("full_control")
+	systemManagementLevelUnknown       = "unknown generic system management level '%d'"
 )
 
 type RackLinkAttachmentType int
@@ -290,36 +290,36 @@ func (o featureSwitch) parse() (int, error) {
 	}
 }
 
-func (o GenericSystemManagementLevel) Int() int {
+func (o SystemManagementLevel) Int() int {
 	return int(o)
 }
 
-func (o GenericSystemManagementLevel) String() string {
+func (o SystemManagementLevel) String() string {
 	switch o {
-	case GenericSystemUnmanaged:
-		return string(genericSystemUnmanaged)
-	case GenericSystemTelemetryOnly:
-		return string(genericSystemTelemetryOnly)
-	case GenericSystemFullControl:
-		return string(genericSystemFullControl)
+	case SystemManagementLevelUnmanaged:
+		return string(systemManagementLevelUnmanaged)
+	case SystemManagementLevelTelemetryOnly:
+		return string(systemManagementLevelTelemetryOnly)
+	case SystemManagementLevelFullControl:
+		return string(systemManagementLevelFullControl)
 	default:
-		return fmt.Sprintf(genericSystemUnknown, o)
+		return fmt.Sprintf(systemManagementLevelUnknown, o)
 	}
 }
 
-func (o genericSystemManagementLevel) string() string {
+func (o systemManagementLevel) string() string {
 	return string(o)
 }
-func (o genericSystemManagementLevel) parse() (int, error) {
+func (o systemManagementLevel) parse() (int, error) {
 	switch o {
-	case genericSystemFullControl:
-		return int(GenericSystemFullControl), nil
-	case genericSystemUnmanaged:
-		return int(GenericSystemUnmanaged), nil
-	case genericSystemTelemetryOnly:
-		return int(GenericSystemTelemetryOnly), nil
+	case systemManagementLevelFullControl:
+		return int(SystemManagementLevelFullControl), nil
+	case systemManagementLevelUnmanaged:
+		return int(SystemManagementLevelUnmanaged), nil
+	case systemManagementLevelTelemetryOnly:
+		return int(SystemManagementLevelTelemetryOnly), nil
 	default:
-		return 0, fmt.Errorf(GenericSystemUnknown, o)
+		return 0, fmt.Errorf(SystemManagementLevelUnknown, o)
 	}
 }
 
@@ -870,7 +870,7 @@ func (o rawRackLink) polish(rack *rawRackType) (*RackLink, error) {
 type RackElementGenericSystemRequest struct {
 	Count            int
 	AsnDomain        FeatureSwitch
-	ManagementLevel  GenericSystemManagementLevel
+	ManagementLevel  SystemManagementLevel
 	PortChannelIdMin int
 	PortChannelIdMax int
 	Loopback         FeatureSwitch
@@ -902,7 +902,7 @@ func (o *RackElementGenericSystemRequest) raw(tagMap map[ObjectId]DesignTagData)
 	return &rawRackElementGenericSystemRequest{
 		Count:            o.Count,
 		AsnDomain:        featureSwitch(o.AsnDomain.String()),
-		ManagementLevel:  genericSystemManagementLevel(o.ManagementLevel.String()),
+		ManagementLevel:  systemManagementLevel(o.ManagementLevel.String()),
 		PortChannelIdMin: o.PortChannelIdMin,
 		PortChannelIdMax: o.PortChannelIdMax,
 		Loopback:         featureSwitch(o.Loopback.String()),
@@ -914,22 +914,22 @@ func (o *RackElementGenericSystemRequest) raw(tagMap map[ObjectId]DesignTagData)
 }
 
 type rawRackElementGenericSystemRequest struct {
-	Count            int                          `json:"count"`
-	AsnDomain        featureSwitch                `json:"asn_domain"`
-	ManagementLevel  genericSystemManagementLevel `json:"management_level"`
-	PortChannelIdMin int                          `json:"port_channel_id_min"`
-	PortChannelIdMax int                          `json:"port_channel_id_max"`
-	Loopback         featureSwitch                `json:"loopback"`
-	Label            string                       `json:"label"`
-	LogicalDevice    ObjectId                     `json:"logical_device"`
-	Links            []rawRackLinkRequest         `json:"links"`
-	Tags             []string                     `json:"tags,omitempty"`
+	Count            int                   `json:"count"`
+	AsnDomain        featureSwitch         `json:"asn_domain"`
+	ManagementLevel  systemManagementLevel `json:"management_level"`
+	PortChannelIdMin int                   `json:"port_channel_id_min"`
+	PortChannelIdMax int                   `json:"port_channel_id_max"`
+	Loopback         featureSwitch         `json:"loopback"`
+	Label            string                `json:"label"`
+	LogicalDevice    ObjectId              `json:"logical_device"`
+	Links            []rawRackLinkRequest  `json:"links"`
+	Tags             []string              `json:"tags,omitempty"`
 }
 
 type RackElementGenericSystem struct {
 	Count            int
 	AsnDomain        FeatureSwitch
-	ManagementLevel  GenericSystemManagementLevel
+	ManagementLevel  SystemManagementLevel
 	PortChannelIdMin int
 	PortChannelIdMax int
 	Loopback         FeatureSwitch
@@ -940,16 +940,16 @@ type RackElementGenericSystem struct {
 }
 
 type rawRackElementGenericSystem struct {
-	Count            int                          `json:"count"`
-	AsnDomain        featureSwitch                `json:"asn_domain"`
-	ManagementLevel  genericSystemManagementLevel `json:"management_level"`
-	PortChannelIdMin int                          `json:"port_channel_id_min"`
-	PortChannelIdMax int                          `json:"port_channel_id_max"`
-	Loopback         featureSwitch                `json:"loopback"`
-	Tags             []string                     `json:"tags"`
-	Label            string                       `json:"label"`
-	LogicalDevice    ObjectId                     `json:"logical_device"`
-	Links            []rawRackLink                `json:"links"`
+	Count            int                   `json:"count"`
+	AsnDomain        featureSwitch         `json:"asn_domain"`
+	ManagementLevel  systemManagementLevel `json:"management_level"`
+	PortChannelIdMin int                   `json:"port_channel_id_min"`
+	PortChannelIdMax int                   `json:"port_channel_id_max"`
+	Loopback         featureSwitch         `json:"loopback"`
+	Tags             []string              `json:"tags"`
+	Label            string                `json:"label"`
+	LogicalDevice    ObjectId              `json:"logical_device"`
+	Links            []rawRackLink         `json:"links"`
 }
 
 func (o *rawRackElementGenericSystem) polish(rack *rawRackType) (*RackElementGenericSystem, error) {
@@ -1000,7 +1000,7 @@ func (o *rawRackElementGenericSystem) polish(rack *rawRackType) (*RackElementGen
 	return &RackElementGenericSystem{
 		Count:            o.Count,
 		AsnDomain:        FeatureSwitch(asnDomain),
-		ManagementLevel:  GenericSystemManagementLevel(mgmtLevel),
+		ManagementLevel:  SystemManagementLevel(mgmtLevel),
 		PortChannelIdMin: o.PortChannelIdMin,
 		PortChannelIdMax: o.PortChannelIdMax,
 		Loopback:         FeatureSwitch(loopback),

--- a/apstra/two_stage_l3_clos_system_node_info.go
+++ b/apstra/two_stage_l3_clos_system_node_info.go
@@ -1,0 +1,158 @@
+package apstra
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+)
+
+const (
+	apiUrlBlueprintExperienceWebSystemInfo = apiUrlBlueprintById + apiUrlPathDelim + "experience/web/system-info"
+)
+
+type rawSystemNodeInfoLoopback struct {
+	Ipv6Addr *string   `json:"ipv6_addr"`
+	Ipv4Addr *string   `json:"ipv4_addr"`
+	Id       *ObjectId `json:"id"`
+}
+
+type rawSystemNodeInfo struct {
+	DomainId *string `json:"domain_id"`
+	//UplinkedSystemIds interface{} `json:"uplinked_system_ids"`
+	//DeployMode        interface{} `json:"deploy_mode"`
+	Id             ObjectId                   `json:"id"`
+	Label          string                     `json:"label"`
+	PodId          ObjectId                   `json:"pod_id"`
+	InterfaceMapId *ObjectId                  `json:"interface_map_id"`
+	Loopback       *rawSystemNodeInfoLoopback `json:"loopback"`
+	Hostname       string                     `json:"hostname"`
+	//UnicastVtep        interface{}            `json:"unicast_vtep"`
+	Role systemRole `json:"role"`
+	//SystemId           interface{}   `json:"system_id"`
+	//Hidden             bool          `json:"hidden"`
+	//AnycastVtep        interface{}   `json:"anycast_vtep"`
+	RackId *ObjectId `json:"rack_id"`
+	//LogicalVtep        interface{}   `json:"logical_vtep"`
+	//SuperspinePlaneId  interface{}   `json:"superspine_plane_id"`
+	LogicalDeviceId ObjectId `json:"logical_device_id"`
+	Tags            []string `json:"tags"`
+	//HypervisorId       interface{} `json:"hypervisor_id"`
+	//RedundancyProtocol interface{} `json:"redundancy_protocol"`
+	External         bool `json:"external"`
+	PortChannelIdMin int  `json:"port_channel_id_min"`
+	//PositionData      interface{} `json:"position_data"`
+	PortChannelIdMax  int                   `json:"port_channel_id_max"`
+	RedundancyGroupId *ObjectId             `json:"redundancy_group_id"`
+	GroupLabel        *string               `json:"group_label"`
+	ManagementLevel   systemManagementLevel `json:"management_level"`
+	DeviceProfileId   *ObjectId             `json:"device_profile_id"`
+}
+
+func (o rawSystemNodeInfo) polish() (*SystemNodeInfo, error) {
+	var asn *uint32
+	if o.DomainId != nil {
+		i64, err := strconv.ParseInt(*o.DomainId, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("while parsing ASN string %q - %w", *o.DomainId, err)
+		}
+		i32 := uint32(i64)
+		asn = &i32
+	}
+
+	var loopbackId *ObjectId
+	var loopbackIPv4, loopbackIPv6 *net.IPNet
+	if o.Loopback != nil {
+		loopbackId = o.Loopback.Id
+		if o.Loopback.Ipv4Addr != nil {
+			ip, net, err := net.ParseCIDR(*o.Loopback.Ipv4Addr)
+			if err != nil {
+				return nil, fmt.Errorf("while parsing Loopback IPv4 address %q - %w", *o.Loopback.Ipv4Addr, err)
+			}
+			net.IP = ip
+			loopbackIPv4 = net
+		}
+		if o.Loopback.Ipv6Addr != nil {
+			ip, net, err := net.ParseCIDR(*o.Loopback.Ipv6Addr)
+			if err != nil {
+				return nil, fmt.Errorf("while parsing Loopback IPv6 address %q - %w", *o.Loopback.Ipv6Addr, err)
+			}
+			net.IP = ip
+			loopbackIPv6 = net
+		}
+	}
+
+	managementLevel, err := o.ManagementLevel.parse()
+	if err != nil {
+		return nil, err
+	}
+
+	role, err := o.Role.parse()
+	if err != nil {
+		return nil, err
+	}
+
+	return &SystemNodeInfo{
+		Asn:               asn,
+		DeviceProfileId:   o.DeviceProfileId,
+		External:          o.External,
+		GroupLabel:        o.GroupLabel,
+		Hostname:          o.Hostname,
+		Id:                o.Id,
+		InterfaceMapId:    o.InterfaceMapId,
+		Label:             o.Label,
+		LogicalDevice:     o.LogicalDeviceId,
+		LoopbackId:        loopbackId,
+		LoopbackIpv4:      loopbackIPv4,
+		LoopbackIpv6:      loopbackIPv6,
+		ManagementLevel:   SystemManagementLevel(managementLevel),
+		PodId:             o.PodId,
+		PortChannelIdMax:  o.PortChannelIdMax,
+		PortChannelIdMin:  o.PortChannelIdMin,
+		RackId:            o.RackId,
+		RedundancyGroupId: o.RedundancyGroupId,
+		Role:              SystemRole(role),
+		Tags:              o.Tags,
+	}, nil
+}
+
+type SystemNodeInfo struct {
+	Asn               *uint32
+	DeviceProfileId   *ObjectId
+	External          bool
+	GroupLabel        *string
+	Hostname          string
+	Id                ObjectId
+	InterfaceMapId    *ObjectId
+	Label             string
+	LogicalDevice     ObjectId
+	LoopbackId        *ObjectId
+	LoopbackIpv4      *net.IPNet
+	LoopbackIpv6      *net.IPNet
+	ManagementLevel   SystemManagementLevel
+	PodId             ObjectId
+	PortChannelIdMax  int
+	PortChannelIdMin  int
+	RackId            *ObjectId
+	RedundancyGroupId *ObjectId
+	Role              SystemRole
+	Tags              []string
+}
+
+func (o *TwoStageL3ClosClient) getAllSystemNodeInfos(ctx context.Context) ([]rawSystemNodeInfo, error) {
+	var apiResponse struct {
+		Data []rawSystemNodeInfo `json:"data"`
+	}
+
+	err := o.client.talkToApstra(ctx, &talkToApstraIn{
+		method:      http.MethodGet,
+		urlStr:      fmt.Sprintf(apiUrlBlueprintExperienceWebSystemInfo, o.blueprintId),
+		apiResponse: &apiResponse,
+	})
+	if err != nil {
+		return nil, convertTtaeToAceWherePossible(err)
+	}
+
+	return apiResponse.Data, nil
+}

--- a/apstra/two_stage_l3_clos_system_node_info_integration_test.go
+++ b/apstra/two_stage_l3_clos_system_node_info_integration_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_system_node_info_integration_test.go
+++ b/apstra/two_stage_l3_clos_system_node_info_integration_test.go
@@ -1,0 +1,51 @@
+package apstra
+
+import (
+	"context"
+	"log"
+	"testing"
+)
+
+func TestSystemNodeInfo(t *testing.T) {
+	ctx := context.Background()
+	clients, err := getTestClients(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for clientName, client := range clients {
+		log.Printf("testing ListAllBlueprintIds() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		bpIds, err := client.client.ListAllBlueprintIds(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var bpClient *TwoStageL3ClosClient
+		if len(bpIds) > 0 {
+			log.Printf("testing NewTwoStageL3ClosClient() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+			bpClient, err = client.client.NewTwoStageL3ClosClient(ctx, bpIds[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+		} else {
+			var deleteFunc func(ctx2 context.Context) error
+			bpClient, deleteFunc = testBlueprintA(ctx, t, client.client)
+			defer deleteFunc(ctx)
+		}
+
+		log.Printf("testing GetAllSystemNodeInfos() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		nodeInfos, err := bpClient.GetAllSystemNodeInfos(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for nodeId := range nodeInfos {
+			log.Printf("testing GetSystemNodeInfo() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+			nodeInfo, err := bpClient.GetSystemNodeInfo(ctx, nodeId)
+			if err != nil {
+				t.Fatal(err)
+			}
+			log.Println(nodeInfo.Id)
+		}
+	}
+}


### PR DESCRIPTION
The `/api/blueprints/{id}/experience/web/system-info` API endpoint appears to be one-stop shopping for the web UI's "system" info.

We'll use it to streamline the `Read()` method in the terraform provider's `apstra_datacenter_generic_system` resource (and probably similar future resources)

Also, while poking around in here I learned that `GenericSystemManagementLevel` iota type is useful for systems other than "generic" ones. That type and its values have been renamed to `SystemManagementLevel` 