### PR TITLE
Extend bluerprint `CreateRack()` method to allow creation by object

### DIFF
--- a/apstra/api_design_rack_types.go
+++ b/apstra/api_design_rack_types.go
@@ -1123,6 +1123,7 @@ func (o *RackTypeRequest) raw(ctx context.Context, client *Client) (*rawRackType
 }
 
 type rawRackTypeRequest struct {
+	Id                       ObjectId                      `json:"id,omitempty"`
 	DisplayName              string                        `json:"display_name"`
 	Description              string                        `json:"description"`
 	FabricConnectivityDesign fabricConnectivityDesign      `json:"fabric_connectivity_design"`
@@ -1226,6 +1227,20 @@ func (o *rawRackType) tagByLabel(desired string) (*DesignTagData, bool) {
 		}
 	}
 	return nil, false
+}
+
+func (o *rawRackType) request() *rawRackTypeRequest {
+	return &rawRackTypeRequest{
+		Id:                       o.Id,
+		DisplayName:              o.DisplayName,
+		Description:              o.Description,
+		FabricConnectivityDesign: o.FabricConnectivityDesign,
+		Tags:                     o.Tags,
+		LogicalDevices:           o.LogicalDevices,
+		GenericSystems:           o.GenericSystems,
+		LeafSwitches:             o.LeafSwitches,
+		AccessSwitches:           o.AccessSwitches,
+	}
 }
 
 func (o *Client) listRackTypeIds(ctx context.Context) ([]ObjectId, error) {

--- a/apstra/two_stage_l3_clos_racks.go
+++ b/apstra/two_stage_l3_clos_racks.go
@@ -2,6 +2,7 @@ package apstra
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 )
@@ -12,27 +13,47 @@ const (
 )
 
 type rawTwoStageL3ClosRacksRequest struct {
-	PodId          ObjectId         `json:"pod_id,omitempty"`
-	RackTypeCounts map[ObjectId]int `json:"rack_type_counts"`
-	RackTypes      []rawRackType    `json:"rack_types"`
+	PodId          ObjectId             `json:"pod_id,omitempty"`
+	RackTypeCounts map[ObjectId]int     `json:"rack_type_counts"`
+	RackTypes      []rawRackTypeRequest `json:"rack_types"`
 }
 
 type TwoStageL3ClosRackRequest struct {
 	PodId      ObjectId
 	RackTypeId ObjectId
+	RackType   *RackTypeRequest
 }
 
 func (o *TwoStageL3ClosRackRequest) raw(ctx context.Context, client *Client) (*rawTwoStageL3ClosRacksRequest, error) {
-	// fetch the raw rack type from the API
-	rawRTR, err := client.getRackType(ctx, o.RackTypeId)
-	if err != nil {
-		return nil, err
+	var rawRTR *rawRackTypeRequest
+	var err error
+
+	if o.RackType != nil {
+		rawRTR, err = o.RackType.raw(ctx, client)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// fetch the raw rack type from the API
+		rawRT, err := client.getRackType(ctx, o.RackTypeId)
+		if err != nil {
+			return nil, err
+		}
+
+		rawRTR = rawRT.request()
+	}
+
+	if rawRTR.Id == "" {
+		rawRTR.Id, err = uuid1AsObjectId()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &rawTwoStageL3ClosRacksRequest{
 		PodId:          o.PodId,
 		RackTypeCounts: map[ObjectId]int{rawRTR.Id: 1},
-		RackTypes:      []rawRackType{*rawRTR},
+		RackTypes:      []rawRackTypeRequest{*rawRTR},
 	}, nil
 }
 
@@ -55,6 +76,10 @@ func (o *TwoStageL3ClosClient) createRacks(ctx context.Context, request *rawTwoS
 }
 
 func (o *TwoStageL3ClosClient) CreateRack(ctx context.Context, in *TwoStageL3ClosRackRequest) (ObjectId, error) {
+	if in.RackTypeId != "" && in.RackType != nil {
+		return "", errors.New("TwoStageL3ClosRackRequest passed to CreateRack must not have both a RackType and a RackTypeId")
+	}
+
 	request, err := in.raw(ctx, o.client)
 	if err != nil {
 		return "", err

--- a/apstra/two_stage_l3_clos_racks_integration_test.go
+++ b/apstra/two_stage_l3_clos_racks_integration_test.go
@@ -32,14 +32,32 @@ func TestCreateDeleteRack(t *testing.T) {
 	}
 
 	testCases := map[string]TwoStageL3ClosRackRequest{
-		"single-rack": {
+		"rack-by-id": {
 			PodId:      "",
 			RackTypeId: rackTypeId,
+		},
+		"rack-by-obj": {
+			PodId: "",
+			RackType: &RackTypeRequest{
+				DisplayName:              "test",
+				Description:              "test rack",
+				FabricConnectivityDesign: FabricConnectivityDesignL3Clos,
+				LeafSwitches: []RackElementLeafSwitchRequest{
+					{
+						Label:              "leaf",
+						LinkPerSpineCount:  1,
+						LinkPerSpineSpeed:  "10G",
+						RedundancyProtocol: LeafRedundancyProtocolNone,
+						Tags:               []ObjectId{"hypervisor", "firewall"},
+						LogicalDeviceId:    "AOS-7x10-Leaf",
+					},
+				},
+			},
 		},
 	}
 
 	for clientName, client := range clients {
-		bp, bpDel := testBlueprintC(ctx, t, client.client)
+		bp, bpDel := testBlueprintD(ctx, t, client.client)
 		defer func() {
 			err = bpDel(ctx)
 			if err != nil {
@@ -47,8 +65,8 @@ func TestCreateDeleteRack(t *testing.T) {
 			}
 		}()
 
-		for _, tCase := range testCases {
-			log.Printf("testing CreateRack() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		for tName, tCase := range testCases {
+			log.Printf("testing CreateRack(%s) against %s %s (%s)", tName, client.clientType, clientName, client.client.ApiVersion())
 			id, err := bp.CreateRack(ctx, &tCase)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
Prior to this PR, creating a blueprint in a rack required the caller to specify a rack type ID, which was then fetched from Apstra and then sent to Apstra.

This PR makes it possible for the caller to specify the rack details directly, rather than by reference to a rack type ID.