### PR TITLE
Raw query result handling

### DIFF
--- a/apstra/query_engine.go
+++ b/apstra/query_engine.go
@@ -17,12 +17,15 @@ const (
 type QEQuery interface {
 	Do(context.Context, interface{}) error
 	String() string
+	RawResult() []byte
 	getBlueprintType() BlueprintType
 	setOptional()
+	setRawResult([]byte)
 }
 
 var _ QEQuery = &PathQuery{}
 var _ QEQuery = &MatchQuery{}
+var _ QEQuery = &RawQuery{}
 
 type QEEType int
 
@@ -164,6 +167,7 @@ type PathQuery struct {
 	blueprintType BlueprintType
 	where         []string
 	optional      bool
+	rawResult     []byte
 }
 
 func (o *PathQuery) getBlueprintType() BlueprintType {
@@ -174,8 +178,16 @@ func (o *PathQuery) setOptional() {
 	o.optional = true
 }
 
+func (o *PathQuery) setRawResult(in []byte) {
+	o.rawResult = in
+}
+
 func (o *PathQuery) Do(ctx context.Context, response interface{}) error {
 	return o.client.runQuery(ctx, o.blueprintId, o, response)
+}
+
+func (o *PathQuery) RawResult() []byte {
+	return o.rawResult
 }
 
 func (o *PathQuery) SetBlueprintId(id ObjectId) *PathQuery {
@@ -287,6 +299,7 @@ type MatchQuery struct {
 	firstElement  *MatchQueryElement
 	where         []string
 	optional      bool
+	rawResult     []byte
 }
 
 //func (o *MatchQuery) Having(v QEAttrVal) *MatchQuery          {} // todo
@@ -320,11 +333,19 @@ func (o *MatchQuery) setOptional() {
 	o.optional = true
 }
 
+func (o *MatchQuery) setRawResult(in []byte) {
+	o.rawResult = in
+}
+
 func (o *MatchQuery) Do(ctx context.Context, response interface{}) error {
 	if o.client == nil {
 		return errors.New("attempt to execute query without setting client")
 	}
 	return o.client.runQuery(ctx, o.blueprintId, o, response)
+}
+
+func (o *MatchQuery) RawResult() []byte {
+	return o.rawResult
 }
 
 func (o *MatchQuery) SetBlueprintId(id ObjectId) *MatchQuery {
@@ -394,6 +415,7 @@ type RawQuery struct {
 	blueprintId   ObjectId
 	blueprintType BlueprintType
 	optional      bool
+	rawResult     []byte
 }
 
 func (o *RawQuery) getBlueprintType() BlueprintType {
@@ -404,8 +426,16 @@ func (o *RawQuery) setOptional() {
 	o.optional = true
 }
 
+func (o *RawQuery) setRawResult(in []byte) {
+	o.rawResult = in
+}
+
 func (o *RawQuery) Do(ctx context.Context, response interface{}) error {
 	return o.client.runQuery(ctx, o.blueprintId, o, response)
+}
+
+func (o *RawQuery) RawResult() []byte {
+	return o.rawResult
 }
 
 func (o *RawQuery) SetBlueprintId(id ObjectId) *RawQuery {

--- a/apstra/query_engine_test.go
+++ b/apstra/query_engine_test.go
@@ -5,7 +5,9 @@ package apstra
 
 import (
 	"context"
+	"encoding/json"
 	"log"
+	"reflect"
 	"testing"
 )
 
@@ -473,6 +475,59 @@ func TestRawQuery(t *testing.T) {
 		qo := q.String()
 		if tc.expected != qs {
 			t.Fatalf("test %d with optional expected %q, got %q", i, tc.expectedWithOptional, qo)
+		}
+	}
+}
+
+func TestRawQueryWithBlueprint(t *testing.T) {
+	ctx := context.Background()
+	clients, err := getTestClients(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for clientName, client := range clients {
+		bpClient, bpDel := testBlueprintA(ctx, t, client.client)
+		defer func() {
+			err = bpDel(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		query := new(RawQuery).
+			SetBlueprintType(BlueprintTypeStaging).
+			SetClient(client.
+				client).
+			SetBlueprintId(bpClient.Id()).
+			SetQuery("node(type='system', role='leaf', name='n_system')")
+
+		var queryResponse struct {
+			Count int `json:"count"`
+			Items []struct {
+				System struct {
+					Id    string `json:"id"`
+					Label string `json:"label"`
+				} `json:"n_system"`
+			} `json:"items"`
+		}
+
+		log.Printf("testing raw query against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		err := query.Do(ctx, &queryResponse)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		qr1 := queryResponse
+
+		err = json.Unmarshal(query.RawResult(), &queryResponse)
+		if err != nil {
+			t.Fatal(err)
+		}
+		qr2 := queryResponse
+
+		if !reflect.DeepEqual(qr1, qr2) {
+			t.Fatalf("qr1 and qr2 should be equal, got:\n%q\n\nand:\n%q", qr1, qr2)
 		}
 	}
 }

--- a/apstra/query_engine_test.go
+++ b/apstra/query_engine_test.go
@@ -497,8 +497,7 @@ func TestRawQueryWithBlueprint(t *testing.T) {
 
 		query := new(RawQuery).
 			SetBlueprintType(BlueprintTypeStaging).
-			SetClient(client.
-				client).
+			SetClient(client.client).
 			SetBlueprintId(bpClient.Id()).
 			SetQuery("node(type='system', role='leaf', name='n_system')")
 


### PR DESCRIPTION
This PR adds two new methods to the `QEQuery` interface:

- `RawResult() []byte`
- `setRawResult([]byte)`

Additionally, each implementation of `QEQuery` now sports a new attribute to handle the raw HTTP response:
- `rawResult []byte`

`Client.runQuery()` now uses the new `httpBodyWriter` to collect the HTTP response body ([]byte) into `rawResult`, making the raw HTTP response available to its callers.