### PR TITLE
change `RtPolicy` RT elements from `ObjectId` to `string`

### DIFF
--- a/apstra/types.go
+++ b/apstra/types.go
@@ -31,6 +31,6 @@ func (o VNI) validate() error {
 }
 
 type RtPolicy struct {
-	ImportRTs []ObjectId `json:"import_RTs"`
-	ExportRTs []ObjectId `json:"export_RTs"`
+	ImportRTs []string `json:"import_RTs"`
+	ExportRTs []string `json:"export_RTs"`
 }


### PR DESCRIPTION
`ImportRTs` and `ExportRTs` are strings of the form `"123:456"`.

They should not have been `ObjectId` type. They don't seem to be used anywhere except in a test related to Virtual Networks, which still passes against versions 4.1.0, 4.1.1, 4.1.2 and 4.2.0.

Closes #144 