### PR TITLE
Add methods for setting generic system ASN and loopback IP addresses

### DIFF
--- a/apstra/api_blueprints.go
+++ b/apstra/api_blueprints.go
@@ -10,12 +10,13 @@ import (
 )
 
 const (
-	apiUrlBlueprints        = "/api/blueprints"
-	apiUrlPathDelim         = "/"
-	apiUrlBlueprintsPrefix  = apiUrlBlueprints + apiUrlPathDelim
-	apiUrlBlueprintById     = apiUrlBlueprintsPrefix + "%s"
-	apiUrlBlueprintNodes    = apiUrlBlueprintById + apiUrlPathDelim + "nodes"
-	apiUrlBlueprintNodeById = apiUrlBlueprintNodes + apiUrlPathDelim + "%s"
+	apiUrlBlueprints          = "/api/blueprints"
+	apiUrlPathDelim           = "/"
+	apiUrlBlueprintsPrefix    = apiUrlBlueprints + apiUrlPathDelim
+	apiUrlBlueprintById       = apiUrlBlueprintsPrefix + "%s"
+	apiUrlBlueprintByIdPrefix = apiUrlBlueprintById + apiUrlPathDelim
+	apiUrlBlueprintNodes      = apiUrlBlueprintById + apiUrlPathDelim + "nodes"
+	apiUrlBlueprintNodeById   = apiUrlBlueprintNodes + apiUrlPathDelim + "%s"
 
 	initTypeFromTemplate      = "template_reference"
 	nodeQueryNodeTypeUrlParam = "node_type"

--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -486,3 +486,29 @@ func testBlueprintF(ctx context.Context, t *testing.T, client *Client) (*TwoStag
 
 	return bpClient, deleteFunc
 }
+
+func testBlueprintG(ctx context.Context, t *testing.T, client *Client) (*TwoStageL3ClosClient, func(context.Context) error) {
+	bpId, err := client.CreateBlueprintFromTemplate(context.Background(), &CreateBlueprintFromTemplateRequest{
+		RefDesign:  RefDesignTwoStageL3Clos,
+		Label:      randString(5, "hex"),
+		TemplateId: "L2_Virtual",
+		FabricAddressingPolicy: &FabricAddressingPolicy{
+			SpineSuperspineLinks: AddressingSchemeIp46,
+			SpineLeafLinks:       AddressingSchemeIp46,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bpClient, err := client.NewTwoStageL3ClosClient(ctx, bpId)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bpDeleteFunc := func(ctx context.Context) error {
+		return client.DeleteBlueprint(ctx, bpId)
+	}
+
+	return bpClient, bpDeleteFunc
+}


### PR DESCRIPTION
This PR introduces 3 new `TwoStageL3ClosClient` methods:

- `SetGenericSystemAsn()`
- `SetGenericSystemLoopbackIpv4()`
- `SetGenericSystemLoopbackIpv6()`

Closes #116