### PR TITLE
introduce `PatchNodes()`

### DIFF
--- a/apstra/api_blueprints.go
+++ b/apstra/api_blueprints.go
@@ -520,3 +520,16 @@ func (o *Client) patchNode(ctx context.Context, blueprint ObjectId, node ObjectI
 	})
 	return convertTtaeToAceWherePossible(err)
 }
+
+func (o *Client) patchNodes(ctx context.Context, blueprint ObjectId, request []interface{}) error {
+	err := o.talkToApstra(ctx, &talkToApstraIn{
+		method:   http.MethodPatch,
+		urlStr:   fmt.Sprintf(apiUrlBlueprintNodes, blueprint),
+		apiInput: request,
+	})
+	if err != nil {
+		return convertTtaeToAceWherePossible(err)
+	}
+
+	return nil
+}

--- a/apstra/client.go
+++ b/apstra/client.go
@@ -1297,6 +1297,12 @@ func (o *Client) PatchNode(ctx context.Context, blueprint ObjectId, node ObjectI
 	return o.patchNode(ctx, blueprint, node, request, response)
 }
 
+// PatchNodes patches (only submitted fields are changed) nodes described
+// using the contents of 'request'.
+func (o *Client) PatchNodes(ctx context.Context, blueprint ObjectId, request []interface{}) error {
+	return o.patchNodes(ctx, blueprint, request)
+}
+
 // CreateRackType creates an Apstra Rack Type based on the contents of the
 // supplied RackTypeRequest.
 // Consistent with the Apstra UI and documentation, logical devices (switches,


### PR DESCRIPTION
This PR introduces a method to patch multiple nodes in one go.

We'll use when bulk renaming rack elements in the terraform rack resource.