### PR TITLE
Add `httpBodyWriter` to `talkToApstraIn`

### DIFF
--- a/apstra/talk_to_apstra.go
+++ b/apstra/talk_to_apstra.go
@@ -228,7 +228,7 @@ func (o *Client) talkToApstra(ctx context.Context, in *talkToApstraIn) error {
 	// noinspection GoUnhandledErrorResult
 	defer resp.Body.Close()
 
-	// If the caller gave us an io.Writer, copy the response body into it and return
+	// If the caller gave us an httpBodyWriter, copy the response body into it and return
 	if in.httpBodyWriter != nil {
 		_, err := io.CopyBuffer(in.httpBodyWriter, resp.Body, nil)
 		if err != nil {

--- a/apstra/talk_to_apstra.go
+++ b/apstra/talk_to_apstra.go
@@ -234,6 +234,7 @@ func (o *Client) talkToApstra(ctx context.Context, in *talkToApstraIn) error {
 		if err != nil {
 			return fmt.Errorf("error while reading http response body - %w", err)
 		}
+		return nil
 	}
 
 	// figure out whether Apstra responded with a task ID

--- a/apstra/talk_to_apstra.go
+++ b/apstra/talk_to_apstra.go
@@ -32,6 +32,7 @@ type talkToApstraIn struct {
 	apiResponse    interface{} // if non-nil we'll JSON decode Apstra response here
 	doNotLogin     bool        // when set, Client will not attempt login (we set for anti-recursion)
 	unsynchronized bool        // default behavior is to send apstraApiAsyncParamValFull, block until task completion
+	httpBodyWriter io.Writer   // when non-nil, http body will be written here instead of unpacked into apiResponse
 }
 
 type apstraErr struct {
@@ -218,11 +219,24 @@ func (o *Client) talkToApstra(ctx context.Context, in *talkToApstraIn) error {
 
 			// Try the request again
 			in.doNotLogin = true
-			// todo - reusing the context here is not great
 			return o.talkToApstra(ctx, in)
 		} // HTTP 401
 
 		return newTalkToApstraErr(req, requestBody, resp, "")
+	}
+
+	// If the caller gave us an io.Writer, copy the response body into it and return
+	if in.httpBodyWriter != nil {
+		_, err := io.CopyBuffer(in.httpBodyWriter, resp.Body, nil)
+		if err != nil {
+			return fmt.Errorf("error while reading http response body - %w", err)
+		}
+
+		err = resp.Body.Close()
+		if err != nil {
+			return fmt.Errorf("error while closing http response body - %w", err)
+		}
+		return nil
 	}
 
 	// noinspection GoUnhandledErrorResult

--- a/apstra/talk_to_apstra.go
+++ b/apstra/talk_to_apstra.go
@@ -225,22 +225,16 @@ func (o *Client) talkToApstra(ctx context.Context, in *talkToApstraIn) error {
 		return newTalkToApstraErr(req, requestBody, resp, "")
 	}
 
+	// noinspection GoUnhandledErrorResult
+	defer resp.Body.Close()
+
 	// If the caller gave us an io.Writer, copy the response body into it and return
 	if in.httpBodyWriter != nil {
 		_, err := io.CopyBuffer(in.httpBodyWriter, resp.Body, nil)
 		if err != nil {
 			return fmt.Errorf("error while reading http response body - %w", err)
 		}
-
-		err = resp.Body.Close()
-		if err != nil {
-			return fmt.Errorf("error while closing http response body - %w", err)
-		}
-		return nil
 	}
-
-	// noinspection GoUnhandledErrorResult
-	defer resp.Body.Close()
 
 	// figure out whether Apstra responded with a task ID
 	var tIdR taskIdResponse


### PR DESCRIPTION
The new `httpBodyWriter` element of `talkToApstraIn` allows callers of `talkToApstra` to access the raw http response body from Apstra.

Previously, the only way callers could access Apstra's reply was by supplying the `apiResponse` element, which would be filled by unpacking the API's JSON response.

When `httpBodyWriter` is not nil, `TalkToApstra()` will complete the transaction, check for a non-error HTTP response code, and then send the http response body into `httpBodyWriter` using `io.CopyBuffer`.

The http body will NOT be unpacked into `apiResponse` when `httpBodyWriter` is not nil.