### PR TITLE
Fix `MatchQuery` and `RawQuery` *optional* behavior

### DIFF
--- a/apstra/query_engine.go
+++ b/apstra/query_engine.go
@@ -390,6 +390,10 @@ func (o *MatchQuery) String() string {
 		sb.WriteString(".where(" + where + ")")
 	}
 
+	if o.optional {
+		return "optional(" + sb.String() + ")"
+	}
+
 	return sb.String()
 }
 
@@ -460,7 +464,7 @@ func (o *RawQuery) SetQuery(query string) *RawQuery {
 
 func (o *RawQuery) String() string {
 	if o.optional {
-		return o.query
+		return "optional(" + o.query + ")"
 	}
 
 	return o.query

--- a/apstra/query_engine_test.go
+++ b/apstra/query_engine_test.go
@@ -441,6 +441,17 @@ func TestQueryString(t *testing.T) {
 					Match(new(PathQuery).
 						Node(nil))),
 		},
+		"optional_raw_query": {
+			e: "match(" +
+				"" + "node()," +
+				"" + "optional(" +
+				"" + "" + "node()" +
+				"" + ")" +
+				")",
+			q: new(MatchQuery).Match(new(PathQuery).
+				Node(nil)).
+				Optional(new(RawQuery).SetQuery("node()")),
+		},
 	}
 
 	for tName, tCase := range testCases {

--- a/apstra/query_engine_test.go
+++ b/apstra/query_engine_test.go
@@ -123,26 +123,6 @@ func TestQEEAttributeString(t *testing.T) {
 	}
 }
 
-func TestQueryString(t *testing.T) {
-	x := PathQuery{}
-	y := x.Node([]QEEAttribute{
-		{"type", QEStringVal("system")},
-		{"name", QEStringVal("n_system")},
-		{"system_type", QEStringVal("switch")},
-	}).
-		Out([]QEEAttribute{{"type", QEStringVal("logical_device")}}).
-		Node([]QEEAttribute{
-			{"type", QEStringVal("logical_device")},
-		}).
-		In([]QEEAttribute{{"type", QEStringVal("logical_device")}}).
-		Node([]QEEAttribute{
-			{"type", QEStringVal("interface_map")},
-			{"name", QEStringVal("n_interface_map")},
-		}).
-		String()
-	log.Println("\n", y)
-}
-
 func TestParsingQueryInfo(t *testing.T) {
 	ctx := context.Background()
 	clients, err := getTestClients(ctx, t)
@@ -420,33 +400,58 @@ func TestMatchQueryWhere(t *testing.T) {
 	}
 }
 
-func TestQueryMatchOptional(t *testing.T) {
-	expected := "" +
-		"match(" +
-		"" + "node(type='system',system_type='switch').out().node(type='interface').out().node(type='link',name='n_link')," +
-		"" + "optional(" +
-		"" + "" + "node(type='link',name='n_link').in_().node(type='tag',name='n_tag')" +
-		"" + ")" +
-		")"
-	q1 := new(PathQuery).
-		Node([]QEEAttribute{NodeTypeSystem.QEEAttribute(), {Key: "system_type", Value: QEStringVal("switch")}}).
-		Out([]QEEAttribute{}).
-		Node([]QEEAttribute{NodeTypeInterface.QEEAttribute()}).
-		Out([]QEEAttribute{}).
-		Node([]QEEAttribute{NodeTypeLink.QEEAttribute(), {Key: "name", Value: QEStringVal("n_link")}})
+func TestQueryString(t *testing.T) {
+	type testCase struct {
+		q QEQuery
+		e string
+	}
 
-	q2 := new(PathQuery).
-		Node([]QEEAttribute{NodeTypeLink.QEEAttribute(), {Key: "name", Value: QEStringVal("n_link")}}).
-		In([]QEEAttribute{}).
-		Node([]QEEAttribute{NodeTypeTag.QEEAttribute(), {Key: "name", Value: QEStringVal("n_tag")}})
+	testCases := map[string]testCase{
+		"optional_path_query": {
+			e: "match(" +
+				"" + "node(type='system',system_type='switch').out().node(type='interface').out().node(type='link',name='n_link')," +
+				"" + "optional(" +
+				"" + "" + "node(type='link',name='n_link').in_().node(type='tag',name='n_tag')" +
+				"" + ")" +
+				")",
+			q: new(MatchQuery).
+				Match(new(PathQuery).
+					Node([]QEEAttribute{NodeTypeSystem.QEEAttribute(), {Key: "system_type", Value: QEStringVal("switch")}}).
+					Out([]QEEAttribute{}).
+					Node([]QEEAttribute{NodeTypeInterface.QEEAttribute()}).
+					Out([]QEEAttribute{}).
+					Node([]QEEAttribute{NodeTypeLink.QEEAttribute(), {Key: "name", Value: QEStringVal("n_link")}})).
+				Optional(new(PathQuery).
+					Node([]QEEAttribute{NodeTypeLink.QEEAttribute(), {Key: "name", Value: QEStringVal("n_link")}}).
+					In([]QEEAttribute{}).
+					Node([]QEEAttribute{NodeTypeTag.QEEAttribute(), {Key: "name", Value: QEStringVal("n_tag")}})),
+		},
+		"optional_match_query": {
+			e: "match(" +
+				"" + "node()," +
+				"" + "optional(" +
+				"" + "" + "match(" +
+				"" + "" + "" + "node()" +
+				"" + "" + ")" +
+				"" + ")" +
+				")",
+			q: new(MatchQuery).Match(new(PathQuery).
+				Node(nil)).
+				Optional(new(MatchQuery).
+					Match(new(PathQuery).
+						Node(nil))),
+		},
+	}
 
-	result := new(MatchQuery).
-		Match(q1).
-		Optional(q2).
-		String()
-
-	if expected != result {
-		t.Fatalf("expected: %q, got %q", expected, result)
+	for tName, tCase := range testCases {
+		tName, tCase := tName, tCase
+		t.Run(tName, func(t *testing.T) {
+			t.Parallel()
+			r := tCase.q.String()
+			if tCase.e != r {
+				t.Fatalf("expected:\n%s\n\n got:\n%s", tCase.e, r)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
When a query is added as `optional` within a `MatchQuery`, it should string-ify like this:

```
match(
  <some non-optional query>,
  optional(<the optional query>)      <=== wrapped with "optional()"
)
```

Of the three implementations of the `QEQuery` interface, only `PathQuery` did this correctly.

This PR:
- adds the optional check and `optional()` string wrapper to the `String()` methods of `MatchQuery` and `RawQuery`
- adds tests for optional matches against all three implementations
- discards an old test which could never fail (appears to have been a development aid only)

Closes #175