### PR TITLE
Fix tests

### DIFF
--- a/apstra/api_design_rack_types.go
+++ b/apstra/api_design_rack_types.go
@@ -71,11 +71,13 @@ type SystemManagementLevel int
 type systemManagementLevel string
 
 const (
-	SystemManagementLevelUnmanaged = SystemManagementLevel(iota)
+	SystemManagementLevelNone = SystemManagementLevel(iota)
+	SystemManagementLevelUnmanaged
 	SystemManagementLevelTelemetryOnly
 	SystemManagementLevelFullControl
 	SystemManagementLevelUnknown = "unknown generic system management level '%s'"
 
+	systemManagementLevelNone          = systemManagementLevel("")
 	systemManagementLevelUnmanaged     = systemManagementLevel("unmanaged")
 	systemManagementLevelTelemetryOnly = systemManagementLevel("telemetry_only")
 	systemManagementLevelFullControl   = systemManagementLevel("full_control")
@@ -296,6 +298,8 @@ func (o SystemManagementLevel) Int() int {
 
 func (o SystemManagementLevel) String() string {
 	switch o {
+	case SystemManagementLevelNone:
+		return string(systemManagementLevelNone)
 	case SystemManagementLevelUnmanaged:
 		return string(systemManagementLevelUnmanaged)
 	case SystemManagementLevelTelemetryOnly:
@@ -312,10 +316,12 @@ func (o systemManagementLevel) string() string {
 }
 func (o systemManagementLevel) parse() (int, error) {
 	switch o {
-	case systemManagementLevelFullControl:
-		return int(SystemManagementLevelFullControl), nil
+	case systemManagementLevelNone:
+		return int(SystemManagementLevelNone), nil
 	case systemManagementLevelUnmanaged:
 		return int(SystemManagementLevelUnmanaged), nil
+	case systemManagementLevelFullControl:
+		return int(SystemManagementLevelFullControl), nil
 	case systemManagementLevelTelemetryOnly:
 		return int(SystemManagementLevelTelemetryOnly), nil
 	default:

--- a/apstra/api_design_rack_types.go
+++ b/apstra/api_design_rack_types.go
@@ -71,16 +71,16 @@ type SystemManagementLevel int
 type systemManagementLevel string
 
 const (
-	SystemManagementLevelNone = SystemManagementLevel(iota)
-	SystemManagementLevelUnmanaged
+	SystemManagementLevelUnmanaged = SystemManagementLevel(iota)
 	SystemManagementLevelTelemetryOnly
 	SystemManagementLevelFullControl
+	SystemManagementLevelNone
 	SystemManagementLevelUnknown = "unknown generic system management level '%s'"
 
-	systemManagementLevelNone          = systemManagementLevel("")
 	systemManagementLevelUnmanaged     = systemManagementLevel("unmanaged")
 	systemManagementLevelTelemetryOnly = systemManagementLevel("telemetry_only")
 	systemManagementLevelFullControl   = systemManagementLevel("full_control")
+	systemManagementLevelNone          = systemManagementLevel("")
 	systemManagementLevelUnknown       = "unknown generic system management level '%d'"
 )
 
@@ -298,14 +298,14 @@ func (o SystemManagementLevel) Int() int {
 
 func (o SystemManagementLevel) String() string {
 	switch o {
-	case SystemManagementLevelNone:
-		return string(systemManagementLevelNone)
 	case SystemManagementLevelUnmanaged:
 		return string(systemManagementLevelUnmanaged)
 	case SystemManagementLevelTelemetryOnly:
 		return string(systemManagementLevelTelemetryOnly)
 	case SystemManagementLevelFullControl:
 		return string(systemManagementLevelFullControl)
+	case SystemManagementLevelNone:
+		return string(systemManagementLevelNone)
 	default:
 		return fmt.Sprintf(systemManagementLevelUnknown, o)
 	}
@@ -316,14 +316,14 @@ func (o systemManagementLevel) string() string {
 }
 func (o systemManagementLevel) parse() (int, error) {
 	switch o {
-	case systemManagementLevelNone:
-		return int(SystemManagementLevelNone), nil
 	case systemManagementLevelUnmanaged:
 		return int(SystemManagementLevelUnmanaged), nil
-	case systemManagementLevelFullControl:
-		return int(SystemManagementLevelFullControl), nil
 	case systemManagementLevelTelemetryOnly:
 		return int(SystemManagementLevelTelemetryOnly), nil
+	case systemManagementLevelFullControl:
+		return int(SystemManagementLevelFullControl), nil
+	case systemManagementLevelNone:
+		return int(SystemManagementLevelNone), nil
 	default:
 		return 0, fmt.Errorf(SystemManagementLevelUnknown, o)
 	}

--- a/apstra/api_device_profiles_modular_test.go
+++ b/apstra/api_device_profiles_modular_test.go
@@ -19,11 +19,11 @@ func TestModularDeviceProfile(t *testing.T) {
 
 	mdp1 := &ModularDeviceProfile{
 		Label:            randString(5, "hex"),
-		ChassisProfileId: "Juniper_PTX10008",
+		ChassisProfileId: "Juniper_QFX10016",
 		SlotConfigurations: map[uint64]ModularDeviceSlotConfiguration{
-			0: {LinecardProfileId: "Juniper_PTX10K_LC1201_36CD"},
-			2: {LinecardProfileId: "Juniper_PTX10K_LC1201_36CD"},
-			4: {LinecardProfileId: "Juniper_PTX10K_LC1201_36CD"},
+			0: {LinecardProfileId: "Juniper_QFX10000_30C_M"},
+			2: {LinecardProfileId: "Juniper_QFX10000_30C_M"},
+			4: {LinecardProfileId: "Juniper_QFX10000_30C_M"},
 		},
 	}
 
@@ -44,11 +44,11 @@ func TestModularDeviceProfile(t *testing.T) {
 		}
 
 		mdp1.Label = randString(5, "hex")
-		mdp1.ChassisProfileId = "Juniper_PTX10016"
+		mdp1.ChassisProfileId = "Juniper_QFX10016"
 		mdp1.SlotConfigurations = map[uint64]ModularDeviceSlotConfiguration{
-			1: {LinecardProfileId: "Juniper_PTX10K_LC1202_36MR"},
-			3: {LinecardProfileId: "Juniper_PTX10K_LC1202_36MR"},
-			5: {LinecardProfileId: "Juniper_PTX10K_LC1202_36MR"},
+			1: {LinecardProfileId: "Juniper_QFX10000_30C"},
+			3: {LinecardProfileId: "Juniper_QFX10000_30C"},
+			5: {LinecardProfileId: "Juniper_QFX10000_30C"},
 		}
 		log.Printf("testing UpdateModularDeviceProfile() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		err = client.client.UpdateModularDeviceProfile(ctx, id, mdp1)

--- a/apstra/client_test.go
+++ b/apstra/client_test.go
@@ -49,9 +49,13 @@ func TestLoginBadPassword(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		log.Printf("testing bad password Login() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		// replace the configured password while saving it in in `password`
+		password := client.client.cfg.Pass
 		client.client.cfg.Pass = randString(10, "hex")
+
+		log.Printf("testing bad password Login() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		err = client.client.Login(context.TODO())
+		client.client.cfg.Pass = password // restore the configured password
 		if err == nil {
 			t.Fatal(fmt.Errorf("tried logging in with bad password, did not get errror"))
 		}

--- a/apstra/client_test.go
+++ b/apstra/client_test.go
@@ -60,27 +60,24 @@ func TestLoginBadPassword(t *testing.T) {
 
 func TestLogoutAuthFail(t *testing.T) {
 	ctx := context.Background()
-	clientCfgs, err := getTestClientCfgs(context.Background())
+
+	clients, err := getTestClients(context.Background(), t)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	for name, cfg := range clientCfgs {
-		client, err := cfg.cfg.NewClient(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
-		log.Printf("testing Login() against %s %s (%s)", cfg.cfgType, name, client.ApiVersion())
-		err = client.Login(context.TODO())
+	for clientName, client := range clients {
+		log.Printf("testing Login() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		err = client.client.Login(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		log.Printf("client has this authtoken: '%s'", client.httpHeaders[apstraAuthHeader])
-		client.httpHeaders[apstraAuthHeader] = randJwt()
-		log.Printf("client authtoken changed to: '%s'", client.httpHeaders[apstraAuthHeader])
-		log.Printf("testing failed Logout() against %s %s (%s)", cfg.cfgType, name, client.ApiVersion())
-		err = client.Logout(context.TODO())
+		log.Printf("client has this authtoken: '%s'", client.client.httpHeaders[apstraAuthHeader])
+		client.client.httpHeaders[apstraAuthHeader] = randJwt()
+		log.Printf("client authtoken changed to: '%s'", client.client.httpHeaders[apstraAuthHeader])
+		log.Printf("testing Loout() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		err = client.client.Logout(ctx)
 		if err == nil {
 			t.Fatal(fmt.Errorf("tried logging out with bad token, did not get errror"))
 		}

--- a/apstra/client_test.go
+++ b/apstra/client_test.go
@@ -308,6 +308,14 @@ func TestCRUDIntegerPools(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		for i := len(pools) - 1; i >= 0; i-- {
+			if pools[i].Status == PoolStatusDeleting {
+				log.Printf("dropping pool %s from fetched pool list because it has status %s", pools[i].Id, pools[i].Status.String())
+				pools[i] = pools[len(pools)-1]
+				pools = pools[:len(pools)-1]
+			}
+		}
+
 		if len(pools) != beforePoolCount {
 			t.Fatalf("pools before creation: %d; after creation: %d", beforePoolCount, len(pools))
 		}

--- a/apstra/client_test.go
+++ b/apstra/client_test.go
@@ -129,9 +129,17 @@ func TestGetBlueprintOverlayControlProtocol(t *testing.T) {
 func TestCRUDIntegerPools(t *testing.T) {
 	ctx := context.Background()
 
-	clients, err := getTestClients(context.Background(), t)
+	// get all clients
+	clients, err := getTestClients(ctx, t)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	// remove clients which do not support integer pools
+	for clientName, client := range clients {
+		if integerPoolForbidden().Includes(client.client.apiVersion) {
+			delete(clients, clientName)
+		}
 	}
 
 	validate := func(req *IntPoolRequest, resp *IntPool) {

--- a/apstra/client_test.go
+++ b/apstra/client_test.go
@@ -33,9 +33,11 @@ func TestLoginEmptyPassword(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		log.Printf("testing empty password Login() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		client.client.cfg.Pass = ""
-		err := client.client.Login(context.TODO())
+		clientType := client.clientType
+		client := *client.client // don't use iterator variable because it points to the shared client object
+		log.Printf("testing empty password Login() against %s %s (%s)", clientType, clientName, client.ApiVersion())
+		client.cfg.Pass = ""
+		err := client.Login(context.TODO())
 		if err == nil {
 			t.Fatal(fmt.Errorf("tried logging in with empty password, did not get errror"))
 		}

--- a/apstra/test_helpers.go
+++ b/apstra/test_helpers.go
@@ -183,3 +183,21 @@ func getSystemIdsByRole(ctx context.Context, bp *TwoStageL3ClosClient, role stri
 
 	return result, nil
 }
+
+func sliceContains[A comparable](s []A, item A) bool {
+	for _, element := range s {
+		if element == item {
+			return true
+		}
+	}
+	return false
+}
+
+func sliceContainsAnyOf[A comparable](s, items []A) bool {
+	for _, item := range items {
+		if sliceContains(s, item) {
+			return true
+		}
+	}
+	return false
+}

--- a/apstra/two_stage_l3_clos_cabling_map.go
+++ b/apstra/two_stage_l3_clos_cabling_map.go
@@ -114,14 +114,16 @@ type InterfaceOperationState int
 type interfaceOperationState string
 
 const (
-	InterfaceOperationStateAdminDown = InterfaceOperationState(iota)
-	InterfaceOperationStateDown
+	InterfaceOperationStateNone = InterfaceOperationState(iota)
 	InterfaceOperationStateUp
+	InterfaceOperationStateDown
+	InterfaceOperationStateAdminDown
 	InterfaceOperationStateUnknown = "unknown interface operation state '%s'"
 
-	interfaceOperationStateAdminDown = interfaceOperationState("admin_down")
-	interfaceOperationStateDown      = interfaceOperationState("deduced_down")
+	interfaceOperationStateNone      = interfaceOperationState("")
 	interfaceOperationStateUp        = interfaceOperationState("up")
+	interfaceOperationStateDown      = interfaceOperationState("deduced_down")
+	interfaceOperationStateAdminDown = interfaceOperationState("admin_down")
 	interfaceOperationStateUnknown   = "unknown interface operation state '%d'"
 )
 
@@ -131,12 +133,14 @@ func (o InterfaceOperationState) Int() int {
 
 func (o InterfaceOperationState) String() string {
 	switch o {
-	case InterfaceOperationStateAdminDown:
-		return string(interfaceOperationStateAdminDown)
-	case InterfaceOperationStateDown:
-		return string(interfaceOperationStateDown)
+	case InterfaceOperationStateNone:
+		return string(interfaceOperationStateNone)
 	case InterfaceOperationStateUp:
 		return string(interfaceOperationStateUp)
+	case InterfaceOperationStateDown:
+		return string(interfaceOperationStateDown)
+	case InterfaceOperationStateAdminDown:
+		return string(interfaceOperationStateAdminDown)
 	default:
 		return fmt.Sprintf(interfaceOperationStateUnknown, o)
 	}
@@ -152,12 +156,14 @@ func (o interfaceOperationState) string() string {
 
 func (o interfaceOperationState) parse() (int, error) {
 	switch o {
-	case interfaceOperationStateAdminDown:
-		return int(InterfaceOperationStateAdminDown), nil
-	case interfaceOperationStateDown:
-		return int(InterfaceOperationStateDown), nil
+	case interfaceOperationStateNone:
+		return int(InterfaceOperationStateNone), nil
 	case interfaceOperationStateUp:
 		return int(InterfaceOperationStateUp), nil
+	case interfaceOperationStateDown:
+		return int(InterfaceOperationStateDown), nil
+	case interfaceOperationStateAdminDown:
+		return int(InterfaceOperationStateAdminDown), nil
 	default:
 		return 0, fmt.Errorf(InterfaceOperationStateUnknown, o)
 	}

--- a/apstra/two_stage_l3_clos_cabling_map_unit_test.go
+++ b/apstra/two_stage_l3_clos_cabling_map_unit_test.go
@@ -30,9 +30,10 @@ func TestSwitchLinkStrings(t *testing.T) {
 		{stringVal: "global_anycast_vtep", intType: InterfaceTypeGlobalAnycastVtep, stringType: interfaceTypeGlobalAnycastVtep},
 		{stringVal: "subinterface", intType: InterfaceTypeSubinterface, stringType: interfaceTypeSubinterface},
 
-		{stringVal: "admin_down", intType: InterfaceOperationStateAdminDown, stringType: interfaceOperationStateAdminDown},
-		{stringVal: "deduced_down", intType: InterfaceOperationStateDown, stringType: interfaceOperationStateDown},
+		{stringVal: "", intType: InterfaceOperationStateNone, stringType: interfaceOperationStateNone},
 		{stringVal: "up", intType: InterfaceOperationStateUp, stringType: interfaceOperationStateUp},
+		{stringVal: "deduced_down", intType: InterfaceOperationStateDown, stringType: interfaceOperationStateDown},
+		{stringVal: "admin_down", intType: InterfaceOperationStateAdminDown, stringType: interfaceOperationStateAdminDown},
 
 		{stringVal: "access_l3_peer_link", intType: LinkRoleAccessL3PeerLink, stringType: linkRoleAccessL3PeerLink},
 		{stringVal: "access_server", intType: LinkRoleAccessServer, stringType: linkRoleAccessServer},

--- a/apstra/two_stage_l3_clos_configlet_integration_test.go
+++ b/apstra/two_stage_l3_clos_configlet_integration_test.go
@@ -18,7 +18,7 @@ func TestImportGetUpdateGetDeleteConfiglet(t *testing.T) {
 	}
 
 	configletData := ConfigletData{
-		DisplayName: "TestImportConfiglet",
+		DisplayName: randString(5, "hex"),
 		RefArchs:    []RefDesign{RefDesignTwoStageL3Clos},
 		Generators: []ConfigletGenerator{{
 			ConfigStyle:  PlatformOSJunos,

--- a/apstra/two_stage_l3_clos_connectivity_template_assignment.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_assignment.go
@@ -513,14 +513,17 @@ func (o *TwoStageL3ClosClient) getApplicationPointsConnectivityTemplatesByCt(ctx
 		iterationCount++
 	}
 
-	// The API has an application-point-centric view of the world. Even when
-	// we use a CT filter in our query, the API responds with unrelated CTs
-	// assigned to each matching application point.
-	// Clear unwanted CTs from the API response.
-	for k1, v1 := range result { // k1: Application Point ID; v1: CT status map
-		for k2 := range v1 { // k2: CT ID (value is a bool indicating whether the CT is applied)
-			if k2 != ctId {
-				delete(result[k1], k2) // unwanted map entry
+	// did the caller specify a CT ID?
+	if ctId != "" {
+		// The API has an application-point-centric view of the world. Even when
+		// we use a CT filter in our query, the API responds with unrelated CTs
+		// assigned to each matching application point.
+		// Clear unwanted CTs from the API response.
+		for k1, v1 := range result { // k1: Application Point ID; v1: CT status map
+			for k2 := range v1 { // k2: CT ID (value is a bool indicating whether the CT is applied)
+				if k2 != ctId {
+					delete(result[k1], k2) // unwanted map entry
+				}
 			}
 		}
 	}

--- a/apstra/two_stage_l3_clos_connectivity_template_integration_test.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_integration_test.go
@@ -472,11 +472,9 @@ func TestConnectivityTemplate404(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, client := range clients {
+	for clientName, client := range clients {
+		log.Printf("begin tests against %s, (%s)", clientName, client.client.apiVersion)
 		bpClient, bpDel := testBlueprintA(ctx, t, client.client)
-		if err != nil {
-			t.Fatal(err)
-		}
 		defer func() {
 			err := bpDel(ctx)
 			if err != nil {

--- a/apstra/two_stage_l3_clos_resources_test.go
+++ b/apstra/two_stage_l3_clos_resources_test.go
@@ -99,7 +99,7 @@ func TestSetGetResourceAllocation(t *testing.T) {
 
 func TestAllResourceGroupNames(t *testing.T) {
 	all := AllResourceGroupNames()
-	expected := 18
+	expected := 29
 	if len(all) != expected {
 		t.Fatalf("expected %d resource group names, got %d", expected, len(all))
 	}

--- a/apstra/two_stage_l3_clos_virtual_networks.go
+++ b/apstra/two_stage_l3_clos_virtual_networks.go
@@ -325,15 +325,17 @@ const (
 	SystemRoleLeaf
 	SystemRoleSpine
 	SystemRoleSuperSpine
+	SystemRoleRedundancyGroup
 	SystemRoleUnknown = "unknown System Role '%s'"
 
-	systemRoleNone       = systemRole("")
-	systemRoleAccess     = systemRole("access")
-	systemRoleGeneric    = systemRole("generic")
-	systemRoleLeaf       = systemRole("leaf")
-	systemRoleSpine      = systemRole("spine")
-	systemRoleSuperSpine = systemRole("superspine")
-	systemRoleUnknown    = "unknown System Role '%d'"
+	systemRoleNone            = systemRole("")
+	systemRoleAccess          = systemRole("access")
+	systemRoleGeneric         = systemRole("generic")
+	systemRoleLeaf            = systemRole("leaf")
+	systemRoleSpine           = systemRole("spine")
+	systemRoleSuperSpine      = systemRole("superspine")
+	systemRoleRedundancyGroup = systemRole("redundancy_group")
+	systemRoleUnknown         = "unknown System Role '%d'"
 )
 
 func (o SystemRole) String() string {
@@ -358,6 +360,8 @@ func (o SystemRole) raw() systemRole {
 		return systemRoleSpine
 	case SystemRoleSuperSpine:
 		return systemRoleSuperSpine
+	case SystemRoleRedundancyGroup:
+		return systemRoleRedundancyGroup
 	default:
 		return systemRole(fmt.Sprintf(systemRoleUnknown, o))
 	}
@@ -390,6 +394,8 @@ func (o systemRole) parse() (int, error) {
 		return int(SystemRoleSpine), nil
 	case systemRoleSuperSpine:
 		return int(SystemRoleSuperSpine), nil
+	case systemRoleRedundancyGroup:
+		return int(SystemRoleRedundancyGroup), nil
 	default:
 		return 0, fmt.Errorf(SystemRoleUnknown, o)
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.19.3
 	github.com/google/go-licenses v1.6.0
 	github.com/google/uuid v1.3.0
+	github.com/hashicorp/go-version v1.6.0
 	github.com/orsinium-labs/enum v1.3.0
-	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	google.golang.org/protobuf v1.30.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -229,6 +229,8 @@ github.com/googleapis/gax-go/v2 v2.3.0/go.mod h1:b8LNqSzNabLiUpXKkY7HAR5jr6bIT99
 github.com/googleapis/gax-go/v2 v2.4.0/go.mod h1:XOTVJ59hdnfJLIP/dh8n5CGryZR2LxK9wbMD5+iXC6c=
 github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+cLsWGBF62rFAi7WjWO4=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
+github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -334,8 +336,6 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
-golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=


### PR DESCRIPTION
This PR updates test code to get more of our tests passing.

Most resolved issues relate to:
- behavioral inconsistencies between Apstra versions (older versions not tested)
- built-in objects not available in older Apstra releases
- tests which don't run well when looping over multiple Apstra client versions (changing the password in a client to test for login fail breaking subsequent tests and similar mistakes)

Changes outside of test code include:
- new iota values: `SystemManagementLevelNone`, `InterfaceOperationStateNone` and `SystemRoleRedundancyGroup` (values not used in earlier Apstra releases)
- new CT application code incorrectly filtering its results