### PR TITLE
Remove redundant declaration of `toPtr()`

### DIFF
--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -676,7 +676,3 @@ func testTemplateB(ctx context.Context, t *testing.T, client *Client) (ObjectId,
 
 	return id, deleteFunc
 }
-
-func toPtr[A any](a A) *A {
-	return &a
-}


### PR DESCRIPTION
I broke `main` but writing `toPtr()` in two places in two different branches and then merging them together.

This PR removes one of them.