### PR TITLE
More tests fixed

### DIFF
--- a/apstra/api_device_profiles_test.go
+++ b/apstra/api_device_profiles_test.go
@@ -11,31 +11,35 @@ import (
 )
 
 func TestListAndGetAllDeviceProfiles(t *testing.T) {
-	clients, err := getTestClients(context.Background(), t)
+	ctx := context.Background()
+
+	clients, err := getTestClients(ctx, t)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for clientName, client := range clients {
 		log.Printf("testing listDeviceProfileIds() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		ids, err := client.client.listDeviceProfileIds(context.TODO())
+		ids, err := client.client.listDeviceProfileIds(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
+
 		if len(ids) <= 0 {
 			t.Fatalf("only got %d ids", len(ids))
 		}
+
 		for _, i := range samples(len(ids)) {
 			id := ids[i]
 			log.Printf("testing getDeviceProfile(%s) against %s %s (%s)", id, client.clientType, clientName, client.client.ApiVersion())
-			dp, err := client.client.getDeviceProfile(context.TODO(), id)
+			dp, err := client.client.getDeviceProfile(ctx, id)
 			if err != nil {
 				t.Fatal(err)
 			}
 			log.Printf("device profile id '%s' label '%s'\n", id, dp.Label)
 		}
 		log.Printf("testing getAllDeviceProfiles() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		profiles, err := client.client.getAllDeviceProfiles(context.TODO())
+		profiles, err := client.client.getAllDeviceProfiles(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This PR includes a rewrite of a couple of tests related to security policies.

The security policy methods were hastily written to accommodate a POC integration of security director with Apstra.

The tests assumed a predefined blueprint with existing objects where security policies and rules could be added/removed.

This PR rewrites those tests so that the prerequisites (blueprints, security zones, application points, etc...) are prepared prior to running the tests.