### PR TITLE
Add `L3Mtu` field to `AttachLogicalLink` CT primitive

### DIFF
--- a/apstra/two_stage_l3_clos_connectivity_template_primitive_attributes.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_primitive_attributes.go
@@ -121,6 +121,7 @@ type ConnectivityTemplatePrimitiveAttributesAttachLogicalLink struct {
 	Vlan               *Vlan
 	IPv4AddressingType CtPrimitiveIPv4AddressingType
 	IPv6AddressingType CtPrimitiveIPv6AddressingType
+	L3Mtu              *uint16
 }
 
 func (o *ConnectivityTemplatePrimitiveAttributesAttachLogicalLink) fromRawJson(in json.RawMessage) error {
@@ -155,6 +156,7 @@ func (o *ConnectivityTemplatePrimitiveAttributesAttachLogicalLink) raw() (json.R
 		Ipv4AddressingType: o.IPv4AddressingType.raw(),
 		Ipv6AddressingType: o.IPv6AddressingType.raw(),
 		SecurityZone:       o.SecurityZone,
+		L3Mtu:              o.L3Mtu,
 	}
 
 	return json.Marshal(&raw)
@@ -645,6 +647,7 @@ type rawConnectivityTemplatePrimitiveAttributesAttachLogicalLink struct {
 	Ipv4AddressingType ctPrimitiveIPv4AddressingType `json:"ipv4_addressing_type"`
 	Ipv6AddressingType ctPrimitiveIPv6AddressingType `json:"ipv6_addressing_type"`
 	SecurityZone       *ObjectId                     `json:"security_zone"`
+	L3Mtu              *uint16                       `json:"l3_mtu"`
 }
 
 func (o rawConnectivityTemplatePrimitiveAttributesAttachLogicalLink) polish(t *ConnectivityTemplatePrimitiveAttributesAttachLogicalLink) error {
@@ -675,6 +678,7 @@ func (o rawConnectivityTemplatePrimitiveAttributesAttachLogicalLink) polish(t *C
 	t.Vlan = o.Vlan
 	t.IPv4AddressingType = CtPrimitiveIPv4AddressingType(ipv4AddressingType)
 	t.IPv6AddressingType = CtPrimitiveIPv6AddressingType(ipv6AddressingType)
+	t.L3Mtu = o.L3Mtu
 
 	return nil
 }


### PR DESCRIPTION
This PR adds the `L3Mtu` field to the `AttachLogicalLink` CT primitive.

Because this option is version-dependent, it required changing the test framework to include a version constraint for each test case, and to use `t.Run()` so that individual test cases can be skipped without blowing up the whole test.