### PR TITLE
Set test client timeout to 30s

### DIFF
--- a/apstra/test_clients_test.go
+++ b/apstra/test_clients_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 const (
+	clientTimeoutSeconds = 30
+
 	clientTypeCloudlabs = "cloudlabs"
 	clientTypeAws       = "aws"
 
@@ -47,6 +49,10 @@ func getTestClients(ctx context.Context, t *testing.T) (map[string]testClient, e
 		for k := range clientCfgs {
 			clientCfgs[k].cfg.Experimental = true
 		}
+	}
+
+	for k := range clientCfgs {
+		clientCfgs[k].cfg.Timeout = clientTimeoutSeconds * time.Second
 	}
 
 	testClients = make(map[string]testClient, len(clientCfgs))


### PR DESCRIPTION
When testing, the default timeout is sometimes too short (internet blip? Apstra too busy? it probably doesn't matter)

This PR sets the test client timeout to 30s to cut down on timeout-related test failures.