### PR TITLE
Introduce structured error payload to `ClientErr`

### DIFF
--- a/apstra/client.go
+++ b/apstra/client.go
@@ -32,6 +32,7 @@ const (
 	ErrUncommitted
 	ErrWrongType
 	ErrReadOnly
+	ErrCtAssignedToLink
 
 	clientPollingIntervalMs = 1000
 
@@ -39,9 +40,14 @@ const (
 	mutexKeyHttpHeaders = "http headers"
 )
 
+type ErrCtAssignedToLinkDetail struct {
+	LinkIds []ObjectId
+}
+
 type ClientErr struct {
 	errType int
 	err     error
+	detail  interface{}
 }
 
 func (o ClientErr) Error() string {
@@ -50,6 +56,10 @@ func (o ClientErr) Error() string {
 
 func (o ClientErr) Type() int {
 	return o.errType
+}
+
+func (o ClientErr) Detail() interface{} {
+	return o.detail
 }
 
 type apstraHttpClient interface {

--- a/apstra/task_monitor.go
+++ b/apstra/task_monitor.go
@@ -46,6 +46,13 @@ type getAllTasksResponse struct {
 	} `json:"items"`
 }
 
+type detailedStatus struct {
+	ApiResponse            json.RawMessage `json:"api_response"`
+	ConfigBlueprintVersion int             `json:"config_blueprint_version"`
+	Errors                 json.RawMessage `json:"errors"`
+	ErrorCode              int             `json:"error_code"`
+}
+
 // getTaskResponse is sent by Apstra in response to GET at
 // 'apiUrlTaskPrefix + blueprintId + apiUrlTaskSuffix + taskId'
 type getTaskResponse struct {
@@ -58,20 +65,15 @@ type getTaskResponse struct {
 		Data    json.RawMessage   `json:"data"`
 		Method  string            `json:"method"`
 	} `json:"request_data"`
-	UserId         string `json:"user_id"`
-	LastUpdatedAt  string `json:"last_updated_at"`
-	UserName       string `json:"user_name"`
-	CreatedAt      string `json:"created_at"`
-	DetailedStatus struct {
-		ApiResponse            json.RawMessage `json:"api_response"`
-		ConfigBlueprintVersion int             `json:"config_blueprint_version"`
-		Errors                 json.RawMessage `json:"errors"`
-		ErrorCode              int             `json:"error_code"`
-	} `json:"detailed_status"`
-	ConfigLastUpdatedAt string `json:"config_last_updated_at"`
-	UserIp              string `json:"user_ip"`
-	Type                string `json:"type"`
-	Id                  TaskId `json:"id"`
+	UserId              string         `json:"user_id"`
+	LastUpdatedAt       string         `json:"last_updated_at"`
+	UserName            string         `json:"user_name"`
+	CreatedAt           string         `json:"created_at"`
+	DetailedStatus      detailedStatus `json:"detailed_status"`
+	ConfigLastUpdatedAt string         `json:"config_last_updated_at"`
+	UserIp              string         `json:"user_ip"`
+	Type                string         `json:"type"`
+	Id                  TaskId         `json:"id"`
 }
 
 // taskMonitorMonReq uniquely identifies an Apstra task which can be tracked at


### PR DESCRIPTION
This PR adds a new field (`detail`) and method (`Detail()`) to `ApstraClientErr{}`

The idea is to provide a way for consumers to get structured data relevant to the specific error type.

The first implementation is for a new error type (`ErrCtAssignedToLink`) which details link IDs which could not be deleted because they're blocked by an assigned Connectivity Template.