### PR TITLE
Add support for Apstra 4.2 SZ EVPN IRB symmetry mode

### DIFF
--- a/apstra/compatibility.go
+++ b/apstra/compatibility.go
@@ -11,6 +11,9 @@ const (
 	rackBasedTemplateFabricAddressingPolicyForbiddenVersions = "4.1.1, 4.1.2"
 
 	integerPoolForbiddenVersions = "4.1.0, 4.1.1"
+
+	securityZoneJunosEvpnIrbModeRequiredVersions = "4.2.0"
+	securityZoneJunosEvpnIrbModeRequiredError    = "junos_evpn_irb_mode is required by Apstra 4.2 and later"
 )
 
 func parseVersionList(s string) StringSliceWithIncludes {
@@ -46,6 +49,10 @@ func podBasedTemplateFabricAddressingPolicyForbidden() StringSliceWithIncludes {
 
 func integerPoolForbidden() StringSliceWithIncludes {
 	return parseVersionList(integerPoolForbiddenVersions)
+}
+
+func securityZoneJunosEvpnIrbModeRequired() StringSliceWithIncludes {
+	return parseVersionList(securityZoneJunosEvpnIrbModeRequiredVersions)
 }
 
 // ApstraApiSupportedVersions returns the Apstra versions supported by this

--- a/apstra/two_stage_l3_clos_client.go
+++ b/apstra/two_stage_l3_clos_client.go
@@ -149,6 +149,10 @@ func (o *TwoStageL3ClosClient) SetInterfaceMapAssignments(ctx context.Context, a
 
 // CreateSecurityZone creates an Apstra Routing Zone / Security Zone / VRF
 func (o *TwoStageL3ClosClient) CreateSecurityZone(ctx context.Context, cfg *SecurityZoneData) (ObjectId, error) {
+	if cfg.JunosEvpnIrbMode == nil && securityZoneJunosEvpnIrbModeRequired().Includes(o.client.apiVersion) {
+		return "", errors.New(securityZoneJunosEvpnIrbModeRequiredError)
+	}
+
 	response, err := o.createSecurityZone(ctx, cfg.raw())
 	if err != nil {
 		return "", err
@@ -238,6 +242,10 @@ func (o *TwoStageL3ClosClient) GetAllSecurityZones(ctx context.Context) ([]Secur
 
 // UpdateSecurityZone replaces the configuration of zone zoneId with the supplied CreateSecurityZoneCfg
 func (o *TwoStageL3ClosClient) UpdateSecurityZone(ctx context.Context, zoneId ObjectId, cfg *SecurityZoneData) error {
+	if cfg.JunosEvpnIrbMode == nil && securityZoneJunosEvpnIrbModeRequired().Includes(o.client.apiVersion) {
+		return errors.New(securityZoneJunosEvpnIrbModeRequiredError)
+	}
+
 	return o.updateSecurityZone(ctx, zoneId, cfg.raw())
 }
 

--- a/apstra/two_stage_l3_clos_security_zones_integration_test.go
+++ b/apstra/two_stage_l3_clos_security_zones_integration_test.go
@@ -74,10 +74,9 @@ func TestCreateUpdateDeleteRoutingZone(t *testing.T) {
 		label2 := "test-" + randStr2
 		log.Printf("testing UpdateSecurityZone() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		err = bpClient.UpdateSecurityZone(ctx, zoneId, &SecurityZoneData{
-			SzType:  SecurityZoneTypeEVPN,
-			VrfName: vrfName2,
-			Label:   label2,
-			//JunosEvpnIrbMode: junosEvpnIrbMode,
+			SzType:           SecurityZoneTypeEVPN,
+			VrfName:          vrfName2,
+			Label:            label2,
 			JunosEvpnIrbMode: &JunosEvpnIrbModeAsymmetric,
 		})
 		if err != nil {

--- a/apstra/two_stage_l3_clos_security_zones_integration_test.go
+++ b/apstra/two_stage_l3_clos_security_zones_integration_test.go
@@ -33,9 +33,10 @@ func TestCreateUpdateDeleteRoutingZone(t *testing.T) {
 
 		log.Printf("testing CreateSecurityZone() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		zoneId, err := bpClient.CreateSecurityZone(ctx, &SecurityZoneData{
-			SzType:  SecurityZoneTypeEVPN,
-			VrfName: vrfName,
-			Label:   label,
+			SzType:           SecurityZoneTypeEVPN,
+			VrfName:          vrfName,
+			Label:            label,
+			JunosEvpnIrbMode: &JunosEvpnIrbModeSymmetric,
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -62,6 +63,11 @@ func TestCreateUpdateDeleteRoutingZone(t *testing.T) {
 		if zone.Id != zoneId {
 			t.Fatalf("created vs. fetched zone IDs don't match: '%s' and '%s'", zone.Id, zoneId)
 		}
+		if securityZoneJunosEvpnIrbModeRequired().Includes(client.client.apiVersion) {
+			if zone.Data.JunosEvpnIrbMode.Value != JunosEvpnIrbModeSymmetric.Value {
+				t.Fatal()
+			}
+		}
 
 		randStr2 := randString(5, "hex")
 		vrfName2 := "test-" + randStr2
@@ -71,6 +77,8 @@ func TestCreateUpdateDeleteRoutingZone(t *testing.T) {
 			SzType:  SecurityZoneTypeEVPN,
 			VrfName: vrfName2,
 			Label:   label2,
+			//JunosEvpnIrbMode: junosEvpnIrbMode,
+			JunosEvpnIrbMode: &JunosEvpnIrbModeAsymmetric,
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -85,6 +93,10 @@ func TestCreateUpdateDeleteRoutingZone(t *testing.T) {
 			t.Fatal()
 		}
 		if zone.Data.VrfName != vrfName2 {
+			t.Fatal()
+		}
+		if securityZoneJunosEvpnIrbModeRequired().Includes(client.client.apiVersion) &&
+			zone.Data.JunosEvpnIrbMode.Value != JunosEvpnIrbModeAsymmetric.Value {
 			t.Fatal()
 		}
 


### PR DESCRIPTION
This PR introduces support for Apstra 4.2 Security Zone EVPN IRB symmetry mode.

Closes #153