### PR TITLE
Add enum `DeviceProfileTypes` for parsing/enumeration of device profile type strings

### DIFF
--- a/apstra/api_device_profiles_modular.go
+++ b/apstra/api_device_profiles_modular.go
@@ -12,6 +12,7 @@ type DeviceProfileType enum.Member[string]
 var (
 	DeviceProfileTypeModular    = DeviceProfileType{Value: "modular"}
 	DeviceProfileTypeMonolithic = DeviceProfileType{Value: "monolithic"}
+	DeviceProfileTypes          = enum.New(DeviceProfileTypeModular, DeviceProfileTypeMonolithic)
 )
 
 type rawModularDeviceSlotConfiguration struct {


### PR DESCRIPTION
This should have been in #141.

Closes #156