### PR TITLE
Support for External Generic systems

### DIFF
--- a/apstra/two_stage_l3_clos_interface_transformation_integration_test.go
+++ b/apstra/two_stage_l3_clos_interface_transformation_integration_test.go
@@ -64,7 +64,7 @@ func TestGetSetTransformationId(t *testing.T) {
 		}
 
 		ifName := "Ethernet1/1"
-		linkIds, err := bpClient.CreateLinksWithNewServer(ctx, &CreateLinksWithNewServerRequest{
+		linkIds, err := bpClient.CreateLinksWithNewSystem(ctx, &CreateLinksWithNewSystemRequest{
 			Links: []CreateLinkRequest{
 				{
 					SwitchEndpoint: SwitchLinkEndpoint{
@@ -74,7 +74,7 @@ func TestGetSetTransformationId(t *testing.T) {
 					},
 				},
 			},
-			Server: CreateLinksWithNewServerRequestServer{
+			System: CreateLinksWithNewSystemRequestSystem{
 				LogicalDeviceId: "AOS-1x10-1",
 			},
 		})

--- a/apstra/two_stage_l3_clos_leaf_server_bonding_integration_test.go
+++ b/apstra/two_stage_l3_clos_leaf_server_bonding_integration_test.go
@@ -101,7 +101,7 @@ func TestSetGenericServerBonding(t *testing.T) {
 		}
 
 		type testCase struct {
-			//request         CreateLinksWithNewServerRequest
+			//request         CreateLinksWithNewSystemRequest
 			switchIds       []ObjectId
 			linkCount       int
 			firstInterface  string
@@ -183,9 +183,9 @@ func TestSetGenericServerBonding(t *testing.T) {
 				})
 			}
 
-			request := CreateLinksWithNewServerRequest{
+			request := CreateLinksWithNewSystemRequest{
 				Links: links,
-				Server: CreateLinksWithNewServerRequestServer{
+				System: CreateLinksWithNewSystemRequestSystem{
 					Hostname:         randString(5, "hex"),
 					Label:            randString(5, "hex"),
 					LogicalDeviceId:  ObjectId(tc.logicalDeviceId),
@@ -194,8 +194,8 @@ func TestSetGenericServerBonding(t *testing.T) {
 					Tags:             hostTags,
 				},
 			}
-			log.Printf("testing CreateLinksWithNewServer() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-			linkIds, err := bpClient.CreateLinksWithNewServer(ctx, &request)
+			log.Printf("testing CreateLinksWithNewSystem() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+			linkIds, err := bpClient.CreateLinksWithNewSystem(ctx, &request)
 			if err != nil {
 				t.Fatalf("test case %d - %s", i, err)
 			}
@@ -211,8 +211,8 @@ func TestSetGenericServerBonding(t *testing.T) {
 			}
 
 			sort.Strings(systemTags)
-			sort.Strings(request.Server.Tags)
-			compareSlices(t, systemTags, request.Server.Tags, fmt.Sprintf("test case %d system tags", i))
+			sort.Strings(request.System.Tags)
+			compareSlices(t, systemTags, request.System.Tags, fmt.Sprintf("test case %d system tags", i))
 
 			var node struct {
 				PoMax int `json:"port_channel_id_max"`
@@ -222,11 +222,11 @@ func TestSetGenericServerBonding(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if request.Server.PortChannelIdMin != node.PoMin {
-				t.Fatalf("expected port channel id min: %d got %d", request.Server.PortChannelIdMin, node.PoMin)
+			if request.System.PortChannelIdMin != node.PoMin {
+				t.Fatalf("expected port channel id min: %d got %d", request.System.PortChannelIdMin, node.PoMin)
 			}
-			if request.Server.PortChannelIdMax != node.PoMax {
-				t.Fatalf("expected port channel id max: %d got %d", request.Server.PortChannelIdMax, node.PoMax)
+			if request.System.PortChannelIdMax != node.PoMax {
+				t.Fatalf("expected port channel id max: %d got %d", request.System.PortChannelIdMax, node.PoMax)
 			}
 
 			originalLinkTagDigests := make([]string, len(request.Links))

--- a/apstra/two_stage_l3_clos_switch_system_links_integration_test.go
+++ b/apstra/two_stage_l3_clos_switch_system_links_integration_test.go
@@ -28,11 +28,6 @@ func TestCreateDeleteServer(t *testing.T) {
 			}
 		}()
 
-		//bpClient, err := client.client.NewTwoStageL3ClosClient(ctx, "c09e3975-6799-41a3-ab1a-d96f93cd5d3e")
-		//if err != nil {
-		//	t.Fatal(err)
-		//}
-
 		leafQuery := new(PathQuery).
 			SetBlueprintId(bpClient.Id()).
 			SetBlueprintType(BlueprintTypeStaging).
@@ -81,15 +76,16 @@ func TestCreateDeleteServer(t *testing.T) {
 			desiredTags = append(desiredTags, randString(5, "hex"))
 		}
 
-		log.Printf("testing CreateLinksWithNewServer() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		linkIds, err := bpClient.CreateLinksWithNewServer(ctx, &CreateLinksWithNewServerRequest{
-			Server: CreateLinksWithNewServerRequestServer{
+		log.Printf("testing CreateLinksWithNewSystem() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		linkIds, err := bpClient.CreateLinksWithNewSystem(ctx, &CreateLinksWithNewSystemRequest{
+			System: CreateLinksWithNewSystemRequestSystem{
 				Hostname:         randString(5, "hex"),
 				Label:            randString(5, "hex"),
 				LogicalDeviceId:  "AOS-2x10-1",
 				PortChannelIdMin: 0,
 				PortChannelIdMax: 0,
 				Tags:             desiredTags,
+				Type:             SystemTypeExternal,
 			},
 			Links: links,
 		})

--- a/apstra/two_stage_l3_clos_switch_system_links_integration_test.go
+++ b/apstra/two_stage_l3_clos_switch_system_links_integration_test.go
@@ -12,7 +12,152 @@ import (
 	"testing"
 )
 
-func TestCreateDeleteServer(t *testing.T) {
+func TestCreateDeleteGenericSystem(t *testing.T) {
+	ctx := context.Background()
+	clients, err := getTestClients(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for clientName, client := range clients {
+		bpClient, bpDel := testBlueprintD(ctx, t, client.client)
+		defer func() {
+			err := bpDel(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		leafQuery := new(PathQuery).
+			SetBlueprintId(bpClient.Id()).
+			SetBlueprintType(BlueprintTypeStaging).
+			SetClient(bpClient.client).
+			Node([]QEEAttribute{
+				NodeTypeRack.QEEAttribute(),
+				{"label", QEStringVal("l2_esi_2x_links_001")},
+			}).
+			In([]QEEAttribute{RelationshipTypePartOfRack.QEEAttribute()}).
+			Node([]QEEAttribute{
+				NodeTypeSystem.QEEAttribute(),
+				{"system_type", QEStringVal("switch")},
+				{"role", QEStringVal("leaf")},
+				{"name", QEStringVal("n_leaf")},
+			})
+
+		var leafResult struct {
+			Items []struct {
+				Leaf struct {
+					Id ObjectId `json:"id"`
+				} `json:"n_leaf"`
+			} `json:"items"`
+		}
+
+		err = leafQuery.Do(ctx, &leafResult)
+		if err != nil {
+			t.Fatal(err)
+		}
+		links := make([]CreateLinkRequest, len(leafResult.Items))
+		for i, item := range leafResult.Items {
+			links[i] = CreateLinkRequest{
+				LagMode:        RackLinkLagModeActive,
+				GroupLabel:     "foo",
+				Tags:           []string{"link blah", "link also blah"},
+				SystemEndpoint: SwitchLinkEndpoint{},
+				SwitchEndpoint: SwitchLinkEndpoint{
+					TransformationId: 1,
+					SystemId:         item.Leaf.Id,
+					IfName:           "xe-0/0/3",
+				},
+			}
+		}
+
+		var desiredTags []string
+		for i := 0; i < rand.Intn(3)+2; i++ {
+			desiredTags = append(desiredTags, randString(5, "hex"))
+		}
+
+		log.Printf("testing CreateLinksWithNewSystem() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		linkIds, err := bpClient.CreateLinksWithNewSystem(ctx, &CreateLinksWithNewSystemRequest{
+			System: CreateLinksWithNewSystemRequestSystem{
+				Hostname:         randString(5, "hex"),
+				Label:            randString(5, "hex"),
+				LogicalDeviceId:  "AOS-2x10-1",
+				PortChannelIdMin: 0,
+				PortChannelIdMax: 0,
+				Tags:             desiredTags,
+				Type:             SystemTypeServer,
+			},
+			Links: links,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		systemId, err := bpClient.SystemNodeFromLinkIds(ctx, linkIds, SystemNodeRoleGeneric)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		observedTags, err := bpClient.GetNodeTags(ctx, systemId)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cmLinks, err := bpClient.GetCablingMapLinksBySystem(ctx, systemId)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var aggregateCount int
+		for i := range cmLinks {
+			if cmLinks[i].Type == LinkTypeAggregateLink {
+				aggregateCount++
+			}
+		}
+
+		if aggregateCount != 1 {
+			t.Fatalf("expected 1 aggregate link, got %d", aggregateCount)
+		}
+
+		sort.Strings(desiredTags)
+		sort.Strings(observedTags)
+		compareSlices(t, desiredTags, observedTags, fmt.Sprintf("generic system tags"))
+
+		newLinks := make([]CreateLinkRequest, len(leafResult.Items))
+		for i, item := range leafResult.Items {
+			newLinks[i] = CreateLinkRequest{
+				LagMode:    RackLinkLagModePassive,
+				GroupLabel: "bar",
+				Tags:       []string{"a", "b"},
+				SystemEndpoint: SwitchLinkEndpoint{
+					SystemId: systemId,
+				},
+				SwitchEndpoint: SwitchLinkEndpoint{
+					TransformationId: 1,
+					SystemId:         item.Leaf.Id,
+					IfName:           "xe-0/0/2",
+				},
+			}
+		}
+
+		log.Printf("testing AddLinksToSystem() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		newLinkIds, err := bpClient.AddLinksToSystem(ctx, newLinks)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(leafResult.Items) != len(newLinkIds) {
+			t.Fatalf("expected %d additional link IDs, got %d", len(leafResult.Items), len(newLinks))
+		}
+
+		log.Printf("testing DeleteGenericSystem() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		err = bpClient.DeleteGenericSystem(ctx, systemId)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestCreateDeleteExternalGenericSystem(t *testing.T) {
 	ctx := context.Background()
 	clients, err := getTestClients(ctx, t)
 	if err != nil {

--- a/apstra/two_stage_l3_clos_switch_system_links_unit_test.go
+++ b/apstra/two_stage_l3_clos_switch_system_links_unit_test.go
@@ -1,0 +1,42 @@
+package apstra
+
+import "testing"
+
+func TestSystemTypeStrings(t *testing.T) {
+	type apiStringIota interface {
+		String() string
+		Int() int
+	}
+
+	type apiIotaString interface {
+		parse() (int, error)
+		string() string
+	}
+
+	type stringTestData struct {
+		stringVal  string
+		intType    apiStringIota
+		stringType apiIotaString
+	}
+	testData := []stringTestData{
+		{stringVal: "external", intType: SystemTypeExternal, stringType: systemTypeExternal},
+		{stringVal: "server", intType: SystemTypeServer, stringType: systemTypeServer},
+		{stringVal: "switch", intType: SystemTypeSwitch, stringType: systemTypeSwitch},
+	}
+
+	for i, td := range testData {
+		ii := td.intType.Int()
+		is := td.intType.String()
+		sp, err := td.stringType.parse()
+		if err != nil {
+			t.Fatal(err)
+		}
+		ss := td.stringType.string()
+		if td.intType.String() != td.stringType.string() ||
+			td.intType.Int() != sp ||
+			td.stringType.string() != td.stringVal {
+			t.Fatalf("test index %d mismatch: %d %d '%s' '%s' '%s'",
+				i, ii, sp, is, ss, td.stringVal)
+		}
+	}
+}


### PR DESCRIPTION
- Change `Server` references to `System` in various structs and methods because the API in question adds Generic Systems, External Generic Systems and Access Switches.
- Add `Type` field to `CreateLinksWithNewSystemRequestSystem` struct
- Add iota type for `Type` field