### PR TITLE
Introduce blueprint client node ID cache

### DIFF
--- a/apstra/client.go
+++ b/apstra/client.go
@@ -138,9 +138,11 @@ func (o *Client) NewTwoStageL3ClosClient(ctx context.Context, blueprintId Object
 		return nil, fmt.Errorf("cannot create '%s' client for blueprint '%s' (type '%s')",
 			RefDesignTwoStageL3Clos.String(), blueprintId, bp.Design)
 	}
+
 	result := &TwoStageL3ClosClient{
-		client:      o,
-		blueprintId: blueprintId,
+		client:        o,
+		blueprintId:   blueprintId,
+		nodeIdsByType: make(map[NodeType][]ObjectId),
 	}
 	result.Mutex = &TwoStageL3ClosMutex{client: result}
 

--- a/apstra/two_stage_l3_clos_client_integration_test.go
+++ b/apstra/two_stage_l3_clos_client_integration_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_client_integration_test.go
+++ b/apstra/two_stage_l3_clos_client_integration_test.go
@@ -1,0 +1,64 @@
+package apstra
+
+import (
+	"context"
+	"log"
+	"testing"
+)
+
+func TestNodeIdsByType(t *testing.T) {
+	ctx := context.Background()
+
+	clients, err := getTestClients(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for clientName, client := range clients {
+		testBlueprintANodeCount := 4
+		bpClient, bpDel := testBlueprintA(ctx, t, client.client)
+		defer func() {
+			err = bpDel(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		if len(bpClient.nodeIdsByType) != 0 {
+			t.Fatal("nodeIdsByType should be empty with a new blueprint client")
+		}
+
+		log.Printf("testing NodeIdsByType() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		systemIds, err := bpClient.NodeIdsByType(ctx, NodeTypeSystem)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(systemIds) != testBlueprintANodeCount {
+			t.Fatalf("expected %d nodes, got %d nodes", testBlueprintANodeCount, len(systemIds))
+		}
+
+		log.Printf("purging system node slice")
+		bpClient.nodeIdsByType[NodeTypeSystem] = []ObjectId{}
+
+		log.Printf("testing NodeIdsByType() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		systemIds, err = bpClient.NodeIdsByType(ctx, NodeTypeSystem)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(systemIds) != 0 {
+			t.Fatalf("expected 0 nodes, got %d nodes", len(systemIds))
+		}
+
+		log.Printf("testing RefreshNodeIdsByType() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		systemIds, err = bpClient.RefreshNodeIdsByType(ctx, NodeTypeSystem)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(systemIds) != testBlueprintANodeCount {
+			t.Fatalf("expected %d nodes, got %d nodes", testBlueprintANodeCount, len(systemIds))
+		}
+	}
+}


### PR DESCRIPTION
This PR introduces a cache (`map[NodeType][]ObjectId`) and methods for interacting with it to the `TwoStageL3ClosClient` object.

The idea is to simplify the common task of determining the IDs of graph nodes, and speed up consumers of that data by caching the results.

Now, rather than composing a complicated graph query and parsing the response, callers can just do:

```go
err, nodeIds := myClient.NodeIdsByType(ctx, NodeTypeSystem)
```

If `NodeTypeSystem` IDs have already been cached, they'll be returned. Otherwise, we'll perform the graph query, cache the results, and then return them.

If the caller wants fresh node data, they can force an update with:

```go
err, nodeIds := myClient.RefreshNodeIdsByType(ctx, NodeTypeSystem)
```
