### PR TITLE
Ensure `PortRanges.String()` produces a correctly ordered result

### DIFF
--- a/apstra/two_stage_l3_clos_policy_rules.go
+++ b/apstra/two_stage_l3_clos_policy_rules.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/orsinium-labs/enum"
 	"math"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -118,6 +119,14 @@ func (o PortRanges) string() string {
 	if len(o) == 0 {
 		return portAny
 	}
+
+	sort.Slice(o, func(i, j int) bool {
+		if o[i].First < o[j].First {
+			return true
+		}
+		return false
+	})
+
 	sb := strings.Builder{}
 	sb.WriteString(o[0].string())
 	for _, pr := range o[1:] {

--- a/apstra/two_stage_l3_clos_policy_rules_test.go
+++ b/apstra/two_stage_l3_clos_policy_rules_test.go
@@ -1,0 +1,53 @@
+package apstra
+
+import (
+	"testing"
+)
+
+func TestPortRangesSorted(t *testing.T) {
+	type testCase struct {
+		portRanges PortRanges
+		expected   string
+	}
+	testCases := map[string]testCase{
+		"single_val": {
+			portRanges: PortRanges{{1, 1}},
+			expected:   "1",
+		},
+		"multiple_val": {
+			portRanges: PortRanges{{1, 1}, {2, 2}, {3, 3}},
+			expected:   "1,2,3",
+		},
+		"single_range": {
+			portRanges: PortRanges{{1, 3}},
+			expected:   "1-3",
+		},
+		"multiple_range": {
+			portRanges: PortRanges{{1, 3}, {5, 7}, {9, 11}},
+			expected:   "1-3,5-7,9-11",
+		},
+		"mixed": {
+			portRanges: PortRanges{{1, 1}, {3, 5}, {7, 7}, {9, 11}},
+			expected:   "1,3-5,7,9-11",
+		},
+		"single_val_unordered": {
+			portRanges: PortRanges{{3, 3}, {1, 1}, {2, 2}},
+			expected:   "1,2,3",
+		},
+		"mixed_unordered": {
+			portRanges: PortRanges{{9, 11}, {3, 5}, {7, 7}, {1, 1}},
+			expected:   "1,3-5,7,9-11",
+		},
+	}
+
+	for tName, tCase := range testCases {
+		tName, tCase := tName, tCase
+		t.Run(tName, func(t *testing.T) {
+			t.Parallel()
+			result := tCase.portRanges.string()
+			if tCase.expected != result {
+				t.Fatalf("expected %q, got %q", tCase.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Prior to this change it was possible to get port range strings like "5,1,3" and "10-20,4,5-7".

This PR ensures that those will now be rendered as "1,3,5" and "4,5-7,10-20"