### PR TITLE
Introduce Enum stringer support

### DIFF
--- a/apstra/api_device_profiles_modular.go
+++ b/apstra/api_device_profiles_modular.go
@@ -9,6 +9,10 @@ import (
 
 type DeviceProfileType enum.Member[string]
 
+func (o DeviceProfileType) String() string {
+	return o.Value
+}
+
 var (
 	DeviceProfileTypeModular    = DeviceProfileType{Value: "modular"}
 	DeviceProfileTypeMonolithic = DeviceProfileType{Value: "monolithic"}

--- a/apstra/api_device_profiles_modular.go
+++ b/apstra/api_device_profiles_modular.go
@@ -13,6 +13,15 @@ func (o DeviceProfileType) String() string {
 	return o.Value
 }
 
+func (o *DeviceProfileType) FromString(s string) error {
+	t := DeviceProfileTypes.Parse(s)
+	if t == nil {
+		return fmt.Errorf("failed to parse DeviceProfileType %q", s)
+	}
+	o.Value = t.Value
+	return nil
+}
+
 var (
 	DeviceProfileTypeModular    = DeviceProfileType{Value: "modular"}
 	DeviceProfileTypeMonolithic = DeviceProfileType{Value: "monolithic"}

--- a/apstra/api_iba_widgets.go
+++ b/apstra/api_iba_widgets.go
@@ -16,6 +16,10 @@ const (
 
 type IbaWidgetType enum.Member[string]
 
+func (o IbaWidgetType) String() string {
+	return o.Value
+}
+
 var (
 	IbaWidgetTypeStage          = IbaWidgetType{Value: "stage"}
 	IbaWidgetTypeAnomalyHeatmap = IbaWidgetType{Value: "anomaly_heatmap"}

--- a/apstra/api_iba_widgets.go
+++ b/apstra/api_iba_widgets.go
@@ -20,6 +20,15 @@ func (o IbaWidgetType) String() string {
 	return o.Value
 }
 
+func (o *IbaWidgetType) FromString(s string) error {
+	t := IbaWidgetTypes.Parse(s)
+	if t == nil {
+		return fmt.Errorf("failed to parse IbaWidgetTypes %q", s)
+	}
+	o.Value = t.Value
+	return nil
+}
+
 var (
 	IbaWidgetTypeStage          = IbaWidgetType{Value: "stage"}
 	IbaWidgetTypeAnomalyHeatmap = IbaWidgetType{Value: "anomaly_heatmap"}

--- a/apstra/two_stage_l3_clos_policies.go
+++ b/apstra/two_stage_l3_clos_policies.go
@@ -14,6 +14,10 @@ const (
 
 type PolicyApplicationPointType enum.Member[string]
 
+func (o PolicyApplicationPointType) String() string {
+	return o.Value
+}
+
 var (
 	PolicyApplicationPointTypeGroup          = PolicyApplicationPointType{Value: "group"}
 	PolicyApplicationPointTypeInternal       = PolicyApplicationPointType{Value: "internal"}

--- a/apstra/two_stage_l3_clos_policies.go
+++ b/apstra/two_stage_l3_clos_policies.go
@@ -18,6 +18,15 @@ func (o PolicyApplicationPointType) String() string {
 	return o.Value
 }
 
+func (o *PolicyApplicationPointType) FromString(s string) error {
+	t := PolicyApplicationPointTypes.Parse(s)
+	if t == nil {
+		return fmt.Errorf("failed to parse PolicyApplicationPointType %q", s)
+	}
+	o.Value = t.Value
+	return nil
+}
+
 var (
 	PolicyApplicationPointTypeGroup          = PolicyApplicationPointType{Value: "group"}
 	PolicyApplicationPointTypeInternal       = PolicyApplicationPointType{Value: "internal"}

--- a/apstra/two_stage_l3_clos_policy_rules.go
+++ b/apstra/two_stage_l3_clos_policy_rules.go
@@ -19,6 +19,10 @@ const (
 
 type PolicyRuleAction enum.Member[string]
 
+func (o PolicyRuleAction) String() string {
+	return o.Value
+}
+
 var (
 	PolicyRuleActionDeny      = PolicyRuleAction{Value: "deny"}
 	PolicyRuleActionDenyLog   = PolicyRuleAction{Value: "deny_log"}
@@ -34,6 +38,10 @@ var (
 
 type PolicyRuleProtocol enum.Member[string]
 
+func (o PolicyRuleProtocol) String() string {
+	return o.Value
+}
+
 var (
 	PolicyRuleProtocolIcmp = PolicyRuleProtocol{Value: "ICMP"}
 	PolicyRuleProtocolIp   = PolicyRuleProtocol{Value: "IP"}
@@ -48,6 +56,10 @@ var (
 )
 
 type TcpStateQualifier enum.Member[string]
+
+func (o TcpStateQualifier) String() string {
+	return o.Value
+}
 
 var (
 	TcpStateQualifierEstablished = TcpStateQualifier{Value: "established"}

--- a/apstra/two_stage_l3_clos_policy_rules.go
+++ b/apstra/two_stage_l3_clos_policy_rules.go
@@ -23,6 +23,15 @@ func (o PolicyRuleAction) String() string {
 	return o.Value
 }
 
+func (o *PolicyRuleAction) FromString(s string) error {
+	t := PolicyRuleActions.Parse(s)
+	if t == nil {
+		return fmt.Errorf("failed to parse PolicyRuleAction %q", s)
+	}
+	o.Value = t.Value
+	return nil
+}
+
 var (
 	PolicyRuleActionDeny      = PolicyRuleAction{Value: "deny"}
 	PolicyRuleActionDenyLog   = PolicyRuleAction{Value: "deny_log"}
@@ -42,6 +51,15 @@ func (o PolicyRuleProtocol) String() string {
 	return o.Value
 }
 
+func (o *PolicyRuleProtocol) FromString(s string) error {
+	t := PolicyRuleProtocols.Parse(s)
+	if t == nil {
+		return fmt.Errorf("failed to parse PolicyRuleProtocol %q", s)
+	}
+	o.Value = t.Value
+	return nil
+}
+
 var (
 	PolicyRuleProtocolIcmp = PolicyRuleProtocol{Value: "ICMP"}
 	PolicyRuleProtocolIp   = PolicyRuleProtocol{Value: "IP"}
@@ -59,6 +77,15 @@ type TcpStateQualifier enum.Member[string]
 
 func (o TcpStateQualifier) String() string {
 	return o.Value
+}
+
+func (o *TcpStateQualifier) FromString(s string) error {
+	t := TcpStateQualifiers.Parse(s)
+	if t == nil {
+		return fmt.Errorf("failed to parse TcpStateQualifier %q", s)
+	}
+	o.Value = t.Value
+	return nil
 }
 
 var (

--- a/apstra/two_stage_l3_clos_remote_gateways.go
+++ b/apstra/two_stage_l3_clos_remote_gateways.go
@@ -16,6 +16,10 @@ const (
 
 type RemoteGatewayRouteTypes enum.Member[string]
 
+func (o RemoteGatewayRouteTypes) String() string {
+	return o.Value
+}
+
 var (
 	RemoteGatewayRouteTypesAll      = RemoteGatewayRouteTypes{Value: "all"}
 	RemoteGatewayRouteTypesFiveOnly = RemoteGatewayRouteTypes{Value: "type5_only"}

--- a/apstra/two_stage_l3_clos_remote_gateways.go
+++ b/apstra/two_stage_l3_clos_remote_gateways.go
@@ -20,6 +20,15 @@ func (o RemoteGatewayRouteTypes) String() string {
 	return o.Value
 }
 
+func (o *RemoteGatewayRouteTypes) FromString(s string) error {
+	t := RemoteGatewayRouteTypesEnum.Parse(s)
+	if t == nil {
+		return fmt.Errorf("failed to parse RemoteGatewayRouteTypes %q", s)
+	}
+	o.Value = t.Value
+	return nil
+}
+
 var (
 	RemoteGatewayRouteTypesAll      = RemoteGatewayRouteTypes{Value: "all"}
 	RemoteGatewayRouteTypesFiveOnly = RemoteGatewayRouteTypes{Value: "type5_only"}

--- a/apstra/two_stage_l3_clos_security_zones.go
+++ b/apstra/two_stage_l3_clos_security_zones.go
@@ -9,6 +9,10 @@ import (
 
 type JunosEvpnIrbMode enum.Member[string]
 
+func (o JunosEvpnIrbMode) String() string {
+	return o.Value
+}
+
 var (
 	JunosEvpnIrbModeSymmetric  = JunosEvpnIrbMode{Value: "symmetric"}
 	JunosEvpnIrbModeAsymmetric = JunosEvpnIrbMode{Value: "asymmetric"}

--- a/apstra/two_stage_l3_clos_security_zones.go
+++ b/apstra/two_stage_l3_clos_security_zones.go
@@ -13,6 +13,15 @@ func (o JunosEvpnIrbMode) String() string {
 	return o.Value
 }
 
+func (o *JunosEvpnIrbMode) FromString(s string) error {
+	t := JunosEvpnIrbModes.Parse(s)
+	if t == nil {
+		return fmt.Errorf("failed to parse JunosEvpnIrbMode %q", s)
+	}
+	o.Value = t.Value
+	return nil
+}
+
 var (
 	JunosEvpnIrbModeSymmetric  = JunosEvpnIrbMode{Value: "symmetric"}
 	JunosEvpnIrbModeAsymmetric = JunosEvpnIrbMode{Value: "asymmetric"}


### PR DESCRIPTION
This PR introduces `String() string` and `FromString (s string)` methods to `enum` types for use with the rosetta translation mechanism.