### PR TITLE
Update client's map of mutex handling

### DIFF
--- a/apstra/client.go
+++ b/apstra/client.go
@@ -256,7 +256,7 @@ func (o *Client) lock(id string) {
 
 		mu.Lock()
 	} else {
-		mu := &sync.Mutex{}
+		mu = new(sync.Mutex)
 		mu.Lock()
 		o.sync[id] = mu
 
@@ -266,7 +266,14 @@ func (o *Client) lock(id string) {
 
 // unlock releases the named *sync.Mutex in Client.sync
 func (o *Client) unlock(id string) {
-	o.sync[id].Unlock()
+	o.syncLock.Lock()
+	defer o.syncLock.Unlock()
+
+	if mu, ok := o.sync[id]; ok {
+		mu.Unlock()
+	} else {
+		panic("attempt to unlock unknown mutex: '" + id + "'")
+	}
 }
 
 // Login submits username and password from the ClientCfg (Client.cfg) to the

--- a/apstra/two_stage_l3_clos_client.go
+++ b/apstra/two_stage_l3_clos_client.go
@@ -964,8 +964,9 @@ func (o *TwoStageL3ClosClient) refreshNodeIdsByType(ctx context.Context, nt Node
 }
 
 func (o *TwoStageL3ClosClient) NodeIdsByType(ctx context.Context, nt NodeType) ([]ObjectId, error) {
-	o.client.lock(o.blueprintId.String() + "_" + "node_ids")
-	defer o.client.unlock(o.blueprintId.String() + "_" + "node_ids")
+	lockId := o.lockId("node_ids")
+	o.client.lock(lockId)
+	defer o.client.unlock(lockId)
 
 	if nodeIds, ok := o.nodeIdsByType[nt]; ok {
 		return nodeIds, nil // already done!
@@ -980,8 +981,9 @@ func (o *TwoStageL3ClosClient) NodeIdsByType(ctx context.Context, nt NodeType) (
 }
 
 func (o *TwoStageL3ClosClient) RefreshNodeIdsByType(ctx context.Context, nt NodeType) ([]ObjectId, error) {
-	o.client.lock(o.blueprintId.String() + "_" + "node_ids")
-	defer o.client.unlock(o.blueprintId.String() + "_" + "node_ids")
+	lockId := o.lockId("node_ids")
+	o.client.lock(lockId)
+	defer o.client.unlock(lockId)
 
 	err := o.refreshNodeIdsByType(ctx, nt)
 	if err != nil {


### PR DESCRIPTION
Minor changes to handling map-of-mutexes in client object:

- Lock the lock-of-locks (`o.syncLock`) before consulting `o.sync` map to avoid concurrent map write crash.
- Eliminate unnecessary redeclaration of `mu` in  `func (o *Client) lock()`.
- Use `new()` style variable declaration.