### PR TITLE
Refactor security policy

### DIFF
--- a/apstra/client.go
+++ b/apstra/client.go
@@ -227,7 +227,6 @@ func (o *Client) getApiVersion(ctx context.Context) (string, error) {
 
 // lock creates (if necessary) a *sync.Mutex in Client.sync, and then locks it.
 func (o *Client) lock(id string) {
-
 	o.syncLock.Lock() // lock the map of locks - no defer unlock here, we unlock aggressively in the 'found' case below.
 	if mu, found := o.sync[id]; found {
 		o.syncLock.Unlock()

--- a/apstra/compatibility.go
+++ b/apstra/compatibility.go
@@ -16,7 +16,7 @@ const (
 	securityZoneJunosEvpnIrbModeRequiredError    = "junos_evpn_irb_mode is required by Apstra 4.2 and later"
 
 	vnL3MtuForbiddenVersions = "4.1.0, 4.1.1, 4.1.2"
-	vnL3MtuForbiddenError    = "Virtual Network operations support L3 MTU option only with Apstra 4.2 and later"
+	vnL3MtuForbiddenError    = "virtual network operations support L3 MTU option only with Apstra 4.2 and later"
 )
 
 func parseVersionList(s string) StringSliceWithIncludes {

--- a/apstra/two_stage_l3_clos_client.go
+++ b/apstra/two_stage_l3_clos_client.go
@@ -266,17 +266,35 @@ func (o *TwoStageL3ClosClient) UpdateSecurityZone(ctx context.Context, zoneId Ob
 
 // GetAllPolicies returns []Policy representing all policies configured within the DC blueprint
 func (o *TwoStageL3ClosClient) GetAllPolicies(ctx context.Context) ([]Policy, error) {
-	return o.getAllPolicies(ctx)
+	policies, err := o.getAllPolicies(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]Policy, len(policies))
+	for i, raw := range policies {
+		polished, err := raw.polish()
+		if err != nil {
+			return nil, err
+		}
+		result[i] = *polished
+	}
+	return result, nil
 }
 
 // GetPolicy returns *Policy representing policy 'id' within the DC blueprint
 func (o *TwoStageL3ClosClient) GetPolicy(ctx context.Context, id ObjectId) (*Policy, error) {
-	return o.getPolicy(ctx, id)
+	raw, err := o.getPolicy(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return raw.polish()
 }
 
 // CreatePolicy creates a policy within the DC blueprint, returns its ID
-func (o *TwoStageL3ClosClient) CreatePolicy(ctx context.Context, policy *Policy) (ObjectId, error) {
-	return o.createPolicy(ctx, policy)
+func (o *TwoStageL3ClosClient) CreatePolicy(ctx context.Context, data *PolicyData) (ObjectId, error) {
+	return o.createPolicy(ctx, data.request())
 }
 
 // DeletePolicy deletes policy 'id' within the DC blueprint
@@ -285,8 +303,8 @@ func (o *TwoStageL3ClosClient) DeletePolicy(ctx context.Context, id ObjectId) er
 }
 
 // UpdatePolicy calls PUT to replace the configuration of policy 'id' within the DC blueprint
-func (o *TwoStageL3ClosClient) UpdatePolicy(ctx context.Context, id ObjectId, policy *Policy) error {
-	return o.updatePolicy(ctx, id, policy)
+func (o *TwoStageL3ClosClient) UpdatePolicy(ctx context.Context, id ObjectId, data *PolicyData) error {
+	return o.updatePolicy(ctx, id, data.request())
 }
 
 // AddPolicyRule adds a policy rule at 'position' (bumping all other rules
@@ -294,7 +312,7 @@ func (o *TwoStageL3ClosClient) UpdatePolicy(ctx context.Context, id ObjectId, po
 // on the list, etc... Use -1 for last on the list. The returned ObjectId
 // represents the new rule
 func (o *TwoStageL3ClosClient) AddPolicyRule(ctx context.Context, rule *PolicyRule, position int, policyId ObjectId) (ObjectId, error) {
-	return o.addPolicyRule(ctx, rule, position, policyId)
+	return o.addPolicyRule(ctx, rule.raw(), position, policyId)
 }
 
 // DeletePolicyRuleById deletes the given rule. If the rule doesn't exist, a

--- a/apstra/two_stage_l3_clos_client.go
+++ b/apstra/two_stage_l3_clos_client.go
@@ -292,6 +292,16 @@ func (o *TwoStageL3ClosClient) GetPolicy(ctx context.Context, id ObjectId) (*Pol
 	return raw.polish()
 }
 
+// GetPolicyByLabel returns *Policy representing policy identified by 'label' within the DC blueprint
+func (o *TwoStageL3ClosClient) GetPolicyByLabel(ctx context.Context, label string) (*Policy, error) {
+	raw, err := o.getPolicyByLabel(ctx, label)
+	if err != nil {
+		return nil, err
+	}
+
+	return raw.polish()
+}
+
 // CreatePolicy creates a policy within the DC blueprint, returns its ID
 func (o *TwoStageL3ClosClient) CreatePolicy(ctx context.Context, data *PolicyData) (ObjectId, error) {
 	return o.createPolicy(ctx, data.request())

--- a/apstra/two_stage_l3_clos_client.go
+++ b/apstra/two_stage_l3_clos_client.go
@@ -311,7 +311,7 @@ func (o *TwoStageL3ClosClient) UpdatePolicy(ctx context.Context, id ObjectId, da
 // down). Position 0 makes the new policy first on the list, 1 makes it second
 // on the list, etc... Use -1 for last on the list. The returned ObjectId
 // represents the new rule
-func (o *TwoStageL3ClosClient) AddPolicyRule(ctx context.Context, rule *PolicyRule, position int, policyId ObjectId) (ObjectId, error) {
+func (o *TwoStageL3ClosClient) AddPolicyRule(ctx context.Context, rule *PolicyRuleData, position int, policyId ObjectId) (ObjectId, error) {
 	return o.addPolicyRule(ctx, rule.raw(), position, policyId)
 }
 

--- a/apstra/two_stage_l3_clos_policies.go
+++ b/apstra/two_stage_l3_clos_policies.go
@@ -3,232 +3,48 @@ package apstra
 import (
 	"context"
 	"fmt"
-	"math"
+	"github.com/orsinium-labs/enum"
 	"net/http"
-	"strconv"
-	"strings"
-	"time"
 )
 
 const (
 	apiUrlPolicies   = apiUrlBlueprintById + apiUrlPathDelim + "policies"
 	apiUrlPolicyById = apiUrlPolicies + apiUrlPathDelim + "%s"
-
-	portAny       = "any"
-	portRangeSep  = "-"
-	portRangesSep = ","
 )
 
-// RULE_SCHEMA = {
-//    'id': s.Optional(s.NodeId(description='ID of the rule node')),
-//    'label': s.GenericName(description='Unique user-friendly name of the rule'),
-//    'protocol': s.SecurityRuleProtocol(),
-//    'src_port': s.PortSetOrAny(),
-//    'dst_port': s.PortSetOrAny(),
-//    'description': s.Optional(s.Description(), load_default=''),
-//    'action': s.SecurityRuleAction() //             ['deny', 'deny_log', 'permit', 'permit_log'],
-//}
+type PolicyApplicationPointType enum.Member[string]
 
-type PolicyRuleAction int
-type policyRuleAction string
-
-const (
-	PolicyRuleActionDeny = PolicyRuleAction(iota)
-	PolicyRuleActionDenyLog
-	PolicyRuleActionPermit
-	PolicyRuleActionPermitLog
-	PolicyRuleActionUnknown = "unknown policy action '%s'"
-
-	policyRuleActionDeny      = policyRuleAction("deny")
-	policyRuleActionDenyLog   = policyRuleAction("deny_log")
-	policyRuleActionPermit    = policyRuleAction("permit")
-	policyRuleActionPermitLog = policyRuleAction("permit_log")
-	policyRuleActionUnknown   = "unknown policy action %d"
+var (
+	PolicyApplicationPointTypeGroup          = PolicyApplicationPointType{Value: "group"}
+	PolicyApplicationPointTypeInternal       = PolicyApplicationPointType{Value: "internal"}
+	PolicyApplicationPointTypeExternal       = PolicyApplicationPointType{Value: "external"}
+	PolicyApplicationPointTypeSecurityZone   = PolicyApplicationPointType{Value: "security_zone"}
+	PolicyApplicationPointTypeVirtualNetwork = PolicyApplicationPointType{Value: "virtual_network"}
+	PolicyApplicationPointTypes              = enum.New(
+		PolicyApplicationPointTypeGroup,
+		PolicyApplicationPointTypeInternal,
+		PolicyApplicationPointTypeExternal,
+		PolicyApplicationPointTypeSecurityZone,
+		PolicyApplicationPointTypeVirtualNetwork,
+	)
 )
-
-func (o PolicyRuleAction) Int() int {
-	return int(o)
-}
-
-func (o PolicyRuleAction) String() string {
-	return string(o.raw())
-}
-
-func (o PolicyRuleAction) raw() policyRuleAction {
-	switch o {
-	case PolicyRuleActionDeny:
-		return policyRuleActionDeny
-	case PolicyRuleActionDenyLog:
-		return policyRuleActionDenyLog
-	case PolicyRuleActionPermit:
-		return policyRuleActionPermit
-	case PolicyRuleActionPermitLog:
-		return policyRuleActionPermitLog
-	default:
-		return policyRuleAction(fmt.Sprintf(policyRuleActionUnknown, o))
-	}
-}
-
-func (o policyRuleAction) string() string {
-	return string(o)
-}
-
-func (o policyRuleAction) parse() (int, error) {
-	switch o {
-	case policyRuleActionDeny:
-		return int(PolicyRuleActionDeny), nil
-	case policyRuleActionDenyLog:
-		return int(PolicyRuleActionDenyLog), nil
-	case policyRuleActionPermit:
-		return int(PolicyRuleActionPermit), nil
-	case policyRuleActionPermitLog:
-		return int(PolicyRuleActionPermitLog), nil
-	default:
-		return 0, fmt.Errorf(PolicyRuleActionUnknown, o)
-	}
-}
-
-type PortRange struct {
-	first uint16
-	last  uint16
-}
-
-func (o PortRange) string() string {
-	switch {
-	case o.first == o.last:
-		return strconv.Itoa(int(o.first))
-	case o.first < o.last:
-		return strconv.Itoa(int(o.first)) + portRangeSep + strconv.Itoa(int(o.last))
-	default:
-		return strconv.Itoa(int(o.last)) + portRangeSep + strconv.Itoa(int(o.first))
-	}
-}
-
-type rawPortRanges string
-
-func (o rawPortRanges) parse() (PortRanges, error) {
-	if o == portAny {
-		return []PortRange{}, nil
-	}
-
-	rawRangeSlice := strings.Split(string(o), portRangesSep)
-	result := make([]PortRange, len(rawRangeSlice))
-	for i, raw := range rawRangeSlice {
-		var first, last uint64
-		var err error
-		portStrs := strings.Split(raw, portRangeSep)
-		switch len(portStrs) {
-		case 1:
-			first, err = strconv.ParseUint(raw, 10, 16)
-			if err != nil {
-				return nil, fmt.Errorf("error parsing port range '%s' - %w", raw, err)
-			}
-			last = first
-		case 2:
-			first, err = strconv.ParseUint(portStrs[0], 10, 16)
-			if err != nil {
-				return nil, fmt.Errorf("error parsing first element of port range '%s' - %w", raw, err)
-			}
-			last, err = strconv.ParseUint(portStrs[1], 10, 16)
-			if err != nil {
-				return nil, fmt.Errorf("error parsing last element of port range '%s' - %w", raw, err)
-			}
-		default:
-			return nil, fmt.Errorf("cannot parse port range '%s'", raw)
-		}
-		if first > math.MaxUint16 || last > math.MaxUint16 {
-			return nil, fmt.Errorf("port spec '%s' falls outside of range %d-%d", raw, 0, math.MaxUint16)
-		}
-		result[i] = PortRange{
-			first: uint16(first),
-			last:  uint16(last),
-		}
-	}
-	return result, nil
-}
-
-type PortRanges []PortRange
-
-func (o PortRanges) string() string {
-	if len(o) == 0 {
-		return portAny
-	}
-	sb := strings.Builder{}
-	sb.WriteString(o[0].string())
-	for _, pr := range o[1:] {
-		sb.WriteString(portRangesSep + pr.string())
-	}
-	return sb.String()
-}
-
-type PolicyRule struct {
-	Id          ObjectId
-	Label       string
-	Description string
-	Protocol    string
-	Action      PolicyRuleAction
-	SrcPort     PortRanges
-	DstPort     PortRanges
-}
-
-func (o PolicyRule) raw() *rawPolicyRule {
-	return &rawPolicyRule{
-		Id:          o.Id,
-		Label:       o.Label,
-		Description: o.Description,
-		Protocol:    o.Protocol,
-		Action:      o.Action.raw(),
-		SrcPort:     rawPortRanges(o.SrcPort.string()),
-		DstPort:     rawPortRanges(o.DstPort.string()),
-	}
-}
-
-type rawPolicyRule struct {
-	Id          ObjectId         `json:"id,omitempty"`
-	Label       string           `json:"label"`
-	Description string           `json:"description"`
-	Protocol    string           `json:"protocol"`
-	Action      policyRuleAction `json:"action"`
-	SrcPort     rawPortRanges    `json:"src_port"`
-	DstPort     rawPortRanges    `json:"dst_port"`
-}
-
-func (o rawPolicyRule) polish() (*PolicyRule, error) {
-	action, err := o.Action.parse()
-	if err != nil {
-		return nil, err
-	}
-	srcPort, err := o.SrcPort.parse()
-	if err != nil {
-		return nil, err
-	}
-	dstPort, err := o.DstPort.parse()
-	if err != nil {
-		return nil, err
-	}
-	return &PolicyRule{
-		Id:          o.Id,
-		Label:       o.Label,
-		Description: o.Description,
-		Protocol:    o.Protocol,
-		Action:      PolicyRuleAction(action),
-		SrcPort:     srcPort,
-		DstPort:     dstPort,
-	}, nil
-}
 
 type Policy struct {
-	Enabled             bool                   `json:"enabled"`
-	Label               string                 `json:"label"`
-	Description         string                 `json:"description"`
-	SrcApplicationPoint PolicyApplicationPoint `json:"src_application_point"`
-	DstApplicationPoint PolicyApplicationPoint `json:"dst_application_point"`
-	Rules               []PolicyRule           `json:"rules"`
-	Tags                []string               `json:"tags"`
-	Id                  ObjectId               `json:"object_id,omitempty"`
+	Id   ObjectId `json:"object_id,omitempty"`
+	Data *PolicyData
 }
 
-func (o Policy) request() *policyRequest {
+type PolicyData struct {
+	Enabled             bool                       `json:"enabled"`
+	Label               string                     `json:"label"`
+	Description         string                     `json:"description"`
+	SrcApplicationPoint PolicyApplicationPointData `json:"src_application_point"`
+	DstApplicationPoint PolicyApplicationPointData `json:"dst_application_point"`
+	Rules               []PolicyRule               `json:"rules"`
+	Tags                []string                   `json:"tags"`
+}
+
+func (o PolicyData) request() *policyRequest {
 	rules := make([]rawPolicyRule, len(o.Rules))
 	for i, rule := range o.Rules {
 		rules[i] = *rule.raw()
@@ -241,7 +57,6 @@ func (o Policy) request() *policyRequest {
 		DstApplicationPoint: o.DstApplicationPoint.ObjectId(),
 		Rules:               rules,
 		Tags:                o.Tags,
-		Id:                  o.Id,
 	}
 }
 
@@ -253,21 +68,20 @@ type policyRequest struct {
 	DstApplicationPoint ObjectId        `json:"dst_application_point"`
 	Rules               []rawPolicyRule `json:"rules"`
 	Tags                []string        `json:"tags"`
-	Id                  ObjectId        `json:"object_id,omitempty"`
 }
 
-type policyResponse struct {
-	Enabled             bool                         `json:"enabled"`
-	Label               string                       `json:"label"`
-	Description         string                       `json:"description"`
-	SrcApplicationPoint PolicyApplicationPointDigest `json:"src_application_point"`
-	DstApplicationPoint PolicyApplicationPointDigest `json:"dst_application_point"`
-	Rules               []rawPolicyRule              `json:"rules"`
-	Tags                []string                     `json:"tags"`
-	Id                  ObjectId                     `json:"id,omitempty"`
+type rawPolicy struct {
+	Enabled             bool                       `json:"enabled"`
+	Label               string                     `json:"label"`
+	Description         string                     `json:"description"`
+	SrcApplicationPoint PolicyApplicationPointData `json:"src_application_point"`
+	DstApplicationPoint PolicyApplicationPointData `json:"dst_application_point"`
+	Rules               []rawPolicyRule            `json:"rules"`
+	Tags                []string                   `json:"tags"`
+	Id                  ObjectId                   `json:"id"`
 }
 
-func (o policyResponse) polish() (*Policy, error) {
+func (o rawPolicy) polish() (*Policy, error) {
 	rules := make([]PolicyRule, len(o.Rules))
 	for i, raw := range o.Rules {
 		polished, err := raw.polish()
@@ -277,34 +91,44 @@ func (o policyResponse) polish() (*Policy, error) {
 		rules[i] = *polished
 	}
 	return &Policy{
-		Enabled:             o.Enabled,
-		Label:               o.Label,
-		Description:         o.Description,
-		SrcApplicationPoint: o.SrcApplicationPoint,
-		DstApplicationPoint: o.DstApplicationPoint,
-		Rules:               rules,
-		Tags:                o.Tags,
-		Id:                  o.Id,
+		Id: o.Id,
+		Data: &PolicyData{
+			Enabled:             o.Enabled,
+			Label:               o.Label,
+			Description:         o.Description,
+			SrcApplicationPoint: o.SrcApplicationPoint,
+			DstApplicationPoint: o.DstApplicationPoint,
+			Rules:               rules,
+			Tags:                o.Tags,
+		},
 	}, nil
 }
 
-type PolicyApplicationPoint interface {
-	ObjectId() ObjectId
+func (o rawPolicy) request() *policyRequest {
+	return &policyRequest{
+		Enabled:             o.Enabled,
+		Label:               o.Label,
+		Description:         o.Description,
+		SrcApplicationPoint: o.SrcApplicationPoint.Id,
+		DstApplicationPoint: o.DstApplicationPoint.Id,
+		Rules:               o.Rules,
+		Tags:                o.Tags,
+	}
 }
 
-type PolicyApplicationPointDigest struct {
+type PolicyApplicationPointData struct {
 	Id    ObjectId `json:"id"`
 	Label string   `json:"label"`
 	Type  string   `json:"type"` // group, internal, external, security_zone, virtual_network
 }
 
-func (o PolicyApplicationPointDigest) ObjectId() ObjectId {
+func (o PolicyApplicationPointData) ObjectId() ObjectId {
 	return o.Id
 }
 
-func (o *TwoStageL3ClosClient) getAllPolicies(ctx context.Context) ([]Policy, error) {
+func (o *TwoStageL3ClosClient) getAllPolicies(ctx context.Context) ([]rawPolicy, error) {
 	response := &struct {
-		Policies []policyResponse `json:"policies"`
+		Policies []rawPolicy `json:"policies"`
 	}{}
 	err := o.client.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodGet,
@@ -315,19 +139,11 @@ func (o *TwoStageL3ClosClient) getAllPolicies(ctx context.Context) ([]Policy, er
 		return nil, convertTtaeToAceWherePossible(err)
 	}
 
-	result := make([]Policy, len(response.Policies))
-	for i, policy := range response.Policies {
-		polished, err := policy.polish()
-		if err != nil {
-			return nil, err
-		}
-		result[i] = *polished
-	}
-	return result, nil
+	return response.Policies, nil
 }
 
-func (o *TwoStageL3ClosClient) getPolicy(ctx context.Context, id ObjectId) (*Policy, error) {
-	response := &policyResponse{}
+func (o *TwoStageL3ClosClient) getPolicy(ctx context.Context, id ObjectId) (*rawPolicy, error) {
+	response := &rawPolicy{}
 	err := o.client.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodGet,
 		urlStr:      fmt.Sprintf(apiUrlPolicyById, o.blueprintId, id),
@@ -337,18 +153,16 @@ func (o *TwoStageL3ClosClient) getPolicy(ctx context.Context, id ObjectId) (*Pol
 		return nil, convertTtaeToAceWherePossible(err)
 	}
 
-	return response.polish()
+	return response, nil
 }
 
-func (o *TwoStageL3ClosClient) createPolicy(ctx context.Context, policy *Policy) (ObjectId, error) {
-	response := &struct {
-		Id ObjectId `json:"id"`
-	}{}
+func (o *TwoStageL3ClosClient) createPolicy(ctx context.Context, data *policyRequest) (ObjectId, error) {
+	var response objectIdResponse
 	err := o.client.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodPost,
 		urlStr:      fmt.Sprintf(apiUrlPolicies, o.blueprintId),
-		apiInput:    policy,
-		apiResponse: response,
+		apiInput:    data,
+		apiResponse: &response,
 	})
 	if err != nil {
 		return "", convertTtaeToAceWherePossible(err)
@@ -364,90 +178,11 @@ func (o *TwoStageL3ClosClient) deletePolicy(ctx context.Context, id ObjectId) er
 	return convertTtaeToAceWherePossible(err)
 }
 
-func (o *TwoStageL3ClosClient) updatePolicy(ctx context.Context, id ObjectId, policy *Policy) error {
+func (o *TwoStageL3ClosClient) updatePolicy(ctx context.Context, id ObjectId, data *policyRequest) error {
 	err := o.client.talkToApstra(ctx, &talkToApstraIn{
 		method:   http.MethodPut,
 		urlStr:   fmt.Sprintf(apiUrlPolicyById, o.blueprintId, id),
-		apiInput: policy.request(),
+		apiInput: data,
 	})
 	return convertTtaeToAceWherePossible(err)
-}
-
-func (o *TwoStageL3ClosClient) getPolicyRuleIdByLabel(ctx context.Context, policyId ObjectId, label string) (ObjectId, error) {
-	start := time.Now()
-	for i := 0; i <= dcClientMaxRetries; i++ {
-		time.Sleep(dcClientRetryBackoff * time.Duration(i))
-		policy, err := o.getPolicy(ctx, policyId)
-		if err != nil {
-			return "", err
-		}
-		for _, rule := range policy.Rules {
-			if rule.Label == label {
-				return rule.Id, nil
-			}
-		}
-	}
-	return "", fmt.Errorf("rule '%s' didn't appear in policy '%s' after %s", label, policyId, time.Since(start))
-}
-
-func (o *TwoStageL3ClosClient) addPolicyRule(ctx context.Context, rule *PolicyRule, position int, policyId ObjectId) (ObjectId, error) {
-	policy, err := o.getPolicy(ctx, policyId)
-	if err != nil {
-		return "", err
-	}
-
-	currentRuleCount := len(policy.Rules)
-
-	if position < 0 {
-		position = currentRuleCount
-	}
-
-	switch {
-	// empty rule set is an easy case
-	case currentRuleCount == 0:
-		policy.Rules = []PolicyRule{*rule}
-	// zero insertion point
-	case position <= 0:
-		policy.Rules = append([]PolicyRule{*rule}, policy.Rules...)
-	// end insertion point
-	case position >= currentRuleCount:
-		policy.Rules = append(policy.Rules, *rule)
-	// insert in the middle
-	default:
-		policy.Rules = append(policy.Rules[:position+1], policy.Rules[position:]...)
-		policy.Rules[position] = *rule
-	}
-
-	// push the new policy
-	err = o.updatePolicy(ctx, policyId, policy)
-	if err != nil {
-		return "", err
-	}
-
-	return o.getPolicyRuleIdByLabel(ctx, policyId, rule.Label)
-}
-
-func (o *TwoStageL3ClosClient) deletePolicyRuleById(ctx context.Context, policyId ObjectId, ruleId ObjectId) error {
-	policy, err := o.getPolicy(ctx, policyId)
-	if err != nil {
-		return err
-	}
-
-	ruleIdx := -1
-	for i, rule := range policy.Rules {
-		if rule.Id == ruleId {
-			ruleIdx = i
-			break
-		}
-	}
-
-	if ruleIdx < 0 {
-		return ClientErr{
-			errType: ErrNotfound,
-			err:     fmt.Errorf("rule id '%s' not found in policy '%s'", ruleId, policyId),
-		}
-	}
-
-	policy.Rules = append(policy.Rules[:ruleIdx], policy.Rules[ruleIdx+1:]...)
-	return o.updatePolicy(ctx, policyId, policy)
 }

--- a/apstra/two_stage_l3_clos_policies.go
+++ b/apstra/two_stage_l3_clos_policies.go
@@ -45,6 +45,14 @@ type PolicyData struct {
 }
 
 func (o PolicyData) request() *policyRequest {
+	var srcApplicationPoint, dstApplicationPoint ObjectId
+	if o.SrcApplicationPoint != nil {
+		srcApplicationPoint = o.SrcApplicationPoint.Id
+	}
+	if o.DstApplicationPoint != nil {
+		dstApplicationPoint = o.DstApplicationPoint.Id
+	}
+
 	rules := make([]rawPolicyRule, len(o.Rules))
 	for i, rule := range o.Rules {
 		rules[i] = *rule.Data.raw()
@@ -53,8 +61,8 @@ func (o PolicyData) request() *policyRequest {
 		Enabled:             o.Enabled,
 		Label:               o.Label,
 		Description:         o.Description,
-		SrcApplicationPoint: o.SrcApplicationPoint.ObjectId(),
-		DstApplicationPoint: o.DstApplicationPoint.ObjectId(),
+		SrcApplicationPoint: srcApplicationPoint,
+		DstApplicationPoint: dstApplicationPoint,
 		Rules:               rules,
 		Tags:                o.Tags,
 	}
@@ -120,10 +128,6 @@ type PolicyApplicationPointData struct {
 	Id    ObjectId `json:"id"`
 	Label string   `json:"label"`
 	Type  string   `json:"type"` // group, internal, external, security_zone, virtual_network
-}
-
-func (o PolicyApplicationPointData) ObjectId() ObjectId {
-	return o.Id
 }
 
 func (o *TwoStageL3ClosClient) getAllPolicies(ctx context.Context) ([]rawPolicy, error) {

--- a/apstra/two_stage_l3_clos_policies.go
+++ b/apstra/two_stage_l3_clos_policies.go
@@ -64,8 +64,8 @@ type policyRequest struct {
 	Enabled             bool            `json:"enabled"`
 	Label               string          `json:"label"`
 	Description         string          `json:"description"`
-	SrcApplicationPoint ObjectId        `json:"src_application_point"`
-	DstApplicationPoint ObjectId        `json:"dst_application_point"`
+	SrcApplicationPoint ObjectId        `json:"src_application_point,omitempty"`
+	DstApplicationPoint ObjectId        `json:"dst_application_point,omitempty"`
 	Rules               []rawPolicyRule `json:"rules"`
 	Tags                []string        `json:"tags"`
 }
@@ -74,8 +74,8 @@ type rawPolicy struct {
 	Enabled             bool                        `json:"enabled"`
 	Label               string                      `json:"label"`
 	Description         string                      `json:"description"`
-	SrcApplicationPoint *PolicyApplicationPointData `json:"src_application_point"`
-	DstApplicationPoint *PolicyApplicationPointData `json:"dst_application_point"`
+	SrcApplicationPoint *PolicyApplicationPointData `json:"src_application_point,omitempty"`
+	DstApplicationPoint *PolicyApplicationPointData `json:"dst_application_point,omitempty"`
 	Rules               []rawPolicyRule             `json:"rules"`
 	Tags                []string                    `json:"tags"`
 	Id                  ObjectId                    `json:"id"`

--- a/apstra/two_stage_l3_clos_policies.go
+++ b/apstra/two_stage_l3_clos_policies.go
@@ -35,13 +35,13 @@ type Policy struct {
 }
 
 type PolicyData struct {
-	Enabled             bool                       `json:"enabled"`
-	Label               string                     `json:"label"`
-	Description         string                     `json:"description"`
-	SrcApplicationPoint PolicyApplicationPointData `json:"src_application_point"`
-	DstApplicationPoint PolicyApplicationPointData `json:"dst_application_point"`
-	Rules               []PolicyRule               `json:"rules"`
-	Tags                []string                   `json:"tags"`
+	Enabled             bool                        `json:"enabled"`
+	Label               string                      `json:"label"`
+	Description         string                      `json:"description"`
+	SrcApplicationPoint *PolicyApplicationPointData `json:"src_application_point"`
+	DstApplicationPoint *PolicyApplicationPointData `json:"dst_application_point"`
+	Rules               []PolicyRule                `json:"rules"`
+	Tags                []string                    `json:"tags"`
 }
 
 func (o PolicyData) request() *policyRequest {
@@ -71,14 +71,14 @@ type policyRequest struct {
 }
 
 type rawPolicy struct {
-	Enabled             bool                       `json:"enabled"`
-	Label               string                     `json:"label"`
-	Description         string                     `json:"description"`
-	SrcApplicationPoint PolicyApplicationPointData `json:"src_application_point"`
-	DstApplicationPoint PolicyApplicationPointData `json:"dst_application_point"`
-	Rules               []rawPolicyRule            `json:"rules"`
-	Tags                []string                   `json:"tags"`
-	Id                  ObjectId                   `json:"id"`
+	Enabled             bool                        `json:"enabled"`
+	Label               string                      `json:"label"`
+	Description         string                      `json:"description"`
+	SrcApplicationPoint *PolicyApplicationPointData `json:"src_application_point"`
+	DstApplicationPoint *PolicyApplicationPointData `json:"dst_application_point"`
+	Rules               []rawPolicyRule             `json:"rules"`
+	Tags                []string                    `json:"tags"`
+	Id                  ObjectId                    `json:"id"`
 }
 
 func (o rawPolicy) polish() (*Policy, error) {

--- a/apstra/two_stage_l3_clos_policies.go
+++ b/apstra/two_stage_l3_clos_policies.go
@@ -47,7 +47,7 @@ type PolicyData struct {
 func (o PolicyData) request() *policyRequest {
 	rules := make([]rawPolicyRule, len(o.Rules))
 	for i, rule := range o.Rules {
-		rules[i] = *rule.raw()
+		rules[i] = *rule.Data.raw()
 	}
 	return &policyRequest{
 		Enabled:             o.Enabled,

--- a/apstra/two_stage_l3_clos_policies.go
+++ b/apstra/two_stage_l3_clos_policies.go
@@ -189,7 +189,7 @@ func (o *TwoStageL3ClosClient) getPolicyByLabel(ctx context.Context, label strin
 			err:     fmt.Errorf("policy with label %q not found", label),
 		}
 	case 1:
-		policy := policies[1]
+		policy := policies[0]
 		return &policy, nil
 	default:
 		return nil, ClientErr{

--- a/apstra/two_stage_l3_clos_policies_test.go
+++ b/apstra/two_stage_l3_clos_policies_test.go
@@ -289,8 +289,8 @@ func TestCreateDatacenterPolicy(t *testing.T) {
 				Enabled:             randBool(),
 				Label:               randString(5, "hex"),
 				Description:         randString(5, "hex"),
-				SrcApplicationPoint: PolicyApplicationPointData{Id: vnIds[0]},
-				DstApplicationPoint: PolicyApplicationPointData{Id: vnIds[1]},
+				SrcApplicationPoint: &PolicyApplicationPointData{Id: vnIds[0]},
+				DstApplicationPoint: &PolicyApplicationPointData{Id: vnIds[1]},
 				Rules:               nil,
 				Tags:                tags,
 			},
@@ -298,8 +298,8 @@ func TestCreateDatacenterPolicy(t *testing.T) {
 				Enabled:             randBool(),
 				Label:               randString(5, "hex"),
 				Description:         randString(5, "hex"),
-				SrcApplicationPoint: PolicyApplicationPointData{Id: vnIds[1]},
-				DstApplicationPoint: PolicyApplicationPointData{Id: vnIds[0]},
+				SrcApplicationPoint: &PolicyApplicationPointData{Id: vnIds[1]},
+				DstApplicationPoint: &PolicyApplicationPointData{Id: vnIds[0]},
 				Rules:               nil,
 				Tags:                tags,
 			},
@@ -410,8 +410,8 @@ func TestAddDeletePolicyRule(t *testing.T) {
 		policyId, err := bp.CreatePolicy(ctx, &PolicyData{
 			Enabled:             false,
 			Label:               randString(5, "hex"),
-			SrcApplicationPoint: PolicyApplicationPointData{Id: vnIds[0]},
-			DstApplicationPoint: PolicyApplicationPointData{Id: vnIds[1]},
+			SrcApplicationPoint: &PolicyApplicationPointData{Id: vnIds[0]},
+			DstApplicationPoint: &PolicyApplicationPointData{Id: vnIds[1]},
 		})
 		if err != nil {
 			t.Fatal(err)

--- a/apstra/two_stage_l3_clos_policies_test.go
+++ b/apstra/two_stage_l3_clos_policies_test.go
@@ -140,6 +140,20 @@ func comparePolicyRules(aName string, a PolicyRule, bName string, b PolicyRule, 
 		t.Fatalf("Policy Rule IDs don't match: %s has %q, %s has %q", aName, a.Id, bName, b.Id)
 	}
 
+	aData := a.Data != nil
+	bData := b.Data != nil
+
+	if (aData || bData) && !(aData && bData) { //xor
+		t.Fatalf("Policy Rule data presence mismatch -- a: %t vs. b: %t", aData, bData)
+	}
+
+	if aData && bData {
+		comparePolicyRuleData(aName, a.Data, bName, b.Data, t)
+	}
+
+}
+
+func comparePolicyRuleData(aName string, a *PolicyRuleData, bName string, b *PolicyRuleData, t *testing.T) {
 	if a.Label != b.Label {
 		t.Fatalf("Policy Rule Labels don't match: %s has %q, %s has %q", aName, a.Label, bName, b.Label)
 	}
@@ -417,7 +431,7 @@ func TestAddDeletePolicyRule(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		newRule := &PolicyRule{
+		newRule := &PolicyRuleData{
 			Label:             randString(5, "hex"),
 			Description:       randString(5, "hex"),
 			Protocol:          PolicyRuleProtocolTcp,

--- a/apstra/two_stage_l3_clos_policies_test.go
+++ b/apstra/two_stage_l3_clos_policies_test.go
@@ -410,7 +410,7 @@ func TestAddDeletePolicyRule(t *testing.T) {
 		newRule := &PolicyRule{
 			Label:       randString(5, "hex"),
 			Description: randString(5, "hex"),
-			Protocol:    "TCP",
+			Protocol:    PolicyRuleProtocolTcp,
 			Action:      PolicyRuleActionDenyLog,
 			SrcPort:     PortRanges{{5, 6}},
 			DstPort:     PortRanges{{7, 8}, {9, 10}},
@@ -423,7 +423,7 @@ func TestAddDeletePolicyRule(t *testing.T) {
 		ruleCount := len(p.Rules)
 
 		log.Printf("testing addPolicyRule() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		ruleId, err := bp.addPolicyRule(context.TODO(), newRule.raw(), 0, policyId)
+		ruleId, err := bp.AddPolicyRule(ctx, newRule, 0, policyId)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -437,7 +437,7 @@ func TestAddDeletePolicyRule(t *testing.T) {
 		}
 
 		log.Printf("testing deletePolicyRuleById() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		err = bp.deletePolicyRuleById(context.TODO(), policyId, ruleId)
+		err = bp.deletePolicyRuleById(ctx, policyId, ruleId)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/apstra/two_stage_l3_clos_policies_test.go
+++ b/apstra/two_stage_l3_clos_policies_test.go
@@ -20,17 +20,17 @@ func TestPortRangeString(t *testing.T) {
 	tests = append(tests, struct {
 		data     PortRange
 		expected string
-	}{data: PortRange{First: 10, last: 10}, expected: "10"})
+	}{data: PortRange{First: 10, Last: 10}, expected: "10"})
 
 	tests = append(tests, struct {
 		data     PortRange
 		expected string
-	}{data: PortRange{First: 10, last: 20}, expected: "10-20"})
+	}{data: PortRange{First: 10, Last: 20}, expected: "10-20"})
 
 	tests = append(tests, struct {
 		data     PortRange
 		expected string
-	}{data: PortRange{First: 20, last: 10}, expected: "10-20"})
+	}{data: PortRange{First: 20, Last: 10}, expected: "10-20"})
 
 	for _, test := range tests {
 		if test.expected != test.data.string() {
@@ -48,7 +48,7 @@ func portRangeSlicesMatch(a, b []PortRange) bool {
 		if a[i].First != b[i].First {
 			return false
 		}
-		if a[i].last != b[i].last {
+		if a[i].Last != b[i].Last {
 			return false
 		}
 	}
@@ -64,22 +64,22 @@ func TestRawPortRangesParse(t *testing.T) {
 	tests = append(tests, struct {
 		data     rawPortRanges
 		expected []PortRange
-	}{data: "10", expected: []PortRange{{First: 10, last: 10}}})
+	}{data: "10", expected: []PortRange{{First: 10, Last: 10}}})
 
 	tests = append(tests, struct {
 		data     rawPortRanges
 		expected []PortRange
-	}{data: "10,11", expected: []PortRange{{First: 10, last: 10}, {First: 11, last: 11}}})
+	}{data: "10,11", expected: []PortRange{{First: 10, Last: 10}, {First: 11, Last: 11}}})
 
 	tests = append(tests, struct {
 		data     rawPortRanges
 		expected []PortRange
-	}{data: "12,11", expected: []PortRange{{First: 12, last: 12}, {First: 11, last: 11}}})
+	}{data: "12,11", expected: []PortRange{{First: 12, Last: 12}, {First: 11, Last: 11}}})
 
 	tests = append(tests, struct {
 		data     rawPortRanges
 		expected []PortRange
-	}{data: "10-11,12-13", expected: []PortRange{{First: 10, last: 11}, {First: 12, last: 13}}})
+	}{data: "10-11,12-13", expected: []PortRange{{First: 10, Last: 11}, {First: 12, Last: 13}}})
 
 	for i, test := range tests {
 		parsed, err := test.data.parse()
@@ -130,8 +130,8 @@ func comparePolicyPortRanges(a PortRange, aName string, b PortRange, bName strin
 		t.Fatalf("Policy Port Ranges 'first' field don't match: %s has %d, %s has %d", aName, a.First, bName, b.First)
 	}
 
-	if a.last != b.last {
-		t.Fatalf("Policy Port Ranges 'last' field don't match: %s has %d, %s has %d", aName, a.last, bName, b.last)
+	if a.Last != b.Last {
+		t.Fatalf("Policy Port Ranges 'last' field don't match: %s has %d, %s has %d", aName, a.Last, bName, b.Last)
 	}
 }
 

--- a/apstra/two_stage_l3_clos_policies_test.go
+++ b/apstra/two_stage_l3_clos_policies_test.go
@@ -20,17 +20,17 @@ func TestPortRangeString(t *testing.T) {
 	tests = append(tests, struct {
 		data     PortRange
 		expected string
-	}{data: PortRange{first: 10, last: 10}, expected: "10"})
+	}{data: PortRange{First: 10, last: 10}, expected: "10"})
 
 	tests = append(tests, struct {
 		data     PortRange
 		expected string
-	}{data: PortRange{first: 10, last: 20}, expected: "10-20"})
+	}{data: PortRange{First: 10, last: 20}, expected: "10-20"})
 
 	tests = append(tests, struct {
 		data     PortRange
 		expected string
-	}{data: PortRange{first: 20, last: 10}, expected: "10-20"})
+	}{data: PortRange{First: 20, last: 10}, expected: "10-20"})
 
 	for _, test := range tests {
 		if test.expected != test.data.string() {
@@ -45,7 +45,7 @@ func portRangeSlicesMatch(a, b []PortRange) bool {
 	}
 
 	for i := 0; i < len(a); i++ {
-		if a[i].first != b[i].first {
+		if a[i].First != b[i].First {
 			return false
 		}
 		if a[i].last != b[i].last {
@@ -64,22 +64,22 @@ func TestRawPortRangesParse(t *testing.T) {
 	tests = append(tests, struct {
 		data     rawPortRanges
 		expected []PortRange
-	}{data: "10", expected: []PortRange{{first: 10, last: 10}}})
+	}{data: "10", expected: []PortRange{{First: 10, last: 10}}})
 
 	tests = append(tests, struct {
 		data     rawPortRanges
 		expected []PortRange
-	}{data: "10,11", expected: []PortRange{{first: 10, last: 10}, {first: 11, last: 11}}})
+	}{data: "10,11", expected: []PortRange{{First: 10, last: 10}, {First: 11, last: 11}}})
 
 	tests = append(tests, struct {
 		data     rawPortRanges
 		expected []PortRange
-	}{data: "12,11", expected: []PortRange{{first: 12, last: 12}, {first: 11, last: 11}}})
+	}{data: "12,11", expected: []PortRange{{First: 12, last: 12}, {First: 11, last: 11}}})
 
 	tests = append(tests, struct {
 		data     rawPortRanges
 		expected []PortRange
-	}{data: "10-11,12-13", expected: []PortRange{{first: 10, last: 11}, {first: 12, last: 13}}})
+	}{data: "10-11,12-13", expected: []PortRange{{First: 10, last: 11}, {First: 12, last: 13}}})
 
 	for i, test := range tests {
 		parsed, err := test.data.parse()
@@ -126,8 +126,8 @@ func TestGetAllPolicies(t *testing.T) {
 }
 
 func comparePolicyPortRanges(a PortRange, aName string, b PortRange, bName string, t *testing.T) {
-	if a.first != b.first {
-		t.Fatalf("Policy Port Ranges 'first' field don't match: %s has %d, %s has %d", aName, a.first, bName, b.first)
+	if a.First != b.First {
+		t.Fatalf("Policy Port Ranges 'first' field don't match: %s has %d, %s has %d", aName, a.First, bName, b.First)
 	}
 
 	if a.last != b.last {

--- a/apstra/two_stage_l3_clos_policies_test.go
+++ b/apstra/two_stage_l3_clos_policies_test.go
@@ -218,12 +218,12 @@ func comparePolicyData(a *PolicyData, aName string, b *PolicyData, bName string,
 		t.Fatalf("Policy Descriptions don't match: %s has %q, %s has %q", aName, a.Description, bName, b.Description)
 	}
 
-	if a.SrcApplicationPoint.ObjectId() != b.SrcApplicationPoint.ObjectId() {
-		t.Fatalf("Policy SrcApplicationPoints don't match: %s has %q, %s has %q", aName, a.SrcApplicationPoint.ObjectId(), bName, b.SrcApplicationPoint.ObjectId())
+	if a.SrcApplicationPoint.Id != b.SrcApplicationPoint.Id {
+		t.Fatalf("Policy SrcApplicationPoints don't match: %s has %q, %s has %q", aName, a.SrcApplicationPoint.Id, bName, b.SrcApplicationPoint.Id)
 	}
 
-	if a.DstApplicationPoint.ObjectId() != b.DstApplicationPoint.ObjectId() {
-		t.Fatalf("Policy DstApplicationPoints don't match: %s has %q, %s has %q", aName, a.DstApplicationPoint.ObjectId(), bName, b.DstApplicationPoint.ObjectId())
+	if a.DstApplicationPoint.Id != b.DstApplicationPoint.Id {
+		t.Fatalf("Policy DstApplicationPoints don't match: %s has %q, %s has %q", aName, a.DstApplicationPoint.Id, bName, b.DstApplicationPoint.Id)
 	}
 
 	compareSlicesAsSets(t, a.Tags, b.Tags, fmt.Sprintf("%s tags: %v, %s tags %v", aName, a.Tags, bName, b.Tags))

--- a/apstra/two_stage_l3_clos_policy_rules.go
+++ b/apstra/two_stage_l3_clos_policy_rules.go
@@ -54,18 +54,18 @@ var (
 )
 
 type PortRange struct {
-	first uint16
+	First uint16
 	last  uint16
 }
 
 func (o PortRange) string() string {
 	switch {
-	case o.first == o.last:
-		return strconv.Itoa(int(o.first))
-	case o.first < o.last:
-		return strconv.Itoa(int(o.first)) + portRangeSep + strconv.Itoa(int(o.last))
+	case o.First == o.last:
+		return strconv.Itoa(int(o.First))
+	case o.First < o.last:
+		return strconv.Itoa(int(o.First)) + portRangeSep + strconv.Itoa(int(o.last))
 	default:
-		return strconv.Itoa(int(o.last)) + portRangeSep + strconv.Itoa(int(o.first))
+		return strconv.Itoa(int(o.last)) + portRangeSep + strconv.Itoa(int(o.First))
 	}
 }
 
@@ -105,7 +105,7 @@ func (o rawPortRanges) parse() (PortRanges, error) {
 			return nil, fmt.Errorf("port spec '%s' falls outside of range %d-%d", raw, 0, math.MaxUint16)
 		}
 		result[i] = PortRange{
-			first: uint16(first),
+			First: uint16(first),
 			last:  uint16(last),
 		}
 	}

--- a/apstra/two_stage_l3_clos_policy_rules.go
+++ b/apstra/two_stage_l3_clos_policy_rules.go
@@ -16,16 +16,6 @@ const (
 	portRangesSep = ","
 )
 
-// RULE_SCHEMA = {
-//    'id': s.Optional(s.NodeId(description='ID of the rule node')),
-//    'label': s.GenericName(description='Unique user-friendly name of the rule'),
-//    'protocol': s.SecurityRuleProtocol(),
-//    'src_port': s.PortSetOrAny(),
-//    'dst_port': s.PortSetOrAny(),
-//    'description': s.Optional(s.Description(), load_default=''),
-//    'action': s.SecurityRuleAction() //             ['deny', 'deny_log', 'permit', 'permit_log'],
-//}
-
 type PolicyRuleAction enum.Member[string]
 
 var (
@@ -146,14 +136,17 @@ func (o rawPolicyRule) polish() (*PolicyRule, error) {
 	if action == nil {
 		return nil, fmt.Errorf("unknown policy rule action %q", o.Action)
 	}
+
 	srcPort, err := o.SrcPort.parse()
 	if err != nil {
 		return nil, err
 	}
+
 	dstPort, err := o.DstPort.parse()
 	if err != nil {
 		return nil, err
 	}
+
 	return &PolicyRule{
 		Id:          o.Id,
 		Label:       o.Label,

--- a/apstra/two_stage_l3_clos_policy_rules.go
+++ b/apstra/two_stage_l3_clos_policy_rules.go
@@ -55,17 +55,17 @@ var (
 
 type PortRange struct {
 	First uint16
-	last  uint16
+	Last  uint16
 }
 
 func (o PortRange) string() string {
 	switch {
-	case o.First == o.last:
+	case o.First == o.Last:
 		return strconv.Itoa(int(o.First))
-	case o.First < o.last:
-		return strconv.Itoa(int(o.First)) + portRangeSep + strconv.Itoa(int(o.last))
+	case o.First < o.Last:
+		return strconv.Itoa(int(o.First)) + portRangeSep + strconv.Itoa(int(o.Last))
 	default:
-		return strconv.Itoa(int(o.last)) + portRangeSep + strconv.Itoa(int(o.First))
+		return strconv.Itoa(int(o.Last)) + portRangeSep + strconv.Itoa(int(o.First))
 	}
 }
 
@@ -106,7 +106,7 @@ func (o rawPortRanges) parse() (PortRanges, error) {
 		}
 		result[i] = PortRange{
 			First: uint16(first),
-			last:  uint16(last),
+			Last:  uint16(last),
 		}
 	}
 	return result, nil

--- a/apstra/two_stage_l3_clos_policy_rules.go
+++ b/apstra/two_stage_l3_clos_policy_rules.go
@@ -127,7 +127,11 @@ func (o PortRanges) string() string {
 }
 
 type PolicyRule struct {
-	Id                ObjectId
+	Id   ObjectId
+	Data *PolicyRuleData
+}
+
+type PolicyRuleData struct {
 	Label             string
 	Description       string
 	Protocol          PolicyRuleProtocol
@@ -137,7 +141,7 @@ type PolicyRule struct {
 	TcpStateQualifier *TcpStateQualifier
 }
 
-func (o PolicyRule) raw() *rawPolicyRule {
+func (o PolicyRuleData) raw() *rawPolicyRule {
 	var tcpStateQualifier *string
 	if o.TcpStateQualifier != nil {
 		s := o.TcpStateQualifier.Value
@@ -145,7 +149,6 @@ func (o PolicyRule) raw() *rawPolicyRule {
 	}
 
 	return &rawPolicyRule{
-		Id:                o.Id,
 		Label:             o.Label,
 		Description:       o.Description,
 		Protocol:          o.Protocol.Value,
@@ -197,14 +200,16 @@ func (o rawPolicyRule) polish() (*PolicyRule, error) {
 	}
 
 	return &PolicyRule{
-		Id:                o.Id,
-		Label:             o.Label,
-		Description:       o.Description,
-		Protocol:          *protocol,
-		Action:            *action,
-		SrcPort:           srcPort,
-		DstPort:           dstPort,
-		TcpStateQualifier: tcpStateQualifier,
+		Id: o.Id,
+		Data: &PolicyRuleData{
+			Label:             o.Label,
+			Description:       o.Description,
+			Protocol:          *protocol,
+			Action:            *action,
+			SrcPort:           srcPort,
+			DstPort:           dstPort,
+			TcpStateQualifier: tcpStateQualifier,
+		},
 	}, nil
 }
 

--- a/apstra/two_stage_l3_clos_policy_rules.go
+++ b/apstra/two_stage_l3_clos_policy_rules.go
@@ -1,0 +1,255 @@
+package apstra
+
+import (
+	"context"
+	"fmt"
+	"github.com/orsinium-labs/enum"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	portAny       = "any"
+	portRangeSep  = "-"
+	portRangesSep = ","
+)
+
+// RULE_SCHEMA = {
+//    'id': s.Optional(s.NodeId(description='ID of the rule node')),
+//    'label': s.GenericName(description='Unique user-friendly name of the rule'),
+//    'protocol': s.SecurityRuleProtocol(),
+//    'src_port': s.PortSetOrAny(),
+//    'dst_port': s.PortSetOrAny(),
+//    'description': s.Optional(s.Description(), load_default=''),
+//    'action': s.SecurityRuleAction() //             ['deny', 'deny_log', 'permit', 'permit_log'],
+//}
+
+type PolicyRuleAction enum.Member[string]
+
+var (
+	PolicyRuleActionDeny      = PolicyRuleAction{Value: "deny"}
+	PolicyRuleActionDenyLog   = PolicyRuleAction{Value: "deny_log"}
+	PolicyRuleActionPermit    = PolicyRuleAction{Value: "permit"}
+	PolicyRuleActionPermitLog = PolicyRuleAction{Value: "permit_log"}
+	PolicyRuleActions         = enum.New(PolicyRuleActionDeny, PolicyRuleActionDenyLog, PolicyRuleActionPermit, PolicyRuleActionPermitLog)
+)
+
+type PortRange struct {
+	first uint16
+	last  uint16
+}
+
+func (o PortRange) string() string {
+	switch {
+	case o.first == o.last:
+		return strconv.Itoa(int(o.first))
+	case o.first < o.last:
+		return strconv.Itoa(int(o.first)) + portRangeSep + strconv.Itoa(int(o.last))
+	default:
+		return strconv.Itoa(int(o.last)) + portRangeSep + strconv.Itoa(int(o.first))
+	}
+}
+
+type rawPortRanges string
+
+func (o rawPortRanges) parse() (PortRanges, error) {
+	if o == portAny {
+		return []PortRange{}, nil
+	}
+
+	rawRangeSlice := strings.Split(string(o), portRangesSep)
+	result := make([]PortRange, len(rawRangeSlice))
+	for i, raw := range rawRangeSlice {
+		var first, last uint64
+		var err error
+		portStrs := strings.Split(raw, portRangeSep)
+		switch len(portStrs) {
+		case 1:
+			first, err = strconv.ParseUint(raw, 10, 16)
+			if err != nil {
+				return nil, fmt.Errorf("error parsing port range '%s' - %w", raw, err)
+			}
+			last = first
+		case 2:
+			first, err = strconv.ParseUint(portStrs[0], 10, 16)
+			if err != nil {
+				return nil, fmt.Errorf("error parsing first element of port range '%s' - %w", raw, err)
+			}
+			last, err = strconv.ParseUint(portStrs[1], 10, 16)
+			if err != nil {
+				return nil, fmt.Errorf("error parsing last element of port range '%s' - %w", raw, err)
+			}
+		default:
+			return nil, fmt.Errorf("cannot parse port range '%s'", raw)
+		}
+		if first > math.MaxUint16 || last > math.MaxUint16 {
+			return nil, fmt.Errorf("port spec '%s' falls outside of range %d-%d", raw, 0, math.MaxUint16)
+		}
+		result[i] = PortRange{
+			first: uint16(first),
+			last:  uint16(last),
+		}
+	}
+	return result, nil
+}
+
+type PortRanges []PortRange
+
+func (o PortRanges) string() string {
+	if len(o) == 0 {
+		return portAny
+	}
+	sb := strings.Builder{}
+	sb.WriteString(o[0].string())
+	for _, pr := range o[1:] {
+		sb.WriteString(portRangesSep + pr.string())
+	}
+	return sb.String()
+}
+
+type PolicyRule struct {
+	Id          ObjectId
+	Label       string
+	Description string
+	Protocol    string
+	Action      PolicyRuleAction
+	SrcPort     PortRanges
+	DstPort     PortRanges
+}
+
+func (o PolicyRule) raw() *rawPolicyRule {
+	return &rawPolicyRule{
+		Id:          o.Id,
+		Label:       o.Label,
+		Description: o.Description,
+		Protocol:    o.Protocol,
+		Action:      o.Action.Value,
+		SrcPort:     rawPortRanges(o.SrcPort.string()),
+		DstPort:     rawPortRanges(o.DstPort.string()),
+	}
+}
+
+type rawPolicyRule struct {
+	Id          ObjectId      `json:"id,omitempty"`
+	Label       string        `json:"label"`
+	Description string        `json:"description"`
+	Protocol    string        `json:"protocol"`
+	Action      string        `json:"action"`
+	SrcPort     rawPortRanges `json:"src_port"`
+	DstPort     rawPortRanges `json:"dst_port"`
+}
+
+func (o rawPolicyRule) polish() (*PolicyRule, error) {
+	action := PolicyRuleActions.Parse(o.Action)
+	if action == nil {
+		return nil, fmt.Errorf("unknown policy rule action %q", o.Action)
+	}
+	srcPort, err := o.SrcPort.parse()
+	if err != nil {
+		return nil, err
+	}
+	dstPort, err := o.DstPort.parse()
+	if err != nil {
+		return nil, err
+	}
+	return &PolicyRule{
+		Id:          o.Id,
+		Label:       o.Label,
+		Description: o.Description,
+		Protocol:    o.Protocol,
+		Action:      *action,
+		SrcPort:     srcPort,
+		DstPort:     dstPort,
+	}, nil
+}
+
+func (o *TwoStageL3ClosClient) getPolicyRuleIdByLabel(ctx context.Context, policyId ObjectId, label string) (ObjectId, error) {
+	start := time.Now()
+	for i := 0; i <= dcClientMaxRetries; i++ {
+		time.Sleep(dcClientRetryBackoff * time.Duration(i))
+		policy, err := o.getPolicy(ctx, policyId)
+		if err != nil {
+			return "", err
+		}
+		for _, rule := range policy.Rules {
+			if rule.Label == label {
+				return rule.Id, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("rule '%s' didn't appear in policy '%s' after %s", label, policyId, time.Since(start))
+}
+
+func (o *TwoStageL3ClosClient) addPolicyRule(ctx context.Context, rule *rawPolicyRule, position int, policyId ObjectId) (ObjectId, error) {
+	// ensure exclusive access to the policy while we recalculate the rules
+	lockId := o.lockId(policyId)
+	o.client.lock(lockId)
+	defer o.client.unlock(lockId)
+
+	policy, err := o.getPolicy(ctx, policyId)
+	if err != nil {
+		return "", err
+	}
+
+	currentRuleCount := len(policy.Rules)
+
+	if position < 0 {
+		position = currentRuleCount
+	}
+
+	switch {
+	case currentRuleCount == 0:
+		// empty rule set is an easy case
+		policy.Rules = []rawPolicyRule{*rule}
+	case position == 0:
+		// insert at the beginning
+		policy.Rules = append([]rawPolicyRule{*rule}, policy.Rules...)
+	case position >= currentRuleCount:
+		// insert at the end
+		policy.Rules = append(policy.Rules, *rule)
+	default:
+		// insert somewhere in the middle
+		policy.Rules = append(policy.Rules[:position+1], policy.Rules[position:]...)
+		policy.Rules[position] = *rule
+	}
+
+	// push the new policy
+	err = o.updatePolicy(ctx, policyId, policy.request())
+	if err != nil {
+		return "", err
+	}
+
+	return o.getPolicyRuleIdByLabel(ctx, policyId, rule.Label)
+}
+
+func (o *TwoStageL3ClosClient) deletePolicyRuleById(ctx context.Context, policyId ObjectId, ruleId ObjectId) error {
+	// ensure exclusive access to the policy while we recalculate the rules
+	lockId := o.lockId(policyId)
+	o.client.lock(lockId)
+	defer o.client.unlock(lockId)
+
+	policy, err := o.getPolicy(ctx, policyId)
+	if err != nil {
+		return err
+	}
+
+	ruleIdx := -1
+	for i, rule := range policy.Rules {
+		if rule.Id == ruleId {
+			ruleIdx = i
+			break
+		}
+	}
+
+	if ruleIdx < 0 {
+		return ClientErr{
+			errType: ErrNotfound,
+			err:     fmt.Errorf("rule id '%s' not found in policy '%s'", ruleId, policyId),
+		}
+	}
+
+	policy.Rules = append(policy.Rules[:ruleIdx], policy.Rules[ruleIdx+1:]...)
+	return o.updatePolicy(ctx, policyId, policy.request())
+}


### PR DESCRIPTION
This PR refactors the security policy code (only used by the POC integration with SecurityDirector) to look more like our current standard:

```go
type thing struct {
  Id ObjectId
  Data *ThingData
}
```

It also makes use of `github.com/orsinium-labs/enum` to replace the `iota` types we used to use here. We'll need to do that everywhere eventually, but code that's otherwise unused makes it painless, so doing that now.

It also introduces use of the runtime mutexes from #183 to lock individual security policy objects (lock key uses blueprint ID and security policy ID) while policy rules are being added/removed.

Finally, I moved policy rule structs and methods into their own file (the policy file was getting busy), so the diff looks a little bigger than the actual logic changes which have occurred.