### PR TITLE
Remove `Capability` element from template request structs

### DIFF
--- a/apstra/api_design_templates.go
+++ b/apstra/api_design_templates.go
@@ -371,9 +371,6 @@ func (o TemplateCapability) String() string {
 		return fmt.Sprintf(templateCapabilityUnknown, o)
 	}
 }
-func (o TemplateCapability) raw() templateCapability {
-	return templateCapability(o.String())
-}
 func (o templateCapability) string() string {
 	return string(o)
 }
@@ -1308,7 +1305,6 @@ func (o *Client) getAllL3CollapsedTemplates(ctx context.Context) ([]rawTemplateL
 
 type CreateRackBasedTemplateRequest struct {
 	DisplayName            string
-	Capability             TemplateCapability
 	Spine                  *TemplateElementSpineRequest
 	RackInfos              map[ObjectId]TemplateRackBasedRackInfo
 	DhcpServiceIntent      *DhcpServiceIntent
@@ -1379,7 +1375,6 @@ func (o *CreateRackBasedTemplateRequest) raw(ctx context.Context, client *Client
 	return &rawCreateRackBasedTemplateRequest{
 		Type:                   templateTypeRackBased,
 		DisplayName:            o.DisplayName,
-		Capability:             o.Capability.raw(),
 		Spine:                  *spine,
 		RackTypes:              rackTypes,
 		RackTypeCounts:         rackTypeCounts,
@@ -1394,7 +1389,6 @@ func (o *CreateRackBasedTemplateRequest) raw(ctx context.Context, client *Client
 type rawCreateRackBasedTemplateRequest struct {
 	Type                   templateType               `json:"type"`
 	DisplayName            string                     `json:"display_name"`
-	Capability             templateCapability         `json:"capability,omitempty"`
 	Spine                  rawSpine                   `json:"spine"`
 	RackTypes              []rawRackType              `json:"rack_types"`
 	RackTypeCounts         []RackTypeCount            `json:"rack_type_counts"`
@@ -1437,7 +1431,6 @@ func (o *Client) updateRackBasedTemplate(ctx context.Context, id ObjectId, in *C
 
 type CreatePodBasedTemplateRequest struct {
 	DisplayName             string
-	Capability              TemplateCapability
 	Superspine              *TemplateElementSuperspineRequest
 	RackBasedTemplateIds    []ObjectId
 	RackBasedTemplateCounts []RackBasedTemplateCount
@@ -1479,7 +1472,6 @@ func (o *CreatePodBasedTemplateRequest) raw(ctx context.Context, client *Client)
 	return &rawCreatePodBasedTemplateRequest{
 		Type:                    templateTypePodBased,
 		DisplayName:             o.DisplayName,
-		Capability:              o.Capability.raw(),
 		Superspine:              *superspine,
 		RackBasedTemplates:      rawRackBasedTemplates,
 		RackBasedTemplateCounts: o.RackBasedTemplateCounts,
@@ -1491,7 +1483,6 @@ func (o *CreatePodBasedTemplateRequest) raw(ctx context.Context, client *Client)
 type rawCreatePodBasedTemplateRequest struct {
 	Type                    templateType               `json:"type"`
 	DisplayName             string                     `json:"display_name"`
-	Capability              templateCapability         `json:"capability"`
 	Superspine              rawSuperspine              `json:"superspine"`
 	RackBasedTemplates      []rawTemplateRackBased     `json:"rack_based_templates"`
 	RackBasedTemplateCounts []RackBasedTemplateCount   `json:"rack_based_template_counts"`
@@ -1533,7 +1524,6 @@ func (o *Client) updatePodBasedTemplate(ctx context.Context, id ObjectId, in *Cr
 
 type CreateL3CollapsedTemplateRequest struct {
 	DisplayName          string                 `json:"display_name"`
-	Capability           TemplateCapability     `json:"capability"`
 	MeshLinkCount        int                    `json:"mesh_link_count"`
 	MeshLinkSpeed        LogicalDevicePortSpeed `json:"mesh_link_speed"`
 	RackTypeIds          []ObjectId             `json:"rack_types"`
@@ -1561,7 +1551,6 @@ func (o *CreateL3CollapsedTemplateRequest) raw(ctx context.Context, client *Clie
 	return &rawCreateL3CollapsedTemplateRequest{
 		Type:                 templateTypeL3Collapsed,
 		DisplayName:          o.DisplayName,
-		Capability:           o.Capability.raw(),
 		MeshLinkCount:        o.MeshLinkCount,
 		MeshLinkSpeed:        *o.MeshLinkSpeed.raw(),
 		RackTypes:            rackTypes,
@@ -1575,7 +1564,6 @@ func (o *CreateL3CollapsedTemplateRequest) raw(ctx context.Context, client *Clie
 type rawCreateL3CollapsedTemplateRequest struct {
 	Type                 templateType              `json:"type"`
 	DisplayName          string                    `json:"display_name"`
-	Capability           templateCapability        `json:"capability"`
 	MeshLinkCount        int                       `json:"mesh_link_count"`
 	MeshLinkSpeed        rawLogicalDevicePortSpeed `json:"mesh_link_speed"`
 	RackTypes            []rawRackType             `json:"rack_types"`

--- a/apstra/api_design_templates_test.go
+++ b/apstra/api_design_templates_test.go
@@ -521,7 +521,6 @@ func TestCreateGetDeleteRackBasedTemplate(t *testing.T) {
 	dn := randString(5, "hex")
 	req := CreateRackBasedTemplateRequest{
 		DisplayName: dn,
-		Capability:  TemplateCapabilityBlueprint,
 		Spine: &TemplateElementSpineRequest{
 			Count:                  2,
 			LinkPerSuperspineSpeed: "10G",
@@ -576,7 +575,6 @@ func TestCreateGetDeletePodBasedTemplate(t *testing.T) {
 	rbtdn := "rbtr-" + dn
 	rbtr := CreateRackBasedTemplateRequest{
 		DisplayName: rbtdn,
-		Capability:  TemplateCapabilityBlueprint,
 		Spine: &TemplateElementSpineRequest{
 			Count:                  2,
 			LinkPerSuperspineSpeed: "10G",
@@ -606,7 +604,6 @@ func TestCreateGetDeletePodBasedTemplate(t *testing.T) {
 		pbtdn := "pbtr-" + dn
 		pbtr := CreatePodBasedTemplateRequest{
 			DisplayName: pbtdn,
-			Capability:  TemplateCapabilityPod,
 			Superspine: &TemplateElementSuperspineRequest{
 				PlaneCount:         1,
 				Tags:               nil,
@@ -672,7 +669,6 @@ func TestCreateGetDeleteL3CollapsedTemplate(t *testing.T) {
 
 	req := &CreateL3CollapsedTemplateRequest{
 		DisplayName:   dn,
-		Capability:    TemplateCapabilityBlueprint,
 		MeshLinkCount: 1,
 		MeshLinkSpeed: "10G",
 		RackTypeIds:   []ObjectId{"L3_collapsed_acs"},
@@ -832,7 +828,6 @@ func TestGetTemplateIdsTypesByName(t *testing.T) {
 				id, err := client.client.createRackBasedTemplate(context.Background(), &rawCreateRackBasedTemplateRequest{
 					Type:                   cloneMe.Type,
 					DisplayName:            fmt.Sprintf("%s-%d", templateName, i),
-					Capability:             cloneMe.Capability,
 					Spine:                  cloneMe.Spine,
 					RackTypes:              cloneMe.RackTypes,
 					RackTypeCounts:         cloneMe.RackTypeCounts,
@@ -854,7 +849,6 @@ func TestGetTemplateIdsTypesByName(t *testing.T) {
 				id, err := client.client.createPodBasedTemplate(context.Background(), &rawCreatePodBasedTemplateRequest{
 					Type:                    cloneMe.Type,
 					DisplayName:             fmt.Sprintf("%s-%d", templateName, i),
-					Capability:              cloneMe.Capability,
 					Superspine:              cloneMe.Superspine,
 					RackBasedTemplates:      cloneMe.RackBasedTemplates,
 					RackBasedTemplateCounts: cloneMe.RackBasedTemplateCounts,
@@ -873,7 +867,6 @@ func TestGetTemplateIdsTypesByName(t *testing.T) {
 				id, err := client.client.createL3CollapsedTemplate(context.Background(), &rawCreateL3CollapsedTemplateRequest{
 					Type:                 cloneMe.Type,
 					DisplayName:          fmt.Sprintf("%s-%d", templateName, i),
-					Capability:           cloneMe.Capability,
 					MeshLinkCount:        cloneMe.MeshLinkCount,
 					MeshLinkSpeed:        *cloneMe.MeshLinkSpeed,
 					RackTypes:            cloneMe.RackTypes,

--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -593,7 +593,6 @@ func testTemplateB(ctx context.Context, t *testing.T, client *Client) (ObjectId,
 
 	id, err := client.CreateRackBasedTemplate(ctx, &CreateRackBasedTemplateRequest{
 		DisplayName: rbt.Data.DisplayName,
-		Capability:  rbt.Data.Capability,
 		Spine: &TemplateElementSpineRequest{
 			Count:                  rbt.Data.Spine.Count,
 			LinkPerSuperspineSpeed: rbt.Data.Spine.LinkPerSuperspineSpeed,


### PR DESCRIPTION
This PR removes the `Capability` element from rack-based, pod-based and collapsed template request structs.

It turns out that `capability` is an informational field calculated by the API based on whether the template is eligible to directly create a blueprint.

It's part of the request schema, but the API ignores any value supplied here.