### PR TITLE
Tech Debt: Eliminate AgentMode iota type - this is a breaking change!

### DIFF
--- a/apstra/api_system_agents_test.go
+++ b/apstra/api_system_agents_test.go
@@ -112,6 +112,7 @@ func TestCreateDeleteSwitchAgent(t *testing.T) {
 				Platform:        testSwitch.platform,
 				Label:           label,
 				AgentTypeOffbox: testSwitch.platform.offbox(),
+				OperationMode:   SystemManagementLevelFullControl,
 			})
 			if err != nil {
 				ace := &ClientErr{}
@@ -257,8 +258,6 @@ func TestSystemAgentsStrings(t *testing.T) {
 		{stringVal: "connected", intType: AgentCxnStateConnected, stringType: agentCxnStateConnected},
 		{stringVal: "disconnected", intType: AgentCxnStateDisconnected, stringType: agentCxnStateDisconnected},
 		{stringVal: "auth_failed", intType: AgentCxnStateAuthFail, stringType: agentCxnStateAuthFail},
-		{stringVal: "full_control", intType: AgentModeFull, stringType: agentModeFull},
-		{stringVal: "telemetry_only", intType: AgentModeTelemetry, stringType: agentModeTelemetry},
 
 		{stringVal: "", intType: AgentJobTypeNull, stringType: agentJobTypeNull},
 		{stringVal: "none", intType: AgentJobTypeNone, stringType: agentJobTypeNone},

--- a/apstra/api_systems.go
+++ b/apstra/api_systems.go
@@ -182,13 +182,18 @@ func (o *rawManagedSystemInfo) polish() (*ManagedSystemInfo, error) {
 		return nil, err
 	}
 
+	status, err := o.Status.polish()
+	if err != nil {
+		return nil, err
+	}
+
 	return &ManagedSystemInfo{
 		ContainerStatus: o.ContainerStatus,
 		DeviceKey:       o.DeviceKey,
 		Facts:           o.Facts,
 		Id:              o.Id,
 		Services:        o.Services,
-		Status:          *o.Status.polish(),
+		Status:          *status,
 		UserConfig:      *userConfig,
 	}, nil
 }
@@ -223,36 +228,41 @@ type SystemFacts struct {
 }
 
 type SystemStatus struct {
-	AgentStartTime  time.Time `json:"agent_start_time"`
-	CommState       string    `json:"comm_state"`
-	DeviceStartTime time.Time `json:"device_start_time"`
-	ErrorMessage    string    `json:"error_message"`
-	IsAcknowledged  bool      `json:"is_acknowledged"`
-	OperationMode   AgentMode `json:"operation_mode"`
-	State           string    `json:"state"`
+	AgentStartTime  time.Time             `json:"agent_start_time"`
+	CommState       string                `json:"comm_state"`
+	DeviceStartTime time.Time             `json:"device_start_time"`
+	ErrorMessage    string                `json:"error_message"`
+	IsAcknowledged  bool                  `json:"is_acknowledged"`
+	OperationMode   SystemManagementLevel `json:"operation_mode"`
+	State           string                `json:"state"`
 }
 
 type rawSystemStatus struct {
-	AgentStartTime  time.Time        `json:"agent_start_time"`
-	CommState       string           `json:"comm_state"`
-	DeviceStartTime time.Time        `json:"device_start_time"`
-	ErrorMessage    string           `json:"error_message"`
-	IsAcknowledged  bool             `json:"is_acknowledged"`
-	OperationMode   rawAgentMode     `json:"operation_mode"`
-	State           string           `json:"state"`
-	UserConfig      SystemUserConfig `json:"user_config"`
+	AgentStartTime  time.Time             `json:"agent_start_time"`
+	CommState       string                `json:"comm_state"`
+	DeviceStartTime time.Time             `json:"device_start_time"`
+	ErrorMessage    string                `json:"error_message"`
+	IsAcknowledged  bool                  `json:"is_acknowledged"`
+	OperationMode   systemManagementLevel `json:"operation_mode"`
+	State           string                `json:"state"`
+	UserConfig      SystemUserConfig      `json:"user_config"`
 }
 
-func (o *rawSystemStatus) polish() *SystemStatus {
+func (o *rawSystemStatus) polish() (*SystemStatus, error) {
+	operationMode, err := o.OperationMode.parse()
+	if err != nil {
+		return nil, err
+	}
+
 	return &SystemStatus{
 		AgentStartTime:  o.AgentStartTime,
 		CommState:       o.CommState,
 		DeviceStartTime: o.DeviceStartTime,
 		ErrorMessage:    o.ErrorMessage,
 		IsAcknowledged:  o.IsAcknowledged,
-		OperationMode:   AgentMode(o.OperationMode.parse()),
+		OperationMode:   SystemManagementLevel(operationMode),
 		State:           o.State,
-	}
+	}, nil
 }
 
 type systemUpdate struct {

--- a/apstra/test_clients_cloudlabs_test.go
+++ b/apstra/test_clients_cloudlabs_test.go
@@ -24,6 +24,7 @@ const (
 	vSwitchTypeNexus  = "nxosv"
 	vSwitchTypeSonic  = "sonic-vs"
 	vSwitchTypeQfx    = "vqfx"
+	vSwitchTypeVmx    = "vmx"
 )
 
 type cloudlabsDeviceType string
@@ -35,6 +36,8 @@ func (o cloudlabsDeviceType) platform() AgentPlatform {
 	case vSwitchTypeNexus:
 		return AgentPlatformNXOS
 	case vSwitchTypeQfx:
+		return AgentPlatformJunos
+	case vSwitchTypeVmx:
 		return AgentPlatformJunos
 	default:
 		return AgentPlatformNull
@@ -216,6 +219,7 @@ func (o *cloudlabsTopology) getSwitchInfo() ([]cloudlabsSwitchInfo, error) {
 		case vSwitchTypeNexus:
 		case vSwitchTypeSonic:
 		case vSwitchTypeQfx:
+		case vSwitchTypeVmx:
 		default:
 			continue
 		}


### PR DESCRIPTION
We wound up with two iota types for strings like `full_control`, `telemetry_only`, and `unmanaged`:

- `AgentMode` / `rawAgentMode`
- `SystemManagementLevel` / `systemManagementLevel`

This PR eliminates agent mode, converts uses of it to use system management level instead. This conversion required some new error returns in various private `polish()` methods.

A test broke, due to a different "zero value" in `SystemManagementLevel`, and testing also revealed that CloudLabs has introduced a new switch type: `vmx`, so that's been added to our test suite.

The terraform provider will need to be updated to use `SystemManagementLevel`

Closes #114