### PR TITLE
tests

### DIFF
--- a/apstra/api_iba_widgets.go
+++ b/apstra/api_iba_widgets.go
@@ -17,20 +17,20 @@ const (
 type IbaWidgetType enum.Member[string]
 
 var (
-	IbaWidgetTypeStage          = IbaWidgetType{"stage"}
-	IbaWidgetTypeAnomalyHeatmap = IbaWidgetType{"anomaly_heatmap"}
+	IbaWidgetTypeStage          = IbaWidgetType{Value: "stage"}
+	IbaWidgetTypeAnomalyHeatmap = IbaWidgetType{Value: "anomaly_heatmap"}
 	IbaWidgetTypes              = enum.New(IbaWidgetTypeStage, IbaWidgetTypeAnomalyHeatmap)
 )
 
 type IbaWidget struct {
 	Id        ObjectId
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	CreatedAt *time.Time
+	UpdatedAt *time.Time
 	Data      *IbaWidgetData
 }
 
 type IbaWidgetData struct {
-	AggregationPeriod  time.Duration
+	AggregationPeriod  *time.Duration
 	OrderBy            string
 	StageName          string
 	ShowContext        bool
@@ -40,9 +40,9 @@ type IbaWidgetData struct {
 	ProbeId            ObjectId
 	Label              string
 	Filter             string
-	TimeSeriesDuration time.Duration
+	TimeSeriesDuration *time.Duration
 	DataSource         string
-	MaxItems           int
+	MaxItems           *int
 	CombineGraphs      string
 	VisibleColumns     []string
 	Type               IbaWidgetType
@@ -50,47 +50,70 @@ type IbaWidgetData struct {
 }
 
 type rawIbaWidget struct {
-	AggregationPeriod  int      `json:"aggregation_period"`
-	OrderBy            string   `json:"orderby"`
-	StageName          string   `json:"stage_name"`
-	ShowContext        bool     `json:"show_context"`
-	Description        string   `json:"description"`
-	AnomalousOnly      bool     `json:"anomalous_only"`
-	CreatedAt          string   `json:"created_at"`
-	SpotlightMode      bool     `json:"spotlight_mode"`
-	UpdatedAt          string   `json:"updated_at"`
+	AggregationPeriod  *int     `json:"aggregation_period,omitempty"`
+	OrderBy            string   `json:"orderby,omitempty"`
+	StageName          string   `json:"stage_name,omitempty"`
+	ShowContext        bool     `json:"show_context,omitempty"`
+	Description        string   `json:"description,omitempty"`
+	AnomalousOnly      bool     `json:"anomalous_only,omitempty"`
+	CreatedAt          *string  `json:"created_at,omitempty"`
+	SpotlightMode      bool     `json:"spotlight_mode,omitempty"`
+	UpdatedAt          *string  `json:"updated_at,omitempty"`
 	ProbeId            string   `json:"probe_id"`
 	Label              string   `json:"label"`
-	Filter             string   `json:"filter"`
-	TimeSeriesDuration int      `json:"time_series_duration"`
-	DataSource         string   `json:"data_source"`
-	MaxItems           int      `json:"max_items"`
-	CombineGraphs      string   `json:"combine_graphs"`
-	VisibleColumns     []string `json:"visible_columns"`
+	Filter             string   `json:"filter,omitempty"`
+	TimeSeriesDuration *int     `json:"time_series_duration,omitempty"`
+	DataSource         string   `json:"data_source,omitempty"`
+	MaxItems           *int     `json:"max_items,omitempty"`
+	CombineGraphs      string   `json:"combine_graphs,omitempty"`
+	VisibleColumns     []string `json:"visible_columns,omitempty"`
 	Type               string   `json:"type"`
-	Id                 string   `json:"id"`
-	UpdatedBy          string   `json:"updated_by"`
+	Id                 ObjectId `json:"id,omitempty"`
+	UpdatedBy          string   `json:"updated_by,omitempty"`
 }
 
 func (o *rawIbaWidget) polish() (*IbaWidget, error) {
-	created, err := time.Parse("2006-01-02T15:04:05.000000+0000", o.CreatedAt)
-	if err != nil {
-		return nil, fmt.Errorf("failure parsing create time %s - %w", o.CreatedAt, err)
+	var created, updated *time.Time
+
+	if o.CreatedAt != nil {
+		t, err := time.Parse("2006-01-02T15:04:05.000000+0000", *o.CreatedAt)
+		if err != nil {
+			return nil, fmt.Errorf("failure parsing create time %s - %w", *o.CreatedAt, err)
+		}
+		created = &t
 	}
-	updated, err := time.Parse("2006-01-02T15:04:05.000000+0000", o.UpdatedAt)
-	if err != nil {
-		return nil, fmt.Errorf("failure parsing update time %s - %w", o.UpdatedAt, err)
+
+	if o.UpdatedAt != nil {
+		t, err := time.Parse("2006-01-02T15:04:05.000000+0000", *o.UpdatedAt)
+		if err != nil {
+			return nil, fmt.Errorf("failure parsing create time %s - %w", *o.CreatedAt, err)
+		}
+		created = &t
 	}
-	wtype := IbaWidgetTypes.Parse(o.Type)
-	if wtype == nil {
+
+	widgetType := IbaWidgetTypes.Parse(o.Type)
+	if widgetType == nil {
 		return nil, fmt.Errorf("failure to parse returned Iba Widget type %s", o.Type)
 	}
+
+	var aggregationPeriod *time.Duration
+	if o.AggregationPeriod != nil {
+		td := time.Duration(float64(*o.AggregationPeriod) * float64(time.Second))
+		aggregationPeriod = &td
+	}
+
+	var timeSeriesDuration *time.Duration
+	if o.TimeSeriesDuration != nil {
+		td := time.Duration(float64(*o.AggregationPeriod) * float64(time.Second))
+		timeSeriesDuration = &td
+	}
+
 	return &IbaWidget{
-		Id:        ObjectId(o.Id),
+		Id:        o.Id,
 		CreatedAt: created,
 		UpdatedAt: updated,
 		Data: &IbaWidgetData{
-			AggregationPeriod:  time.Duration(float64(o.AggregationPeriod) * float64(time.Second)),
+			AggregationPeriod:  aggregationPeriod,
 			OrderBy:            o.OrderBy,
 			StageName:          o.StageName,
 			ShowContext:        o.ShowContext,
@@ -100,12 +123,12 @@ func (o *rawIbaWidget) polish() (*IbaWidget, error) {
 			ProbeId:            ObjectId(o.ProbeId),
 			Label:              o.Label,
 			Filter:             o.Filter,
-			TimeSeriesDuration: time.Duration(float64(o.TimeSeriesDuration) * float64(time.Second)),
+			TimeSeriesDuration: timeSeriesDuration,
 			DataSource:         o.DataSource,
 			MaxItems:           o.MaxItems,
 			CombineGraphs:      o.CombineGraphs,
 			VisibleColumns:     o.VisibleColumns,
-			Type:               *wtype,
+			Type:               *widgetType,
 			UpdatedBy:          o.UpdatedBy,
 		},
 	}, nil
@@ -127,11 +150,11 @@ func (o *Client) getAllIbaWidgets(ctx context.Context, bp_id ObjectId) ([]rawIba
 	return response.Items, nil
 }
 
-func (o *Client) getIbaWidget(ctx context.Context, bp_id ObjectId, id ObjectId) (*rawIbaWidget, error) {
+func (o *Client) getIbaWidget(ctx context.Context, bpId ObjectId, id ObjectId) (*rawIbaWidget, error) {
 	response := &rawIbaWidget{}
 	err := o.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodGet,
-		urlStr:      fmt.Sprintf(apiUrlIbaWidgetsById, bp_id, id),
+		urlStr:      fmt.Sprintf(apiUrlIbaWidgetsById, bpId, id),
 		apiResponse: response,
 	})
 	if err != nil {
@@ -140,8 +163,8 @@ func (o *Client) getIbaWidget(ctx context.Context, bp_id ObjectId, id ObjectId) 
 	return response, nil
 }
 
-func (o *Client) getIbaWidgetsByLabel(ctx context.Context, bp_id ObjectId, label string) ([]rawIbaWidget, error) {
-	allIbaWidgets, err := o.getAllIbaWidgets(ctx, bp_id)
+func (o *Client) getIbaWidgetsByLabel(ctx context.Context, bpId ObjectId, label string) ([]rawIbaWidget, error) {
+	allIbaWidgets, err := o.getAllIbaWidgets(ctx, bpId)
 	if err != nil {
 		return nil, convertTtaeToAceWherePossible(err)
 	}
@@ -160,4 +183,26 @@ func (o *Client) getIbaWidgetsByLabel(ctx context.Context, bp_id ObjectId, label
 		}
 	}
 	return result, nil
+}
+
+func (o *Client) getIbaWidgetByLabel(ctx context.Context, bpId ObjectId, label string) (*rawIbaWidget, error) {
+	rawWidgets, err := o.getIbaWidgetsByLabel(ctx, bpId, label)
+	if err != nil {
+		return nil, err
+	}
+
+	switch len(rawWidgets) {
+	case 0:
+		return nil, ClientErr{
+			errType: ErrNotfound,
+			err:     fmt.Errorf("IBA widget with label %q not found in blueprint %q", label, bpId),
+		}
+	case 1:
+		return &rawWidgets[0], nil
+	}
+
+	return nil, ClientErr{
+		errType: ErrMultipleMatch,
+		err:     fmt.Errorf("multiple IBA widget with label %q found in blueprint %q", label, bpId),
+	}
 }

--- a/apstra/api_iba_widgets.go
+++ b/apstra/api_iba_widgets.go
@@ -24,8 +24,8 @@ var (
 
 type IbaWidget struct {
 	Id        ObjectId
-	CreatedAt *time.Time
-	UpdatedAt *time.Time
+	CreatedAt time.Time
+	UpdatedAt time.Time
 	Data      *IbaWidgetData
 }
 
@@ -73,14 +73,14 @@ type rawIbaWidget struct {
 }
 
 func (o *rawIbaWidget) polish() (*IbaWidget, error) {
-	var created, updated *time.Time
+	var created, updated time.Time
 
 	if o.CreatedAt != nil {
 		t, err := time.Parse("2006-01-02T15:04:05.000000+0000", *o.CreatedAt)
 		if err != nil {
 			return nil, fmt.Errorf("failure parsing create time %s - %w", *o.CreatedAt, err)
 		}
-		created = &t
+		created = t
 	}
 
 	if o.UpdatedAt != nil {
@@ -88,7 +88,7 @@ func (o *rawIbaWidget) polish() (*IbaWidget, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failure parsing create time %s - %w", *o.CreatedAt, err)
 		}
-		created = &t
+		created = t
 	}
 
 	widgetType := IbaWidgetTypes.Parse(o.Type)

--- a/apstra/api_iba_widgets_test.go
+++ b/apstra/api_iba_widgets_test.go
@@ -5,7 +5,9 @@ package apstra
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"net/http"
 	"testing"
 )
 
@@ -14,44 +16,137 @@ func TestIbaWidgetsGet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx := context.TODO()
+	ctx := context.Background()
 	for clientName, client := range clients {
 		log.Printf("testing GetAllIbaWidgets against %s %s (%s)", client.clientType, clientName,
 			client.client.ApiVersion())
 
-		bpids, err := client.client.ListAllBlueprintIds(ctx)
+		bpClient, bpDelete := testBlueprintA(ctx, t, client.client)
+		defer bpDelete(ctx)
+		var idResponse objectIdResponse
+
+		probeA := struct {
+			Label     string `json:"label"`
+			Duration  int    `json:"duration"`
+			Threshold int    `json:"threshold"`
+		}{
+			Label:     "BGP Session Flapping",
+			Duration:  300,
+			Threshold: 40,
+		}
+		probeAUrlStr := fmt.Sprintf(apiUrlBlueprintByIdPrefix, bpClient.blueprintId) + "iba/predefined-probes/bgp_session"
+
+		probeB := struct {
+			Label     string `json:"label"`
+			Threshold int    `json:"threshold"`
+		}{
+			Label:     "Drain Traffic Anomaly",
+			Threshold: 100000,
+		}
+		probeBUrlStr := fmt.Sprintf(apiUrlBlueprintByIdPrefix, bpClient.blueprintId) + "iba/predefined-probes/drain_node_traffic_anomaly"
+
+		err = client.client.talkToApstra(ctx, &talkToApstraIn{
+			method:         http.MethodPost,
+			urlStr:         probeAUrlStr,
+			apiInput:       &probeA,
+			apiResponse:    &idResponse,
+			doNotLogin:     false,
+			unsynchronized: false,
+		})
 		if err != nil {
 			t.Fatal(err)
+		}
+		probeAId := idResponse.Id
+
+		err = client.client.talkToApstra(ctx, &talkToApstraIn{
+			method:         http.MethodPost,
+			urlStr:         probeBUrlStr,
+			apiInput:       &probeB,
+			apiResponse:    &idResponse,
+			doNotLogin:     false,
+			unsynchronized: false,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		probeBId := idResponse.Id
+
+		widgetA := rawIbaWidget{
+			Type:      "stage",
+			Label:     probeA.Label,
+			ProbeId:   probeAId.String(),
+			StageName: "BGP Session",
 		}
 
-		// IBA probes will not exist until the blueprint is deployed. This test expects that there will be a blueprint
-		// with existing IBA probes
-		bpClient, err := client.client.NewTwoStageL3ClosClient(ctx, bpids[0])
+		widgetB := rawIbaWidget{
+			Type:      "stage",
+			Label:     probeB.Label,
+			ProbeId:   probeBId.String(),
+			StageName: "excess_range",
+		}
+
+		err = client.client.talkToApstra(ctx, &talkToApstraIn{
+			method:      http.MethodPost,
+			urlStr:      fmt.Sprintf(apiUrlBlueprintByIdPrefix, bpClient.blueprintId) + "iba/widgets",
+			apiInput:    &widgetA,
+			apiResponse: &idResponse,
+		})
 		if err != nil {
 			t.Fatal(err)
 		}
+		widgetAId := idResponse.Id
+
+		err = client.client.talkToApstra(ctx, &talkToApstraIn{
+			method:      http.MethodPost,
+			urlStr:      fmt.Sprintf(apiUrlBlueprintByIdPrefix, bpClient.blueprintId) + "iba/widgets",
+			apiInput:    &widgetB,
+			apiResponse: &idResponse,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		widgetBId := idResponse.Id
 
 		widgets, err := bpClient.GetAllIbaWidgets(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if len(widgets) <= 0 {
-			t.Fatalf("only got %d widgets", len(widgets))
+		if len(widgets) != 2 {
+			t.Fatalf("expected 2 widgets, got %d widgets", len(widgets))
 		}
-		for _, w := range widgets {
-			ws, err := bpClient.GetIbaWidgetsByLabel(ctx, w.Data.Label)
+
+		wa, err := bpClient.GetIbaWidget(ctx, widgetAId)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if wa.Id != widgetAId {
+			t.Fatalf("expected wiget A ID %q, got %q", widgetAId, wa.Id)
+		}
+		if wa.Data.Label != widgetA.Label {
+			t.Fatalf("expected wiget A Label %q, got %q", widgetA.Label, wa.Data.Label)
+		}
+
+		wb, err := bpClient.GetIbaWidget(ctx, widgetBId)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if wb.Id != widgetBId {
+			t.Fatalf("expected wiget B ID %q, got %q", widgetBId, wb.Id)
+		}
+		if wb.Data.Label != widgetB.Label {
+			t.Fatalf("expected wiget B Label %q, got %q", widgetB.Label, wb.Data.Label)
+		}
+
+		for _, widget := range widgets {
+			ws, err := bpClient.GetIbaWidgetByLabel(ctx, widget.Data.Label)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if len(ws) > 1 {
-				t.Fatalf("Was expecting only 1 widget with name %s got %d", w.Data.Label, len(ws))
-			}
-			if ws[0].Id != w.Id {
+			if ws.Id != widget.Id {
 				t.Fatalf("GetIbaWidgetsByLabel returned a different id than the original. Expected %s. Got %s",
-					w.Id, ws[0].Id)
+					widget.Id, ws.Id)
 			}
-			t.Logf("Found Widget Label %s ID %s type %s", w.Id, w.Data.Label, w.Data.Type)
 		}
 	}
 }

--- a/apstra/test_clients_test.go
+++ b/apstra/test_clients_test.go
@@ -18,6 +18,7 @@ const (
 
 	envCloudlabsTopologyIdSep = ":"
 	envApstraApiKeyLogFile    = "SSLKEYLOGFILE"
+	envApstraExperimental     = "APSTRA_EXPERIMENTAL"
 )
 
 type testClientCfg struct {
@@ -40,6 +41,12 @@ func getTestClients(ctx context.Context, t *testing.T) (map[string]testClient, e
 	clientCfgs, err := getTestClientCfgs(ctx)
 	if err != nil {
 		return nil, err
+	}
+
+	if _, ok := os.LookupEnv(envApstraExperimental); ok {
+		for k := range clientCfgs {
+			clientCfgs[k].cfg.Experimental = true
+		}
 	}
 
 	testClients = make(map[string]testClient, len(clientCfgs))

--- a/apstra/two_stage_l3_clos_client.go
+++ b/apstra/two_stage_l3_clos_client.go
@@ -605,6 +605,17 @@ func (o *TwoStageL3ClosClient) GetAllIbaWidgets(ctx context.Context) ([]IbaWidge
 	return widgets, nil
 }
 
+// GetIbaWidgetByLabel returns the IBA Widgets in the blueprint which matches the specified
+// label, or an error in the case of no matches, or multiple matches
+func (o *TwoStageL3ClosClient) GetIbaWidgetByLabel(ctx context.Context, label string) (*IbaWidget, error) {
+	rawWidget, err := o.client.getIbaWidgetByLabel(ctx, o.blueprintId, label)
+	if err != nil {
+		return nil, err
+	}
+
+	return rawWidget.polish()
+}
+
 // GetIbaWidgetsByLabel returns a list of IBA Widgets in the blueprint that match the label
 func (o *TwoStageL3ClosClient) GetIbaWidgetsByLabel(ctx context.Context, label string) ([]IbaWidget, error) {
 	rawWidgets, err := o.client.getIbaWidgetsByLabel(ctx, o.blueprintId, label)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.19.3
 	github.com/google/go-licenses v1.6.0
 	github.com/google/uuid v1.3.0
+	github.com/orsinium-labs/enum v1.3.0
 	google.golang.org/protobuf v1.30.0
 )
 
@@ -30,7 +31,6 @@ require (
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
-	github.com/orsinium-labs/enum v1.3.0 // indirect
 	github.com/otiai10/copy v1.6.0 // indirect
 	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/spf13/cobra v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -251,6 +251,7 @@ github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/matryer/is v1.4.1 h1:55ehd8zaGABKLXQUe2awZ99BD/PTc2ls+KV/dXphgEQ=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=


### PR DESCRIPTION
Added struct field name (`Value`) to Enum creation.

Changed various widget struct fields from object to pointer so the could be used with `omitempty` when sent to API. String types were not among these., making it impossible to send an empty string. If sending an empty string becomes interesting we'll have to change those to pointers as well.

Added `GetWidgetByLabel()` (singular) methods to complement `GetWidgetsByLabel()` (plural).

Added creation of dependencies to IBA widget test: blueprint, probes, widgets.

Added check for `APSTRA_EXPERIMENTAL` env var to test client code for testing against 4.2.0