### PR TITLE
Change client mutex: map[int]*sync.Mutex -> map[string]*sync.Mutex

### DIFF
--- a/apstra/api_user.go
+++ b/apstra/api_user.go
@@ -58,9 +58,9 @@ func (o *Client) login(ctx context.Context) error {
 
 	// stash auth token in client's default set of apstra http httpHeaders
 	// and start the tasskMonitor (these go together)
-	o.lock(clientHttpHeadersMutex)
+	o.lock(clientMutexHttpHeaders)
 	o.httpHeaders[apstraAuthHeader] = response.Token
-	o.unlock(clientHttpHeadersMutex)
+	o.unlock(clientMutexHttpHeaders)
 
 	o.id = response.Id
 	o.startTaskMonitor()
@@ -72,18 +72,18 @@ func (o *Client) logout(ctx context.Context) error {
 	// presence of an auth token is proxy for both
 	// - "logged in" state and
 	// - operation of a task monitor routine
-	o.lock(clientHttpHeadersMutex)
+	o.lock(clientMutexHttpHeaders)
 	if _, tokenFound := o.httpHeaders[apstraAuthHeader]; !tokenFound {
-		o.unlock(clientHttpHeadersMutex)
+		o.unlock(clientMutexHttpHeaders)
 		return nil
 	}
-	o.unlock(clientHttpHeadersMutex)
+	o.unlock(clientMutexHttpHeaders)
 
 	defer func() {
 		o.Log(1, "deleting auth token")
-		o.lock(clientHttpHeadersMutex)
+		o.lock(clientMutexHttpHeaders)
 		delete(o.httpHeaders, apstraAuthHeader)
-		o.unlock(clientHttpHeadersMutex)
+		o.unlock(clientMutexHttpHeaders)
 		o.Log(1, "shutting down the task monitor")
 		o.stopTaskMonitor()
 	}()

--- a/apstra/api_user.go
+++ b/apstra/api_user.go
@@ -58,9 +58,9 @@ func (o *Client) login(ctx context.Context) error {
 
 	// stash auth token in client's default set of apstra http httpHeaders
 	// and start the tasskMonitor (these go together)
-	o.lock(clientMutexHttpHeaders)
+	o.lock(mutexKeyHttpHeaders)
 	o.httpHeaders[apstraAuthHeader] = response.Token
-	o.unlock(clientMutexHttpHeaders)
+	o.unlock(mutexKeyHttpHeaders)
 
 	o.id = response.Id
 	o.startTaskMonitor()
@@ -72,18 +72,18 @@ func (o *Client) logout(ctx context.Context) error {
 	// presence of an auth token is proxy for both
 	// - "logged in" state and
 	// - operation of a task monitor routine
-	o.lock(clientMutexHttpHeaders)
+	o.lock(mutexKeyHttpHeaders)
 	if _, tokenFound := o.httpHeaders[apstraAuthHeader]; !tokenFound {
-		o.unlock(clientMutexHttpHeaders)
+		o.unlock(mutexKeyHttpHeaders)
 		return nil
 	}
-	o.unlock(clientMutexHttpHeaders)
+	o.unlock(mutexKeyHttpHeaders)
 
 	defer func() {
 		o.Log(1, "deleting auth token")
-		o.lock(clientMutexHttpHeaders)
+		o.lock(mutexKeyHttpHeaders)
 		delete(o.httpHeaders, apstraAuthHeader)
-		o.unlock(clientMutexHttpHeaders)
+		o.unlock(mutexKeyHttpHeaders)
 		o.Log(1, "shutting down the task monitor")
 		o.stopTaskMonitor()
 	}()

--- a/apstra/client.go
+++ b/apstra/client.go
@@ -34,7 +34,8 @@ const (
 
 	clientPollingIntervalMs = 1000
 
-	clientHttpHeadersMutex = iota
+	clientMutexIdSep       = ":"
+	clientMutexHttpHeaders = "http headers"
 )
 
 type ClientErr struct {
@@ -111,7 +112,7 @@ type Client struct {
 	taskMonChan chan *taskMonitorMonReq // send tasks for monitoring here
 	ctx         context.Context         // copied from ClientCfg, for async operations
 	logger      Logger                  // logs sent here
-	sync        map[int]*sync.Mutex     // some client operations are not concurrency safe. Their locks live here.
+	sync        map[string]*sync.Mutex  // some client operations are not concurrency safe. Their locks live here.
 	syncLock    sync.Mutex              // control access to the 'sync' map
 }
 
@@ -190,7 +191,7 @@ func (o ClientCfg) NewClient(ctx context.Context) (*Client, error) {
 		httpHeaders: map[string]string{"Accept": "application/json"},
 		logger:      logger,
 		taskMonChan: make(chan *taskMonitorMonReq),
-		sync:        make(map[int]*sync.Mutex),
+		sync:        make(map[string]*sync.Mutex),
 		ctx:         context.Background(),
 	}
 
@@ -225,7 +226,7 @@ func (o *Client) getApiVersion(ctx context.Context) (string, error) {
 }
 
 // lock creates (if necessary) a *sync.Mutex in Client.sync, and then locks it.
-func (o *Client) lock(id int) {
+func (o *Client) lock(id string) {
 
 	o.syncLock.Lock() // lock the map of locks - no defer unlock here, we unlock aggressively in the 'found' case below.
 	if mu, found := o.sync[id]; found {
@@ -242,7 +243,7 @@ func (o *Client) lock(id int) {
 }
 
 // unlock releases the named *sync.Mutex in Client.sync
-func (o *Client) unlock(id int) {
+func (o *Client) unlock(id string) {
 	o.sync[id].Unlock()
 }
 

--- a/apstra/client.go
+++ b/apstra/client.go
@@ -34,8 +34,8 @@ const (
 
 	clientPollingIntervalMs = 1000
 
-	clientMutexIdSep       = ":"
-	clientMutexHttpHeaders = "http headers"
+	mutexKeySeparator   = ":"
+	mutexKeyHttpHeaders = "http headers"
 )
 
 type ClientErr struct {

--- a/apstra/talk_to_apstra.go
+++ b/apstra/talk_to_apstra.go
@@ -167,11 +167,11 @@ func (o *Client) talkToApstra(ctx context.Context, in *talkToApstraIn) error {
 	if in.apiInput != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	o.lock(clientMutexHttpHeaders)
+	o.lock(mutexKeyHttpHeaders)
 	for k, v := range o.httpHeaders {
 		req.Header.Set(k, v)
 	}
-	o.unlock(clientMutexHttpHeaders)
+	o.unlock(mutexKeyHttpHeaders)
 
 	o.logFunc(2, o.dumpHttpRequest, req)
 

--- a/apstra/talk_to_apstra.go
+++ b/apstra/talk_to_apstra.go
@@ -167,11 +167,11 @@ func (o *Client) talkToApstra(ctx context.Context, in *talkToApstraIn) error {
 	if in.apiInput != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	o.lock(clientHttpHeadersMutex)
+	o.lock(clientMutexHttpHeaders)
 	for k, v := range o.httpHeaders {
 		req.Header.Set(k, v)
 	}
-	o.unlock(clientHttpHeadersMutex)
+	o.unlock(clientMutexHttpHeaders)
 
 	o.logFunc(2, o.dumpHttpRequest, req)
 

--- a/apstra/two_stage_l3_clos_client.go
+++ b/apstra/two_stage_l3_clos_client.go
@@ -72,7 +72,7 @@ func (o *TwoStageL3ClosClient) lockId(ids ...ObjectId) string {
 	var buf bytes.Buffer
 	buf.WriteString(o.blueprintId.String())
 	for _, id := range ids {
-		buf.WriteString(clientMutexIdSep + id.String())
+		buf.WriteString(mutexKeySeparator + id.String())
 	}
 	return buf.String()
 }

--- a/apstra/two_stage_l3_clos_client.go
+++ b/apstra/two_stage_l3_clos_client.go
@@ -1,6 +1,7 @@
 package apstra
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -64,6 +65,16 @@ type TwoStageL3ClosClient struct {
 // Id returns the client's Blueprint ID
 func (o *TwoStageL3ClosClient) Id() ObjectId {
 	return o.blueprintId
+}
+
+// lockId returns a string intended to be used with Client.lock()
+func (o *TwoStageL3ClosClient) lockId(ids ...ObjectId) string {
+	var buf bytes.Buffer
+	buf.WriteString(o.blueprintId.String())
+	for _, id := range ids {
+		buf.WriteString(clientMutexIdSep + id.String())
+	}
+	return buf.String()
 }
 
 // SetType sets the client's internal BlueprintType value (staging, etc...).


### PR DESCRIPTION
One element within`Client{}` is a map of `*sync.Mutex`.

Using a map facilitates exclusive access to Apstra objects at a granular level: Only goroutines which want to work on the same data must take turns, while goroutines working in other areas can proceed unimpeded.

Prior to now, the map was defined as `map[int]*sync.Mutex` with the integer map keys declared as constants. This strategy requires all of the possible map keys to be known at compile time.

It would be useful to use map keys which aren't known at compile time. These are map keys based on API attributes, like the combination of blueprint id + rack id (for rack contents manipulations) or blueprint id + security policy id (for security policy manipulations).

This PR includes the following changes:

- map definition is now `map[string]*sync.Mutex`
- predefined map keys are now strings
- new function `TwoStageL3ClosClient.lockId(ids ...ObjectId)` which constructs map keys based on variadic IDs 

With this PR in place, we can now make use of mutexes dedicated to specific blueprint objects.