### PR TITLE
Add support for Fabric L3 MTU at blueprint creation time

### DIFF
--- a/apstra/api_blueprints.go
+++ b/apstra/api_blueprints.go
@@ -19,7 +19,9 @@ const (
 	apiUrlBlueprintNodes      = apiUrlBlueprintById + apiUrlPathDelim + "nodes"
 	apiUrlBlueprintNodeById   = apiUrlBlueprintNodes + apiUrlPathDelim + "%s"
 
-	initTypeFromTemplate      = "template_reference"
+	initTypeFromTemplate   = "template_reference"
+	initTypeTemplateInline = "rack_based_template_inline"
+
 	nodeQueryNodeTypeUrlParam = "node_type"
 )
 

--- a/apstra/api_blueprints.go
+++ b/apstra/api_blueprints.go
@@ -61,30 +61,6 @@ type rawBlueprintRequestFabricAddressingPolicy struct {
 	FabricL3Mtu          *uint16          `json:"fabric_l3_mtu,omitempty"`
 }
 
-func (o *rawBlueprintRequestFabricAddressingPolicy) polish() (*BlueprintRequestFabricAddressingPolicy, error) {
-	var fabricL3Mtu *uint16
-	if o.FabricL3Mtu != nil {
-		t := *o.FabricL3Mtu // copy the pointed-to value
-		fabricL3Mtu = &t
-	}
-
-	ssl, err := o.SpineSuperspineLinks.parse()
-	if err != nil {
-		return nil, err
-	}
-
-	sll, err := o.SpineLeafLinks.parse()
-	if err != nil {
-		return nil, err
-	}
-
-	return &BlueprintRequestFabricAddressingPolicy{
-		SpineSuperspineLinks: AddressingScheme(ssl),
-		SpineLeafLinks:       AddressingScheme(sll),
-		FabricL3Mtu:          fabricL3Mtu,
-	}, nil
-}
-
 type RefDesign int
 type refDesign string
 

--- a/apstra/api_design_templates.go
+++ b/apstra/api_design_templates.go
@@ -470,24 +470,24 @@ func (o *rawAsnAllocationPolicy) polish() (*AsnAllocationPolicy, error) {
 	return &AsnAllocationPolicy{SpineAsnScheme: AsnAllocationScheme(sas)}, err
 }
 
-type FabricAddressingPolicy struct {
+type TemplateFabricAddressingPolicy410Only struct {
 	SpineSuperspineLinks AddressingScheme
 	SpineLeafLinks       AddressingScheme
 }
 
-func (o *FabricAddressingPolicy) raw() *rawFabricAddressingPolicy {
-	return &rawFabricAddressingPolicy{
+func (o *TemplateFabricAddressingPolicy410Only) raw() *rawTemplateFabricAddressingPolicy410Only {
+	return &rawTemplateFabricAddressingPolicy410Only{
 		SpineSuperspineLinks: o.SpineSuperspineLinks.raw(),
 		SpineLeafLinks:       o.SpineLeafLinks.raw(),
 	}
 }
 
-type rawFabricAddressingPolicy struct {
+type rawTemplateFabricAddressingPolicy410Only struct {
 	SpineSuperspineLinks addressingScheme `json:"spine_superspine_links"`
 	SpineLeafLinks       addressingScheme `json:"spine_leaf_links"`
 }
 
-func (o *rawFabricAddressingPolicy) polish() (*FabricAddressingPolicy, error) {
+func (o *rawTemplateFabricAddressingPolicy410Only) polish() (*TemplateFabricAddressingPolicy410Only, error) {
 	ssl, err := o.SpineSuperspineLinks.parse()
 	if err != nil {
 		return nil, err
@@ -498,7 +498,7 @@ func (o *rawFabricAddressingPolicy) polish() (*FabricAddressingPolicy, error) {
 		return nil, err
 	}
 
-	return &FabricAddressingPolicy{
+	return &TemplateFabricAddressingPolicy410Only{
 		SpineSuperspineLinks: AddressingScheme(ssl),
 		SpineLeafLinks:       AddressingScheme(sll),
 	}, nil
@@ -727,7 +727,7 @@ type TemplateRackBasedData struct {
 	AntiAffinityPolicy     *AntiAffinityPolicy
 	VirtualNetworkPolicy   VirtualNetworkPolicy
 	AsnAllocationPolicy    AsnAllocationPolicy
-	FabricAddressingPolicy *FabricAddressingPolicy
+	FabricAddressingPolicy *TemplateFabricAddressingPolicy410Only // Apstra 4.1.0 only
 	Capability             TemplateCapability
 	Spine                  Spine
 	RackInfo               map[ObjectId]TemplateRackBasedRackInfo
@@ -744,20 +744,20 @@ type DhcpServiceIntent struct {
 }
 
 type rawTemplateRackBased struct {
-	Id                     ObjectId                   `json:"id"`
-	Type                   templateType               `json:"type"`
-	DisplayName            string                     `json:"display_name"`
-	AntiAffinityPolicy     *rawAntiAffinityPolicy     `json:"anti_affinity_policy,omitempty"`
-	CreatedAt              time.Time                  `json:"created_at"`
-	LastModifiedAt         time.Time                  `json:"last_modified_at"`
-	VirtualNetworkPolicy   rawVirtualNetworkPolicy    `json:"virtual_network_policy"`
-	AsnAllocationPolicy    rawAsnAllocationPolicy     `json:"asn_allocation_policy"`
-	FabricAddressingPolicy *rawFabricAddressingPolicy `json:"fabric_addressing_policy,omitempty"`
-	Capability             templateCapability         `json:"capability,omitempty"`
-	Spine                  rawSpine                   `json:"spine"`
-	RackTypes              []rawRackType              `json:"rack_types"`
-	RackTypeCounts         []RackTypeCount            `json:"rack_type_counts"`
-	DhcpServiceIntent      DhcpServiceIntent          `json:"dhcp_service_intent"`
+	Id                     ObjectId                                  `json:"id"`
+	Type                   templateType                              `json:"type"`
+	DisplayName            string                                    `json:"display_name"`
+	AntiAffinityPolicy     *rawAntiAffinityPolicy                    `json:"anti_affinity_policy,omitempty"`
+	CreatedAt              time.Time                                 `json:"created_at"`
+	LastModifiedAt         time.Time                                 `json:"last_modified_at"`
+	VirtualNetworkPolicy   rawVirtualNetworkPolicy                   `json:"virtual_network_policy"`
+	AsnAllocationPolicy    rawAsnAllocationPolicy                    `json:"asn_allocation_policy"`
+	FabricAddressingPolicy *rawTemplateFabricAddressingPolicy410Only `json:"fabric_addressing_policy,omitempty"` // Apstra 4.1.0 only
+	Capability             templateCapability                        `json:"capability,omitempty"`
+	Spine                  rawSpine                                  `json:"spine"`
+	RackTypes              []rawRackType                             `json:"rack_types"`
+	RackTypeCounts         []RackTypeCount                           `json:"rack_type_counts"`
+	DhcpServiceIntent      DhcpServiceIntent                         `json:"dhcp_service_intent"`
 }
 
 func (o rawTemplateRackBased) polish() (*TemplateRackBased, error) {
@@ -773,7 +773,7 @@ func (o rawTemplateRackBased) polish() (*TemplateRackBased, error) {
 	if err != nil {
 		return nil, err
 	}
-	var f *FabricAddressingPolicy
+	var f *TemplateFabricAddressingPolicy410Only
 	if o.FabricAddressingPolicy != nil {
 		f, err = o.FabricAddressingPolicy.polish()
 		if err != nil {
@@ -867,7 +867,7 @@ func (o *TemplatePodBased) OverlayControlProtocol() OverlayControlProtocol {
 type TemplatePodBasedData struct {
 	DisplayName             string
 	AntiAffinityPolicy      *AntiAffinityPolicy
-	FabricAddressingPolicy  *FabricAddressingPolicy
+	FabricAddressingPolicy  *TemplateFabricAddressingPolicy410Only // Apstra 4.1.0 only
 	Superspine              Superspine
 	Capability              TemplateCapability
 	RackBasedTemplates      []TemplateRackBased
@@ -875,22 +875,22 @@ type TemplatePodBasedData struct {
 }
 
 type rawTemplatePodBased struct {
-	Id                      ObjectId                   `json:"id"`
-	Type                    templateType               `json:"type"`
-	DisplayName             string                     `json:"display_name"`
-	AntiAffinityPolicy      *rawAntiAffinityPolicy     `json:"anti_affinity_policy,omitempty"`
-	FabricAddressingPolicy  *rawFabricAddressingPolicy `json:"fabric_addressing_policy,omitempty"`
-	Superspine              rawSuperspine              `json:"superspine"`
-	CreatedAt               time.Time                  `json:"created_at"`
-	LastModifiedAt          time.Time                  `json:"last_modified_at"`
-	Capability              templateCapability         `json:"capability,omitempty"`
-	RackBasedTemplates      []rawTemplateRackBased     `json:"rack_based_templates"`
-	RackBasedTemplateCounts []RackBasedTemplateCount   `json:"rack_based_template_counts"`
+	Id                      ObjectId                                  `json:"id"`
+	Type                    templateType                              `json:"type"`
+	DisplayName             string                                    `json:"display_name"`
+	AntiAffinityPolicy      *rawAntiAffinityPolicy                    `json:"anti_affinity_policy,omitempty"`
+	FabricAddressingPolicy  *rawTemplateFabricAddressingPolicy410Only `json:"fabric_addressing_policy,omitempty"` // Apstra 4.1.0 only
+	Superspine              rawSuperspine                             `json:"superspine"`
+	CreatedAt               time.Time                                 `json:"created_at"`
+	LastModifiedAt          time.Time                                 `json:"last_modified_at"`
+	Capability              templateCapability                        `json:"capability,omitempty"`
+	RackBasedTemplates      []rawTemplateRackBased                    `json:"rack_based_templates"`
+	RackBasedTemplateCounts []RackBasedTemplateCount                  `json:"rack_based_template_counts"`
 }
 
 func (o rawTemplatePodBased) polish() (*TemplatePodBased, error) {
 	var err error
-	var fap *FabricAddressingPolicy
+	var fap *TemplateFabricAddressingPolicy410Only
 	if o.FabricAddressingPolicy != nil {
 		fap, err = o.FabricAddressingPolicy.polish()
 		if err != nil {
@@ -1310,7 +1310,7 @@ type CreateRackBasedTemplateRequest struct {
 	DhcpServiceIntent      *DhcpServiceIntent
 	AntiAffinityPolicy     *AntiAffinityPolicy
 	AsnAllocationPolicy    *AsnAllocationPolicy
-	FabricAddressingPolicy *FabricAddressingPolicy
+	FabricAddressingPolicy *TemplateFabricAddressingPolicy410Only // Apstra 4.1.0 only
 	VirtualNetworkPolicy   *VirtualNetworkPolicy
 }
 
@@ -1365,7 +1365,7 @@ func (o *CreateRackBasedTemplateRequest) raw(ctx context.Context, client *Client
 
 	asnAllocationPolicy := o.AsnAllocationPolicy.raw()
 
-	var fabricAddressingPolicy *rawFabricAddressingPolicy
+	var fabricAddressingPolicy *rawTemplateFabricAddressingPolicy410Only
 	if o.FabricAddressingPolicy != nil && !rackBasedTemplateFabricAddressingPolicyForbidden().Includes(client.apiVersion) {
 		fabricAddressingPolicy = o.FabricAddressingPolicy.raw()
 	}
@@ -1387,16 +1387,16 @@ func (o *CreateRackBasedTemplateRequest) raw(ctx context.Context, client *Client
 }
 
 type rawCreateRackBasedTemplateRequest struct {
-	Type                   templateType               `json:"type"`
-	DisplayName            string                     `json:"display_name"`
-	Spine                  rawSpine                   `json:"spine"`
-	RackTypes              []rawRackType              `json:"rack_types"`
-	RackTypeCounts         []RackTypeCount            `json:"rack_type_counts"`
-	DhcpServiceIntent      DhcpServiceIntent          `json:"dhcp_service_intent"`
-	AntiAffinityPolicy     *rawAntiAffinityPolicy     `json:"anti_affinity_policy,omitempty"`
-	AsnAllocationPolicy    rawAsnAllocationPolicy     `json:"asn_allocation_policy"`
-	FabricAddressingPolicy *rawFabricAddressingPolicy `json:"fabric_addressing_policy,omitempty"`
-	VirtualNetworkPolicy   rawVirtualNetworkPolicy    `json:"virtual_network_policy"`
+	Type                   templateType                              `json:"type"`
+	DisplayName            string                                    `json:"display_name"`
+	Spine                  rawSpine                                  `json:"spine"`
+	RackTypes              []rawRackType                             `json:"rack_types"`
+	RackTypeCounts         []RackTypeCount                           `json:"rack_type_counts"`
+	DhcpServiceIntent      DhcpServiceIntent                         `json:"dhcp_service_intent"`
+	AntiAffinityPolicy     *rawAntiAffinityPolicy                    `json:"anti_affinity_policy,omitempty"`
+	AsnAllocationPolicy    rawAsnAllocationPolicy                    `json:"asn_allocation_policy"`
+	FabricAddressingPolicy *rawTemplateFabricAddressingPolicy410Only `json:"fabric_addressing_policy,omitempty"`
+	VirtualNetworkPolicy   rawVirtualNetworkPolicy                   `json:"virtual_network_policy"`
 }
 
 func (o *Client) createRackBasedTemplate(ctx context.Context, in *rawCreateRackBasedTemplateRequest) (ObjectId, error) {
@@ -1435,7 +1435,7 @@ type CreatePodBasedTemplateRequest struct {
 	RackBasedTemplateIds    []ObjectId
 	RackBasedTemplateCounts []RackBasedTemplateCount
 	AntiAffinityPolicy      *AntiAffinityPolicy
-	FabricAddressingPolicy  *FabricAddressingPolicy
+	FabricAddressingPolicy  *TemplateFabricAddressingPolicy410Only // Apstra 4.1.0 only
 }
 
 func (o *CreatePodBasedTemplateRequest) raw(ctx context.Context, client *Client) (*rawCreatePodBasedTemplateRequest, error) {
@@ -1464,7 +1464,7 @@ func (o *CreatePodBasedTemplateRequest) raw(ctx context.Context, client *Client)
 		antiAffinityPolicy = o.AntiAffinityPolicy.raw()
 	}
 
-	var fabricAddressingPolicy *rawFabricAddressingPolicy
+	var fabricAddressingPolicy *rawTemplateFabricAddressingPolicy410Only
 	if o.FabricAddressingPolicy != nil && !podBasedTemplateFabricAddressingPolicyForbidden().Includes(client.apiVersion) {
 		fabricAddressingPolicy = o.FabricAddressingPolicy.raw()
 	}
@@ -1481,13 +1481,13 @@ func (o *CreatePodBasedTemplateRequest) raw(ctx context.Context, client *Client)
 }
 
 type rawCreatePodBasedTemplateRequest struct {
-	Type                    templateType               `json:"type"`
-	DisplayName             string                     `json:"display_name"`
-	Superspine              rawSuperspine              `json:"superspine"`
-	RackBasedTemplates      []rawTemplateRackBased     `json:"rack_based_templates"`
-	RackBasedTemplateCounts []RackBasedTemplateCount   `json:"rack_based_template_counts"`
-	AntiAffinityPolicy      *rawAntiAffinityPolicy     `json:"anti_affinity_policy,omitempty"`
-	FabricAddressingPolicy  *rawFabricAddressingPolicy `json:"fabric_addressing_policy,omitempty"`
+	Type                    templateType                              `json:"type"`
+	DisplayName             string                                    `json:"display_name"`
+	Superspine              rawSuperspine                             `json:"superspine"`
+	RackBasedTemplates      []rawTemplateRackBased                    `json:"rack_based_templates"`
+	RackBasedTemplateCounts []RackBasedTemplateCount                  `json:"rack_based_template_counts"`
+	AntiAffinityPolicy      *rawAntiAffinityPolicy                    `json:"anti_affinity_policy,omitempty"`
+	FabricAddressingPolicy  *rawTemplateFabricAddressingPolicy410Only `json:"fabric_addressing_policy,omitempty"` // Apstra 4.1.0 only
 }
 
 func (o *Client) createPodBasedTemplate(ctx context.Context, in *rawCreatePodBasedTemplateRequest) (ObjectId, error) {

--- a/apstra/client.go
+++ b/apstra/client.go
@@ -705,6 +705,11 @@ func (o *Client) GetAllBlueprintStatus(ctx context.Context) ([]BlueprintStatus, 
 
 // CreateBlueprintFromTemplate creates a blueprint using the supplied reference design and template
 func (o *Client) CreateBlueprintFromTemplate(ctx context.Context, req *CreateBlueprintFromTemplateRequest) (ObjectId, error) {
+	if req.FabricAddressingPolicy != nil &&
+		req.FabricAddressingPolicy.FabricL3Mtu != nil &&
+		fabricL3MtuForbidden().Includes(o.apiVersion) {
+		return "", errors.New(fabricL3MtuForbiddenError)
+	}
 	return o.createBlueprintFromTemplate(ctx, req.raw())
 }
 

--- a/apstra/compatibility.go
+++ b/apstra/compatibility.go
@@ -10,6 +10,9 @@ const (
 
 	rackBasedTemplateFabricAddressingPolicyForbiddenVersions = "4.1.1, 4.1.2, 4.2.0"
 
+	fabricL3MtuForbiddenVersions = "4.1.0, 4.1.1, 4.1.2"
+	fabricL3MtuForbiddenError    = "fabric_l3_mtu permitted only with Apstra 4.2.0 and later"
+
 	integerPoolForbiddenVersions = "4.1.0, 4.1.1"
 
 	policyRuleTcpStateQualifierForbidenVersions = "4.1.0, 4.1.1"
@@ -51,6 +54,10 @@ func rackBasedTemplateFabricAddressingPolicyForbidden() StringSliceWithIncludes 
 
 func podBasedTemplateFabricAddressingPolicyForbidden() StringSliceWithIncludes {
 	return parseVersionList(podBasedTemplateFabricAddressingPolicyForbiddenVersions)
+}
+
+func fabricL3MtuForbidden() StringSliceWithIncludes {
+	return parseVersionList(fabricL3MtuForbiddenVersions)
 }
 
 func integerPoolForbidden() StringSliceWithIncludes {

--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -440,7 +440,7 @@ func testTemplateA(ctx context.Context, t *testing.T, client *Client) (ObjectId,
 		RackInfos: map[ObjectId]TemplateRackBasedRackInfo{
 			rackId: {Count: 1},
 		},
-		FabricAddressingPolicy: &FabricAddressingPolicy{
+		FabricAddressingPolicy: &TemplateFabricAddressingPolicy410Only{
 			SpineSuperspineLinks: AddressingSchemeIp4,
 			SpineLeafLinks:       AddressingSchemeIp4,
 		},
@@ -502,7 +502,7 @@ func testBlueprintG(ctx context.Context, t *testing.T, client *Client) (*TwoStag
 		RefDesign:  RefDesignTwoStageL3Clos,
 		Label:      randString(5, "hex"),
 		TemplateId: templateId,
-		FabricAddressingPolicy: &FabricAddressingPolicy{
+		FabricAddressingPolicy: &BlueprintRequestFabricAddressingPolicy{
 			SpineSuperspineLinks: AddressingSchemeIp46,
 			SpineLeafLinks:       AddressingSchemeIp46,
 		},
@@ -582,7 +582,7 @@ func testTemplateB(ctx context.Context, t *testing.T, client *Client) (ObjectId,
 	}
 
 	rbt.Data.DisplayName = randString(5, "hex")
-	rbt.Data.FabricAddressingPolicy = &FabricAddressingPolicy{
+	rbt.Data.FabricAddressingPolicy = &TemplateFabricAddressingPolicy410Only{
 		SpineSuperspineLinks: AddressingSchemeIp46,
 		SpineLeafLinks:       AddressingSchemeIp46,
 	}

--- a/apstra/query_node.go
+++ b/apstra/query_node.go
@@ -7,6 +7,7 @@ const (
 	NodeTypeEpApplicationInstance
 	NodeTypeEpEndpointPolicy
 	NodeTypeEpGroup
+	NodeTypeFabricAddressingPolicy
 	NodeTypeInterface
 	NodeTypeInterfaceMap
 	NodeTypeLink
@@ -29,6 +30,7 @@ const (
 	nodeTypeEpApplicationInstance  = nodeType("ep_application_instance")
 	nodeTypeEpEndpointPolicy       = nodeType("ep_endpoint_policy")
 	nodeTypeEpGroup                = nodeType("ep_group")
+	nodeTypeFabricAddressingPolicy = nodeType("fabric_addressing_policy")
 	nodeTypeInterface              = nodeType("interface")
 	nodeTypeInterfaceMap           = nodeType("interface_map")
 	nodeTypeLink                   = nodeType("link")
@@ -61,6 +63,8 @@ func (o NodeType) String() string {
 		return string(nodeTypeEpEndpointPolicy)
 	case NodeTypeEpGroup:
 		return string(nodeTypeEpGroup)
+	case NodeTypeFabricAddressingPolicy:
+		return string(nodeTypeFabricAddressingPolicy)
 	case NodeTypeInterface:
 		return string(nodeTypeInterface)
 	case NodeTypeInterfaceMap:

--- a/apstra/two_stage_l3_clos_connectivity_template_integration_test.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_integration_test.go
@@ -327,7 +327,8 @@ func TestCtLayout(t *testing.T) {
 			}
 		}()
 
-		err = bpClient.SetFabricAddressingPolicy(ctx, &TwoStageL3ClosFabricAddressingPolicy{Ipv6Enabled: true})
+		ipv6Enabled := true
+		err = bpClient.SetFabricAddressingPolicy(ctx, &TwoStageL3ClosFabricAddressingPolicy{Ipv6Enabled: &ipv6Enabled})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -341,10 +342,6 @@ func TestCtLayout(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-
-		//sz := SecurityZone{}
-		//rp := DcRoutingPolicy{}
-		_ = client
 
 		vlan := Vlan(11)
 		ct := ConnectivityTemplate{

--- a/apstra/two_stage_l3_clos_fabric_addressing_policy.go
+++ b/apstra/two_stage_l3_clos_fabric_addressing_policy.go
@@ -2,6 +2,7 @@ package apstra
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 )
@@ -11,8 +12,9 @@ const (
 )
 
 type TwoStageL3ClosFabricAddressingPolicy struct {
-	Ipv6Enabled bool  `json:"ipv6_enabled"`
-	EsiMacMsb   uint8 `json:"esi_mac_msb"`
+	Ipv6Enabled *bool   `json:"ipv6_enabled,omitempty"`
+	EsiMacMsb   *uint8  `json:"esi_mac_msb,omitempty"`
+	FabricL3Mtu *uint16 `json:"fabric_l3_mtu,omitempty"`
 }
 
 func (o *TwoStageL3ClosClient) GetFabricAddressingPolicy(ctx context.Context) (*TwoStageL3ClosFabricAddressingPolicy, error) {
@@ -30,8 +32,15 @@ func (o *TwoStageL3ClosClient) GetFabricAddressingPolicy(ctx context.Context) (*
 }
 
 func (o *TwoStageL3ClosClient) SetFabricAddressingPolicy(ctx context.Context, in *TwoStageL3ClosFabricAddressingPolicy) error {
-	if in.EsiMacMsb%2 != 0 {
+	if *in.EsiMacMsb%2 != 0 {
 		return fmt.Errorf("fabric addressing policy esi mac msb must be even, got %d", in.EsiMacMsb)
+	}
+
+	if in.FabricL3Mtu != nil && fabricL3MtuForbidden().Includes(o.client.apiVersion) {
+		return ClientErr{
+			errType: ErrCompatibility,
+			err:     errors.New(fabricL3MtuForbiddenError),
+		}
 	}
 
 	err := o.client.talkToApstra(ctx, &talkToApstraIn{

--- a/apstra/two_stage_l3_clos_fabric_addressing_policy.go
+++ b/apstra/two_stage_l3_clos_fabric_addressing_policy.go
@@ -32,10 +32,6 @@ func (o *TwoStageL3ClosClient) GetFabricAddressingPolicy(ctx context.Context) (*
 }
 
 func (o *TwoStageL3ClosClient) SetFabricAddressingPolicy(ctx context.Context, in *TwoStageL3ClosFabricAddressingPolicy) error {
-	if *in.EsiMacMsb%2 != 0 {
-		return fmt.Errorf("fabric addressing policy esi mac msb must be even, got %d", in.EsiMacMsb)
-	}
-
 	if in.FabricL3Mtu != nil && fabricL3MtuForbidden().Includes(o.client.apiVersion) {
 		return ClientErr{
 			errType: ErrCompatibility,

--- a/apstra/two_stage_l3_clos_fabric_addressing_policy_integration_test.go
+++ b/apstra/two_stage_l3_clos_fabric_addressing_policy_integration_test.go
@@ -40,21 +40,30 @@ func TestGetSetGetFAP(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if fap.EsiMacMsb != defaultEsiMacMsb {
+		if *fap.EsiMacMsb != defaultEsiMacMsb {
 			t.Fatalf("expected mac msb to be %d (apstra default?) got %d", defaultEsiMacMsb, fap.EsiMacMsb)
 		}
 
-		if fap.Ipv6Enabled {
+		if *fap.Ipv6Enabled {
 			t.Fatal("expected ipv6 to be disabled")
 		}
 
 		newMsb := uint8(rand.Intn(100) + 100) // value 100 - 199
 		newMsb = newMsb + newMsb%2            // make it even
 
+		ipv6Enabled := true
+
+		var fabricL3Mtu *uint16
+		if !fabricL3MtuForbidden().Includes(client.client.apiVersion) {
+			flm := uint16(rand.Intn(550)*2 + 8000) // even number 8000 - 9100
+			fabricL3Mtu = &flm
+		}
+
 		log.Printf("testing SetFabricAddressingPolicy() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		err = bpClient.SetFabricAddressingPolicy(ctx, &TwoStageL3ClosFabricAddressingPolicy{
-			EsiMacMsb:   newMsb,
-			Ipv6Enabled: true,
+			EsiMacMsb:   &newMsb,
+			Ipv6Enabled: &ipv6Enabled,
+			FabricL3Mtu: fabricL3Mtu,
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -66,12 +75,18 @@ func TestGetSetGetFAP(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if newMsb != fap.EsiMacMsb {
+		if newMsb != *fap.EsiMacMsb {
 			t.Fatalf("new fabric addressing policy mac msb: expected %d got %d", newMsb, fap.EsiMacMsb)
 		}
 
-		if !fap.Ipv6Enabled {
+		if *fap.Ipv6Enabled != ipv6Enabled {
 			t.Fatal("enabling ipv6 in the fabric addressing policy failed")
+		}
+
+		if fap.FabricL3Mtu != nil {
+			if *fabricL3Mtu != *fap.FabricL3Mtu {
+				t.Fatalf("expected fabric MTU %d, got %d", *fabricL3Mtu, *fap.FabricL3Mtu)
+			}
 		}
 	}
 }

--- a/apstra/two_stage_l3_clos_system_node_info_integration_test.go
+++ b/apstra/two_stage_l3_clos_system_node_info_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"net"
 	"testing"
+	"time"
 )
 
 func TestSystemNodeInfo(t *testing.T) {
@@ -63,8 +64,27 @@ func TestSetSystemAsn(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
+		//switch client.client.ApiVersion() {
+		//case "4.1.0":
+		//	continue
+		//case "4.1.1":
+		//	continue
+		//case "4.1.2":
+		//case "4.2.0":
+		//	continue
+		//}
+		if client.client.ApiVersion() == "4.1.0" {
+			continue
+		}
 		bpClient, deleteFunc := testBlueprintB(ctx, t, client.client)
 		defer deleteFunc(ctx)
+
+		time.Sleep(2 * time.Second) // todo: fix this terrible workaround for 404s from
+		//  /api/blueprints/<id>/experience/web/system-info
+		//  shortly after blueprint creation:
+		//  {"errors": "Cache for <id> blueprint staging not found"}
+		//  see https://apstrktr.atlassian.net/browse/AOS-44024
+		//  and https://apstra-eng.slack.com/archives/C2DFCFHJR/p1703621403168039
 
 		log.Printf("testing GetAllSystemNodeInfos() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		nodeInfos, err := bpClient.GetAllSystemNodeInfos(ctx)

--- a/apstra/two_stage_l3_clos_system_node_info_integration_test.go
+++ b/apstra/two_stage_l3_clos_system_node_info_integration_test.go
@@ -161,7 +161,8 @@ func TestSetSystemLoopbackIpv4v6(t *testing.T) {
 		bpClient, deleteFunc := testBlueprintG(ctx, t, client.client)
 		defer deleteFunc(ctx)
 
-		err = bpClient.SetFabricAddressingPolicy(ctx, &TwoStageL3ClosFabricAddressingPolicy{Ipv6Enabled: true})
+		ipv6Enabled := true
+		err = bpClient.SetFabricAddressingPolicy(ctx, &TwoStageL3ClosFabricAddressingPolicy{Ipv6Enabled: &ipv6Enabled})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/apstra/two_stage_l3_clos_system_node_info_integration_test.go
+++ b/apstra/two_stage_l3_clos_system_node_info_integration_test.go
@@ -64,15 +64,6 @@ func TestSetSystemAsn(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		//switch client.client.ApiVersion() {
-		//case "4.1.0":
-		//	continue
-		//case "4.1.1":
-		//	continue
-		//case "4.1.2":
-		//case "4.2.0":
-		//	continue
-		//}
 		if client.client.ApiVersion() == "4.1.0" {
 			continue
 		}


### PR DESCRIPTION
As of Apstra 4.2.0, it's possible to specify the Fabric L3 MTU value when creating a blueprint.

The value is part of the `fabric_addressing_policy` object sent with the blueprint request.

Problem is, we're now juggling 3 different `fabric_addressing_policy` objects:
- One used when creating templates in v4.1.0
- One used when instantiating a blueprint
- One used with the `/api/blueprints/<id>/fabric-addressing-policy` API endpoint

It's now clear that these are not the same object. They've diverged substantially.

So, we've got 3 new pairs of public/private types:
- `TemplateFabricAddressingPolicy410Only`
- `BlueprintRequestFabricAddressingPolicy`
- `TwoStageL3ClosFabricAddressingPolicy`

This PR:
- renames those types to clarify the distinction between them
- adds compatibility checks for the 4.2.0-and-later fabric L3 MTU setting
- adds some new tests
- converts some values in the `TwoStageL3ClosFabricAddressingPolicy` to pointers because they should be optional JSON fields