### PR TITLE
Add fabric-settings methods for apstra 4.1.x

### DIFF
--- a/apstra/api_design_templates.go
+++ b/apstra/api_design_templates.go
@@ -134,6 +134,15 @@ func (o AntiAffinityMode) String() string {
 	}
 }
 
+func (o *AntiAffinityMode) FromString(s string) error {
+	i, err := antiAffinityMode(s).parse()
+	if err != nil {
+		return err
+	}
+	*o = AntiAffinityMode(i)
+	return nil
+}
+
 func (o AntiAffinityMode) raw() antiAffinityMode {
 	return antiAffinityMode(o.String())
 }

--- a/apstra/two_stage_l3_clos_anti_affinity_policy.go
+++ b/apstra/two_stage_l3_clos_anti_affinity_policy.go
@@ -11,7 +11,8 @@ const (
 	apiUrlBlueprintAntiAffinityPolicy = apiUrlBlueprintByIdPrefix + "anti-affinity-policy"
 )
 
-func (o *TwoStageL3ClosClient) getAntiAffinityPolicy420(ctx context.Context) (*rawAntiAffinityPolicy, error) {
+// getAntiAffinityPolicy is for Apstra 4.2.0 and earlier (not available in 4.2.1)
+func (o *TwoStageL3ClosClient) getAntiAffinityPolicy(ctx context.Context) (*rawAntiAffinityPolicy, error) {
 	if !version.MustConstraints(version.NewConstraint("<=" + apstra420)).Check(o.client.apiVersion) {
 		return nil, fmt.Errorf("apstra %s does not support %q", o.client.apiVersion, apiUrlBlueprintAntiAffinityPolicy)
 	}
@@ -29,7 +30,8 @@ func (o *TwoStageL3ClosClient) getAntiAffinityPolicy420(ctx context.Context) (*r
 	return &result, nil
 }
 
-func (o *TwoStageL3ClosClient) setAntiAffinityPolicy420(ctx context.Context, in *rawAntiAffinityPolicy) error {
+// setAntiAffinityPolicy is for Apstra 4.2.0 and earlier (not available in 4.2.1)
+func (o *TwoStageL3ClosClient) setAntiAffinityPolicy(ctx context.Context, in *rawAntiAffinityPolicy) error {
 	if in == nil {
 		return nil
 	}

--- a/apstra/two_stage_l3_clos_client.go
+++ b/apstra/two_stage_l3_clos_client.go
@@ -1004,6 +1004,8 @@ func (o *TwoStageL3ClosClient) GetFabricSettings(ctx context.Context) (*FabricSe
 		raw, err = o.getFabricSettings(ctx)
 	case version.MustConstraints(version.NewConstraint(apstra420)).Check(o.client.apiVersion):
 		raw, err = o.getFabricSettings420(ctx)
+	case version.MustConstraints(version.NewConstraint(">=" + apstra410 + ",<" + apstra420)).Check(o.client.apiVersion):
+		raw, err = o.getFabricSettings41x(ctx)
 	default:
 		return nil, fmt.Errorf("cannot invoke GetFabricSettings, not supported with Apstra version %q", o.client.apiVersion)
 	}
@@ -1022,6 +1024,8 @@ func (o *TwoStageL3ClosClient) SetFabricSettings(ctx context.Context, in *Fabric
 		return o.setFabricSettings(ctx, in.raw())
 	case version.MustConstraints(version.NewConstraint(apstra420)).Check(o.client.apiVersion):
 		return o.setFabricSettings420(ctx, in.raw())
+	case version.MustConstraints(version.NewConstraint(">=" + apstra410 + ",<" + apstra420)).Check(o.client.apiVersion):
+		return o.setFabricSettings41x(ctx, in.raw())
 	}
 
 	return fmt.Errorf("cannot invoke SetFabricSettings, not supported with Apstra version %q", o.client.apiVersion)

--- a/apstra/two_stage_l3_clos_fabric_settings.go
+++ b/apstra/two_stage_l3_clos_fabric_settings.go
@@ -20,27 +20,25 @@ var (
 	junosEvpnRoutingInstanceTypes         = enum.New(junosEvpnRoutingInstanceTypeVlanAware, junosEvpnRoutingInstanceTypeDefault)
 )
 
-type FabricSettings struct {
-	JunosEvpnDuplicateMacRecoveryTime     *uint16                 // supported in 4.2.0 (not in GUI)
-	MaxExternalRoutes                     *uint32                 // supported in 4.2.0 ( virtual-network-policy)
-	EsiMacMsb                             *uint8                  // supported in 4.2.0 (fabric-addressing-policy)
-	JunosGracefulRestart                  *FeatureSwitchEnum      // supported in 4.2.0 ( virtual-network-policy)
-	OptimiseSzFootprint                   *FeatureSwitchEnum      // supported in 4.2.0 (patch fabric-settings node)
-	JunosEvpnRoutingInstanceVlanAware     *FeatureSwitchEnum      // supported in 4.2.0 ( virtual-network-policy)
-	EvpnGenerateType5HostRoutes           *FeatureSwitchEnum      // supported in 4.2.0 ( virtual-network-policy)
-	MaxFabricRoutes                       *uint32                 // supported in 4.2.0 ( virtual-network-policy)
-	MaxMlagRoutes                         *uint32                 // supported in 4.2.0 ( virtual-network-policy)
-	JunosExOverlayEcmp                    *FeatureSwitchEnum      // supported in 4.2.0 ( virtual-network-policy)
-	DefaultSviL3Mtu                       *uint16                 // supported in 4.2.0 ( virtual-network-policy)
-	JunosEvpnMaxNexthopAndInterfaceNumber *FeatureSwitchEnum      // supported in 4.2.0 ( virtual-network-policy)
-	FabricL3Mtu                           *uint16                 // supported in 4.2.0 (fabric-addressing-policy)
-	Ipv6Enabled                           *bool                   // supported in 4.2.0 (fabric-addressing-policy)
-	OverlayControlProtocol                *OverlayControlProtocol // supported in 4.2.0 ( virtual-network-policy)
-	ExternalRouterMtu                     *uint16                 // supported in 4.2.0 ( virtual-network-policy)
-	MaxEvpnRoutes                         *uint32                 // supported in 4.2.0 (virtual-network-policy)
-	AntiAffinityPolicy                    *AntiAffinityPolicy     // supported in 4.2.0 (anti-affinity-policy)
-	//DefaultFabricEviRouteTarget                 string   					Not Exposed via WebUI
-	//FrrRdVlanOffset                             string					Not Exposed via WebUI
+type FabricSettings struct { //										 4.2.0							4.1.2							4.1.1							4.1.0
+	AntiAffinityPolicy                    *AntiAffinityPolicy     // /anti-affinity-policy			/anti-affinity-policy			/anti-affinity-policy			/anti-affinity-policy
+	DefaultSviL3Mtu                       *uint16                 // virtual_network_policy node	not supported					not supported					not supported.
+	EsiMacMsb                             *uint8                  // /fabric-addressing-policy		/fabric-addressing-policy		/fabric-addressing-policy		/fabric-addressing-policy
+	EvpnGenerateType5HostRoutes           *FeatureSwitchEnum      // virtual_network_policy node	virtual_network_policy node		virtual_network_policy node		virtual_network_policy node
+	ExternalRouterMtu                     *uint16                 // virtual_network_policy node	virtual_network_policy node		virtual_network_policy node		virtual_network_policy node
+	FabricL3Mtu                           *uint16                 // /fabric-addressing-policy		not supported					not supported					not supported
+	Ipv6Enabled                           *bool                   // /fabric-addressing-policy		/fabric-addressing-policy		/fabric-addressing-policy		/fabric-addressing-policy
+	JunosEvpnDuplicateMacRecoveryTime     *uint16                 // virtual_network_policy node	not supported					not supported					not supported
+	JunosEvpnMaxNexthopAndInterfaceNumber *FeatureSwitchEnum      // virtual_network_policy node	not supported					not supported					not supported
+	JunosEvpnRoutingInstanceVlanAware     *FeatureSwitchEnum      // virtual_network_policy node	not supported					not supported					not supported
+	JunosExOverlayEcmp                    *FeatureSwitchEnum      // virtual_network_policy node	not supported					not supported					not supported
+	JunosGracefulRestart                  *FeatureSwitchEnum      // virtual_network_policy node	not supported					not supported					not supported
+	MaxEvpnRoutes                         *uint32                 // virtual_network_policy node	virtual_network_policy node		virtual_network_policy node		virtual_network_policy node
+	MaxExternalRoutes                     *uint32                 // virtual_network_policy node	virtual_network_policy node		virtual_network_policy node		virtual_network_policy node
+	MaxFabricRoutes                       *uint32                 // virtual_network_policy node	virtual_network_policy node		virtual_network_policy node		virtual_network_policy node
+	MaxMlagRoutes                         *uint32                 // virtual_network_policy node	virtual_network_policy node		virtual_network_policy node		virtual_network_policy node
+	OptimiseSzFootprint                   *FeatureSwitchEnum      // security_zone_policy node		not supported					not supported					not supported
+	OverlayControlProtocol                *OverlayControlProtocol // virtual_network_policy node	virtual_network_policy node		virtual_network_policy node		virtual_network_policy node
 }
 
 func (o FabricSettings) raw() *rawFabricSettings {
@@ -58,48 +56,46 @@ func (o FabricSettings) raw() *rawFabricSettings {
 		}
 	}
 	return &rawFabricSettings{
-		JunosEvpnDuplicateMacRecoveryTime:     o.JunosEvpnDuplicateMacRecoveryTime,
-		MaxExternalRoutes:                     o.MaxExternalRoutes,
-		EsiMacMsb:                             o.EsiMacMsb,
-		JunosGracefulRestart:                  stringerPtrToStringPtr(o.JunosGracefulRestart),
-		OptimiseSzFootprint:                   stringerPtrToStringPtr(o.OptimiseSzFootprint),
-		JunosEvpnRoutingInstanceType:          jeriType,
-		EvpnGenerateType5HostRoutes:           stringerPtrToStringPtr(o.EvpnGenerateType5HostRoutes),
-		MaxFabricRoutes:                       o.MaxFabricRoutes,
-		MaxMlagRoutes:                         o.MaxMlagRoutes,
-		JunosExOverlayEcmp:                    stringerPtrToStringPtr(o.JunosExOverlayEcmp),
+		AntiAffinity:                          antiAffinityPolicy,
 		DefaultSviL3Mtu:                       o.DefaultSviL3Mtu,
-		JunosEvpnMaxNexthopAndInterfaceNumber: stringerPtrToStringPtr(o.JunosEvpnMaxNexthopAndInterfaceNumber),
+		EsiMacMsb:                             o.EsiMacMsb,
+		EvpnGenerateType5HostRoutes:           stringerPtrToStringPtr(o.EvpnGenerateType5HostRoutes),
+		ExternalRouterMtu:                     o.ExternalRouterMtu,
 		FabricL3Mtu:                           o.FabricL3Mtu,
 		Ipv6Enabled:                           o.Ipv6Enabled,
-		OverlayControlProtocol:                stringerPtrToStringPtr(o.OverlayControlProtocol),
-		ExternalRouterMtu:                     o.ExternalRouterMtu,
+		JunosEvpnDuplicateMacRecoveryTime:     o.JunosEvpnDuplicateMacRecoveryTime,
+		JunosEvpnMaxNexthopAndInterfaceNumber: stringerPtrToStringPtr(o.JunosEvpnMaxNexthopAndInterfaceNumber),
+		JunosEvpnRoutingInstanceType:          jeriType,
+		JunosExOverlayEcmp:                    stringerPtrToStringPtr(o.JunosExOverlayEcmp),
+		JunosGracefulRestart:                  stringerPtrToStringPtr(o.JunosGracefulRestart),
 		MaxEvpnRoutes:                         o.MaxEvpnRoutes,
-		AntiAffinity:                          antiAffinityPolicy,
+		MaxExternalRoutes:                     o.MaxExternalRoutes,
+		MaxFabricRoutes:                       o.MaxFabricRoutes,
+		MaxMlagRoutes:                         o.MaxMlagRoutes,
+		OptimiseSzFootprint:                   stringerPtrToStringPtr(o.OptimiseSzFootprint),
+		OverlayControlProtocol:                stringerPtrToStringPtr(o.OverlayControlProtocol),
 	}
 }
 
 type rawFabricSettings struct {
-	JunosEvpnDuplicateMacRecoveryTime     *uint16                `json:"junos_evpn_duplicate_mac_recovery_time,omitempty"`
-	MaxExternalRoutes                     *uint32                `json:"max_external_routes,omitempty"`
-	EsiMacMsb                             *uint8                 `json:"esi_mac_msb,omitempty"`
-	JunosGracefulRestart                  *string                `json:"junos_graceful_restart,omitempty"`
-	OptimiseSzFootprint                   *string                `json:"optimise_sz_footprint,omitempty"`
-	JunosEvpnRoutingInstanceType          *string                `json:"junos_evpn_routing_instance_type,omitempty"`
-	EvpnGenerateType5HostRoutes           *string                `json:"evpn_generate_type5_host_routes,omitempty"`
-	MaxFabricRoutes                       *uint32                `json:"max_fabric_routes,omitempty"`
-	MaxMlagRoutes                         *uint32                `json:"max_mlag_routes,omitempty"`
-	JunosExOverlayEcmp                    *string                `json:"junos_ex_overlay_ecmp,omitempty"`
+	AntiAffinity                          *rawAntiAffinityPolicy `json:"anti_affinity,omitempty"`
 	DefaultSviL3Mtu                       *uint16                `json:"default_svi_l3_mtu,omitempty"`
-	JunosEvpnMaxNexthopAndInterfaceNumber *string                `json:"junos_evpn_max_nexthop_and_interface_number,omitempty"`
+	EsiMacMsb                             *uint8                 `json:"esi_mac_msb,omitempty"`
+	EvpnGenerateType5HostRoutes           *string                `json:"evpn_generate_type5_host_routes,omitempty"`
+	ExternalRouterMtu                     *uint16                `json:"external_router_mtu,omitempty"`
 	FabricL3Mtu                           *uint16                `json:"fabric_l3_mtu,omitempty"`
 	Ipv6Enabled                           *bool                  `json:"ipv6_enabled,omitempty"`
-	OverlayControlProtocol                *string                `json:"overlay_control_protocol,omitempty"`
-	ExternalRouterMtu                     *uint16                `json:"external_router_mtu,omitempty"`
+	JunosEvpnDuplicateMacRecoveryTime     *uint16                `json:"junos_evpn_duplicate_mac_recovery_time,omitempty"`
+	JunosEvpnMaxNexthopAndInterfaceNumber *string                `json:"junos_evpn_max_nexthop_and_interface_number,omitempty"`
+	JunosEvpnRoutingInstanceType          *string                `json:"junos_evpn_routing_instance_type,omitempty"`
+	JunosExOverlayEcmp                    *string                `json:"junos_ex_overlay_ecmp,omitempty"`
+	JunosGracefulRestart                  *string                `json:"junos_graceful_restart,omitempty"`
 	MaxEvpnRoutes                         *uint32                `json:"max_evpn_routes,omitempty"`
-	AntiAffinity                          *rawAntiAffinityPolicy `json:"anti_affinity,omitempty"`
-	//FrrRdVlanOffset                       string                `json:"frr_rd_vlan_offset"`
-	//DefaultFabricEviRouteTarget           string                `json:"default_fabric_evi_route_target"`
+	MaxExternalRoutes                     *uint32                `json:"max_external_routes,omitempty"`
+	MaxFabricRoutes                       *uint32                `json:"max_fabric_routes,omitempty"`
+	MaxMlagRoutes                         *uint32                `json:"max_mlag_routes,omitempty"`
+	OptimiseSzFootprint                   *string                `json:"optimise_sz_footprint,omitempty"`
+	OverlayControlProtocol                *string                `json:"overlay_control_protocol,omitempty"`
 }
 
 func (o rawFabricSettings) polish() (*FabricSettings, error) {
@@ -130,24 +126,24 @@ func (o rawFabricSettings) polish() (*FabricSettings, error) {
 		return nil, err
 	}
 	return &FabricSettings{
-		JunosEvpnDuplicateMacRecoveryTime:     o.JunosEvpnDuplicateMacRecoveryTime,
-		MaxExternalRoutes:                     o.MaxExternalRoutes,
-		EsiMacMsb:                             o.EsiMacMsb,
-		JunosGracefulRestart:                  featureSwitchEnumFromStringPtr(o.JunosGracefulRestart),
-		OptimiseSzFootprint:                   featureSwitchEnumFromStringPtr(o.OptimiseSzFootprint),
-		JunosEvpnRoutingInstanceVlanAware:     junosEvpnRoutingInstanceVlanAware,
-		EvpnGenerateType5HostRoutes:           featureSwitchEnumFromStringPtr(o.EvpnGenerateType5HostRoutes),
-		MaxFabricRoutes:                       o.MaxFabricRoutes,
-		MaxMlagRoutes:                         o.MaxMlagRoutes,
-		JunosExOverlayEcmp:                    featureSwitchEnumFromStringPtr(o.JunosExOverlayEcmp),
+		AntiAffinityPolicy:                    antiAffinityPolicy,
 		DefaultSviL3Mtu:                       o.DefaultSviL3Mtu,
-		JunosEvpnMaxNexthopAndInterfaceNumber: featureSwitchEnumFromStringPtr(o.JunosEvpnMaxNexthopAndInterfaceNumber),
+		EsiMacMsb:                             o.EsiMacMsb,
+		EvpnGenerateType5HostRoutes:           featureSwitchEnumFromStringPtr(o.EvpnGenerateType5HostRoutes),
+		ExternalRouterMtu:                     o.ExternalRouterMtu,
 		FabricL3Mtu:                           o.FabricL3Mtu,
 		Ipv6Enabled:                           o.Ipv6Enabled,
-		OverlayControlProtocol:                ocp,
-		ExternalRouterMtu:                     o.ExternalRouterMtu,
+		JunosEvpnDuplicateMacRecoveryTime:     o.JunosEvpnDuplicateMacRecoveryTime,
+		JunosEvpnMaxNexthopAndInterfaceNumber: featureSwitchEnumFromStringPtr(o.JunosEvpnMaxNexthopAndInterfaceNumber),
+		JunosEvpnRoutingInstanceVlanAware:     junosEvpnRoutingInstanceVlanAware,
+		JunosExOverlayEcmp:                    featureSwitchEnumFromStringPtr(o.JunosExOverlayEcmp),
+		JunosGracefulRestart:                  featureSwitchEnumFromStringPtr(o.JunosGracefulRestart),
 		MaxEvpnRoutes:                         o.MaxEvpnRoutes,
-		AntiAffinityPolicy:                    antiAffinityPolicy,
+		MaxExternalRoutes:                     o.MaxExternalRoutes,
+		MaxFabricRoutes:                       o.MaxFabricRoutes,
+		MaxMlagRoutes:                         o.MaxMlagRoutes,
+		OptimiseSzFootprint:                   featureSwitchEnumFromStringPtr(o.OptimiseSzFootprint),
+		OverlayControlProtocol:                ocp,
 	}, nil
 }
 
@@ -165,6 +161,8 @@ func (o *TwoStageL3ClosClient) getFabricSettings(ctx context.Context) (*rawFabri
 	return &response, nil
 }
 
+// getFabricSettings420 does the same job as setFabricSettings, but for Apstra 4.2.0, which collects
+// the parameters in rawFabricSettings from 3 different places
 func (o *TwoStageL3ClosClient) getFabricSettings420(ctx context.Context) (*rawFabricSettings, error) {
 	fabricAddressingPolicy, err := o.GetFabricAddressingPolicy(ctx)
 	if err != nil {
@@ -181,33 +179,62 @@ func (o *TwoStageL3ClosClient) getFabricSettings420(ctx context.Context) (*rawFa
 		return nil, err
 	}
 
-	antiAffinityPolicy, err := o.getAntiAffinityPolicy420(ctx)
+	antiAffinityPolicy, err := o.getAntiAffinityPolicy(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	return &rawFabricSettings{
-		EsiMacMsb:   fabricAddressingPolicy.EsiMacMsb,
-		FabricL3Mtu: fabricAddressingPolicy.FabricL3Mtu,
-		Ipv6Enabled: fabricAddressingPolicy.Ipv6Enabled,
-
-		JunosEvpnDuplicateMacRecoveryTime:     virtualNetworkPolicy.JunosEvpnDuplicateMacRecoveryTime,
-		MaxExternalRoutes:                     virtualNetworkPolicy.MaxExternalRoutes,
-		JunosGracefulRestart:                  virtualNetworkPolicy.JunosGracefulRestart,
-		JunosEvpnRoutingInstanceType:          virtualNetworkPolicy.JunosEvpnRoutingInstanceType,
+		AntiAffinity:                          antiAffinityPolicy,
+		DefaultSviL3Mtu:                       virtualNetworkPolicy.DefaultSviL3Mtu,
+		EsiMacMsb:                             fabricAddressingPolicy.EsiMacMsb,
 		EvpnGenerateType5HostRoutes:           virtualNetworkPolicy.EvpnGenerateType5HostRoutes,
+		ExternalRouterMtu:                     virtualNetworkPolicy.ExternalRouterMtu,
+		FabricL3Mtu:                           fabricAddressingPolicy.FabricL3Mtu,
+		Ipv6Enabled:                           fabricAddressingPolicy.Ipv6Enabled,
+		JunosEvpnDuplicateMacRecoveryTime:     virtualNetworkPolicy.JunosEvpnDuplicateMacRecoveryTime,
+		JunosEvpnMaxNexthopAndInterfaceNumber: virtualNetworkPolicy.JunosEvpnMaxNexthopAndInterfaceNumber,
+		JunosEvpnRoutingInstanceType:          virtualNetworkPolicy.JunosEvpnRoutingInstanceType,
+		JunosExOverlayEcmp:                    virtualNetworkPolicy.JunosExOverlayEcmp,
+		JunosGracefulRestart:                  virtualNetworkPolicy.JunosGracefulRestart,
+		MaxEvpnRoutes:                         virtualNetworkPolicy.MaxEvpnRoutes,
+		MaxExternalRoutes:                     virtualNetworkPolicy.MaxExternalRoutes,
 		MaxFabricRoutes:                       virtualNetworkPolicy.MaxFabricRoutes,
 		MaxMlagRoutes:                         virtualNetworkPolicy.MaxMlagRoutes,
-		JunosExOverlayEcmp:                    virtualNetworkPolicy.JunosExOverlayEcmp,
-		DefaultSviL3Mtu:                       virtualNetworkPolicy.DefaultSviL3Mtu,
-		JunosEvpnMaxNexthopAndInterfaceNumber: virtualNetworkPolicy.JunosEvpnMaxNexthopAndInterfaceNumber,
-		ExternalRouterMtu:                     virtualNetworkPolicy.ExternalRouterMtu,
-		MaxEvpnRoutes:                         virtualNetworkPolicy.MaxEvpnRoutes,
+		OptimiseSzFootprint:                   &optimiseFootprint,
 		OverlayControlProtocol:                virtualNetworkPolicy.OverlayControlProtocol,
+	}, nil
+}
 
-		OptimiseSzFootprint: &optimiseFootprint,
+// getFabricSettings41x does the same job as setFabricSettings, but for Apstra 4.1.x, which collects
+// the parameters in rawFabricSettings from 3 different places
+func (o *TwoStageL3ClosClient) getFabricSettings41x(ctx context.Context) (*rawFabricSettings, error) {
+	fabricAddressingPolicy, err := o.GetFabricAddressingPolicy(ctx)
+	if err != nil {
+		return nil, err
+	}
 
-		AntiAffinity: antiAffinityPolicy,
+	virtualNetworkPolicy, err := o.getVirtualNetworkPolicy41x(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	antiAffinityPolicy, err := o.getAntiAffinityPolicy(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &rawFabricSettings{
+		AntiAffinity:                antiAffinityPolicy,
+		EsiMacMsb:                   fabricAddressingPolicy.EsiMacMsb,
+		EvpnGenerateType5HostRoutes: virtualNetworkPolicy.EvpnGenerateType5HostRoutes,
+		ExternalRouterMtu:           virtualNetworkPolicy.ExternalRouterMtu,
+		Ipv6Enabled:                 fabricAddressingPolicy.Ipv6Enabled,
+		MaxEvpnRoutes:               virtualNetworkPolicy.MaxEvpnRoutes,
+		MaxExternalRoutes:           virtualNetworkPolicy.MaxExternalRoutes,
+		MaxFabricRoutes:             virtualNetworkPolicy.MaxFabricRoutes,
+		MaxMlagRoutes:               virtualNetworkPolicy.MaxMlagRoutes,
+		OverlayControlProtocol:      virtualNetworkPolicy.OverlayControlProtocol,
 	}, nil
 }
 
@@ -232,6 +259,9 @@ func (o *TwoStageL3ClosClient) setFabricSettings420(ctx context.Context, in *raw
 		EsiMacMsb:   in.EsiMacMsb,
 		FabricL3Mtu: in.FabricL3Mtu,
 	})
+	if err != nil {
+		return err
+	}
 
 	err = o.setVirtualNetworkPolicy420(ctx, in)
 	if err != nil {
@@ -243,7 +273,31 @@ func (o *TwoStageL3ClosClient) setFabricSettings420(ctx context.Context, in *raw
 		return err
 	}
 
-	err = o.setAntiAffinityPolicy420(ctx, in.AntiAffinity)
+	err = o.setAntiAffinityPolicy(ctx, in.AntiAffinity)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// setFabricSettings41x does the same job as setFabricSettings, but for Apstra 4.1.x, which controls
+// the parameters in rawFabricSettings in 3 different places
+func (o *TwoStageL3ClosClient) setFabricSettings41x(ctx context.Context, in *rawFabricSettings) error {
+	err := o.SetFabricAddressingPolicy(ctx, &TwoStageL3ClosFabricAddressingPolicy{
+		Ipv6Enabled: in.Ipv6Enabled,
+		EsiMacMsb:   in.EsiMacMsb,
+	})
+	if err != nil {
+		return err
+	}
+
+	err = o.setVirtualNetworkPolicy41x(ctx, in)
+	if err != nil {
+		return err
+	}
+
+	err = o.setAntiAffinityPolicy(ctx, in.AntiAffinity)
 	if err != nil {
 		return err
 	}

--- a/apstra/two_stage_l3_clos_fabric_settings_test.go
+++ b/apstra/two_stage_l3_clos_fabric_settings_test.go
@@ -5,11 +5,116 @@ package apstra
 
 import (
 	"context"
-	"fmt"
 	"github.com/hashicorp/go-version"
 	"log"
 	"testing"
 )
+
+func compareAntiAffinityPolicy(t testing.TB, set, get AntiAffinityPolicy) {
+	t.Helper()
+
+	if set.Algorithm != get.Algorithm {
+		t.Errorf("set AntiAffinityPolicy Algorithm %s got %s", set.Algorithm, get.Algorithm)
+	}
+
+	if set.MaxLinksPerPort != get.MaxLinksPerPort {
+		t.Errorf("set AntiAffinityPolicy MaxLinksPerPort %d got %d", set.MaxLinksPerPort, get.MaxLinksPerPort)
+	}
+
+	if set.MaxLinksPerSlot != get.MaxLinksPerSlot {
+		t.Errorf("set AntiAffinityPolicy MaxLinksPerSlot %d got %d", set.MaxLinksPerSlot, get.MaxLinksPerSlot)
+	}
+
+	if set.MaxPerSystemLinksPerPort != get.MaxPerSystemLinksPerPort {
+		t.Errorf("set AntiAffinityPolicy MaxPerSystemLinksPerPort %d got %d", set.MaxPerSystemLinksPerPort, get.MaxPerSystemLinksPerPort)
+	}
+
+	if set.MaxPerSystemLinksPerSlot != get.MaxPerSystemLinksPerSlot {
+		t.Errorf("set AntiAffinityPolicy MaxPerSystemLinksPerSlot %d got %d", set.MaxPerSystemLinksPerSlot, get.MaxPerSystemLinksPerSlot)
+	}
+
+	if set.Mode != get.Mode {
+		t.Errorf("set AntiAffinityPolicy Mode %s got %s", set.Mode, get.Mode)
+	}
+}
+
+func compareFabricSettings(t testing.TB, set, get FabricSettings) {
+	t.Helper()
+
+	if set.JunosEvpnDuplicateMacRecoveryTime != nil &&
+		*set.JunosEvpnDuplicateMacRecoveryTime != *get.JunosEvpnDuplicateMacRecoveryTime {
+		t.Errorf("set junosEvpnDuplicateMacRecoveryTime %d got %d", *set.JunosEvpnDuplicateMacRecoveryTime, *get.JunosEvpnDuplicateMacRecoveryTime)
+	}
+
+	if set.MaxExternalRoutes != nil && *set.MaxExternalRoutes != *get.MaxExternalRoutes {
+		t.Errorf("set MaxExternalRoutes %d got %d", *set.MaxExternalRoutes, *get.MaxExternalRoutes)
+	}
+
+	if set.EsiMacMsb != nil && *set.EsiMacMsb != *get.EsiMacMsb {
+		t.Errorf("set EsiMacMsb %d got %d", *set.EsiMacMsb, *get.EsiMacMsb)
+	}
+
+	if set.JunosGracefulRestart != nil && *set.JunosGracefulRestart != *get.JunosGracefulRestart {
+		t.Errorf("set JunosGracefulRestart %s got %s", *set.JunosGracefulRestart, *get.JunosGracefulRestart)
+	}
+
+	if set.OptimiseSzFootprint != nil && *set.OptimiseSzFootprint != *get.OptimiseSzFootprint {
+		t.Errorf("set OptimiseSzFootprint %s got %s", *set.OptimiseSzFootprint, *get.OptimiseSzFootprint)
+	}
+
+	if set.JunosEvpnRoutingInstanceVlanAware != nil && *set.JunosEvpnRoutingInstanceVlanAware != *get.JunosEvpnRoutingInstanceVlanAware {
+		t.Errorf("set JunosEvpnRoutingInstanceVlanAware %s got %s", *set.JunosEvpnRoutingInstanceVlanAware, *get.JunosEvpnRoutingInstanceVlanAware)
+	}
+
+	if set.EvpnGenerateType5HostRoutes != nil && *set.EvpnGenerateType5HostRoutes != *get.EvpnGenerateType5HostRoutes {
+		t.Errorf("set EvpnGenerateType5HostRoutes %s got %s", *set.EvpnGenerateType5HostRoutes, *get.EvpnGenerateType5HostRoutes)
+	}
+
+	if set.MaxFabricRoutes != nil && *set.MaxFabricRoutes != *get.MaxFabricRoutes {
+		t.Errorf("set MaxFabricRoutes %d got %d", *set.MaxFabricRoutes, *get.MaxFabricRoutes)
+	}
+
+	if set.MaxMlagRoutes != nil && *set.MaxMlagRoutes != *get.MaxMlagRoutes {
+		t.Errorf("set MaxMlagRoutes %d got %d", *set.MaxMlagRoutes, *get.MaxMlagRoutes)
+	}
+
+	if set.JunosEvpnRoutingInstanceVlanAware != nil && *set.JunosEvpnRoutingInstanceVlanAware != *get.JunosEvpnRoutingInstanceVlanAware {
+		t.Errorf("set JunosEvpnRoutingInstanceVlanAware %s got %s", *set.JunosEvpnRoutingInstanceVlanAware, *get.JunosEvpnRoutingInstanceVlanAware)
+	}
+
+	if set.DefaultSviL3Mtu != nil && *set.DefaultSviL3Mtu != *get.DefaultSviL3Mtu {
+		t.Errorf("set DefaultSviL3Mtu  %d got %d", *set.DefaultSviL3Mtu, *get.DefaultSviL3Mtu)
+	}
+
+	if set.JunosEvpnMaxNexthopAndInterfaceNumber != nil && *set.JunosEvpnMaxNexthopAndInterfaceNumber != *get.JunosEvpnMaxNexthopAndInterfaceNumber {
+		t.Errorf("set JunosEvpnMaxNexthopAndInterfaceNumber %s got %s", *set.JunosEvpnMaxNexthopAndInterfaceNumber, *get.JunosEvpnMaxNexthopAndInterfaceNumber)
+	}
+
+	if set.FabricL3Mtu != nil && *set.FabricL3Mtu != *get.FabricL3Mtu {
+		t.Errorf("set FabricL3Mtu  %d got %d", *set.FabricL3Mtu, *get.FabricL3Mtu)
+	}
+
+	if set.Ipv6Enabled != nil && *set.Ipv6Enabled != *get.Ipv6Enabled {
+		t.Errorf("set Ipv6Enabled %t got %t", *set.Ipv6Enabled, *get.Ipv6Enabled)
+	}
+
+	// don't check overlay control protocol - it's an immutable value. attempts to set it have no effect.
+	//if set.OverlayControlProtocol != get.OverlayControlProtocol {
+	//	t.Errorf("set OverlayControlProtocol %s got %s", set.OverlayControlProtocol, get.OverlayControlProtocol)
+	//}
+
+	if set.ExternalRouterMtu != nil && *set.ExternalRouterMtu != *get.ExternalRouterMtu {
+		t.Errorf("set ExternalRouterMtu %d got %d", *set.ExternalRouterMtu, *get.ExternalRouterMtu)
+	}
+
+	if set.MaxEvpnRoutes != nil && *set.MaxEvpnRoutes != *get.MaxEvpnRoutes {
+		t.Errorf("set MaxEvpnRoutes %d got %d", *set.MaxEvpnRoutes, *get.MaxEvpnRoutes)
+	}
+
+	if set.AntiAffinityPolicy != nil {
+		compareAntiAffinityPolicy(t, *get.AntiAffinityPolicy, *set.AntiAffinityPolicy)
+	}
+}
 
 func TestSetGetFabricSettings(t *testing.T) {
 	ctx := context.Background()
@@ -18,126 +123,57 @@ func TestSetGetFabricSettings(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	compareAntiAffinityPolicy := func(set, get AntiAffinityPolicy) error {
-		if set.Algorithm != get.Algorithm {
-			return fmt.Errorf("set AntiAffinityPolicy Algorithm %s got %s", set.Algorithm, get.Algorithm)
-		}
-
-		if set.MaxLinksPerPort != get.MaxLinksPerPort {
-			return fmt.Errorf("set AntiAffinityPolicy MaxLinksPerPort %d got %d", set.MaxLinksPerPort, get.MaxLinksPerPort)
-		}
-
-		if set.MaxLinksPerSlot != get.MaxLinksPerSlot {
-			return fmt.Errorf("set AntiAffinityPolicy MaxLinksPerSlot %d got %d", set.MaxLinksPerSlot, get.MaxLinksPerSlot)
-		}
-
-		if set.MaxPerSystemLinksPerPort != get.MaxPerSystemLinksPerPort {
-			return fmt.Errorf("set AntiAffinityPolicy MaxPerSystemLinksPerPort %d got %d", set.MaxPerSystemLinksPerPort, get.MaxPerSystemLinksPerPort)
-		}
-
-		if set.MaxPerSystemLinksPerSlot != get.MaxPerSystemLinksPerSlot {
-			return fmt.Errorf("set AntiAffinityPolicy MaxPerSystemLinksPerSlot %d got %d", set.MaxPerSystemLinksPerSlot, get.MaxPerSystemLinksPerSlot)
-		}
-
-		if set.Mode != get.Mode {
-			return fmt.Errorf("set AntiAffinityPolicy Mode %s got %s", set.Mode, get.Mode)
-		}
-
-		return nil
-	}
-
-	compareFabricSettings := func(set, get FabricSettings) error {
-		if set.JunosEvpnDuplicateMacRecoveryTime != nil &&
-			*set.JunosEvpnDuplicateMacRecoveryTime != *get.JunosEvpnDuplicateMacRecoveryTime {
-			return fmt.Errorf("set junosEvpnDuplicateMacRecoveryTime %d got %d", *set.JunosEvpnDuplicateMacRecoveryTime, *get.JunosEvpnDuplicateMacRecoveryTime)
-		}
-
-		if set.MaxExternalRoutes != nil && *set.MaxExternalRoutes != *get.MaxExternalRoutes {
-			return fmt.Errorf("set MaxExternalRoutes %d got %d", *set.MaxExternalRoutes, *get.MaxExternalRoutes)
-		}
-
-		if set.EsiMacMsb != nil && *set.EsiMacMsb != *get.EsiMacMsb {
-			return fmt.Errorf("set EsiMacMsb %d got %d", *set.EsiMacMsb, *get.EsiMacMsb)
-		}
-
-		if set.JunosGracefulRestart != nil && *set.JunosGracefulRestart != *get.JunosGracefulRestart {
-			return fmt.Errorf("set JunosGracefulRestart %s got %s", *set.JunosGracefulRestart, *get.JunosGracefulRestart)
-		}
-
-		if set.OptimiseSzFootprint != nil && *set.OptimiseSzFootprint != *get.OptimiseSzFootprint {
-			return fmt.Errorf("set OptimiseSzFootprint %s got %s", *set.OptimiseSzFootprint, *get.OptimiseSzFootprint)
-		}
-
-		if set.JunosEvpnRoutingInstanceVlanAware != nil && *set.JunosEvpnRoutingInstanceVlanAware != *get.JunosEvpnRoutingInstanceVlanAware {
-			return fmt.Errorf("set JunosEvpnRoutingInstanceVlanAware %s got %s", *set.JunosEvpnRoutingInstanceVlanAware, *get.JunosEvpnRoutingInstanceVlanAware)
-		}
-
-		if set.EvpnGenerateType5HostRoutes != nil && *set.EvpnGenerateType5HostRoutes != *get.EvpnGenerateType5HostRoutes {
-			return fmt.Errorf("set EvpnGenerateType5HostRoutes %s got %s", *set.EvpnGenerateType5HostRoutes, *get.EvpnGenerateType5HostRoutes)
-		}
-
-		if set.MaxFabricRoutes != nil && *set.MaxFabricRoutes != *get.MaxFabricRoutes {
-			return fmt.Errorf("set MaxFabricRoutes %d got %d", *set.MaxFabricRoutes, *get.MaxFabricRoutes)
-		}
-
-		if set.MaxMlagRoutes != nil && *set.MaxMlagRoutes != *get.MaxMlagRoutes {
-			return fmt.Errorf("set MaxMlagRoutes %d got %d", *set.MaxMlagRoutes, *get.MaxMlagRoutes)
-		}
-
-		if set.JunosEvpnRoutingInstanceVlanAware != nil && *set.JunosEvpnRoutingInstanceVlanAware != *get.JunosEvpnRoutingInstanceVlanAware {
-			return fmt.Errorf("set JunosEvpnRoutingInstanceVlanAware %s got %s", *set.JunosEvpnRoutingInstanceVlanAware, *get.JunosEvpnRoutingInstanceVlanAware)
-		}
-
-		if set.DefaultSviL3Mtu != nil && *set.DefaultSviL3Mtu != *get.DefaultSviL3Mtu {
-			return fmt.Errorf("set DefaultSviL3Mtu  %d got %d", *set.DefaultSviL3Mtu, *get.DefaultSviL3Mtu)
-		}
-
-		if set.JunosEvpnMaxNexthopAndInterfaceNumber != nil && *set.JunosEvpnMaxNexthopAndInterfaceNumber != *get.JunosEvpnMaxNexthopAndInterfaceNumber {
-			return fmt.Errorf("set JunosEvpnMaxNexthopAndInterfaceNumber %s got %s", *set.JunosEvpnMaxNexthopAndInterfaceNumber, *get.JunosEvpnMaxNexthopAndInterfaceNumber)
-		}
-
-		if set.FabricL3Mtu != nil && *set.FabricL3Mtu != *get.FabricL3Mtu {
-			return fmt.Errorf("set FabricL3Mtu  %d got %d", *set.FabricL3Mtu, *get.FabricL3Mtu)
-		}
-
-		if set.Ipv6Enabled != nil && *set.Ipv6Enabled != *get.Ipv6Enabled {
-			return fmt.Errorf("set Ipv6Enabled %t got %t", *set.Ipv6Enabled, *get.Ipv6Enabled)
-		}
-
-		// don't check overlay control protocol - it's an immutable value. attempts to set it have no effect.
-		//if set.OverlayControlProtocol != get.OverlayControlProtocol {
-		//	return fmt.Errorf("set OverlayControlProtocol %s got %s", set.OverlayControlProtocol, get.OverlayControlProtocol)
-		//}
-
-		if set.ExternalRouterMtu != nil && *set.ExternalRouterMtu != *get.ExternalRouterMtu {
-			return fmt.Errorf("set ExternalRouterMtu %d got %d", *set.ExternalRouterMtu, *get.ExternalRouterMtu)
-		}
-
-		if set.MaxEvpnRoutes != nil && *set.MaxEvpnRoutes != *get.MaxEvpnRoutes {
-			return fmt.Errorf("set MaxEvpnRoutes %d got %d", *set.MaxEvpnRoutes, *get.MaxEvpnRoutes)
-		}
-
-		if set.AntiAffinityPolicy != nil {
-			err = compareAntiAffinityPolicy(*get.AntiAffinityPolicy, *set.AntiAffinityPolicy)
-			if err != nil {
-				return err
-			}
-		}
-
-		return nil
-	}
-
 	type testCase struct {
 		fabricSettings    FabricSettings
 		versionConstraint version.Constraints
 	}
 
 	testCases := map[string]testCase{
-		"zerovalues": {
-			versionConstraint: version.MustConstraints(version.NewConstraint(">" + apstra412)),
-			fabricSettings:    FabricSettings{},
+		"no_fabric_settings": {
+			//versionConstraint: version.MustConstraints(version.NewConstraint(">" + apstra412)),
+			fabricSettings: FabricSettings{},
 		},
-		"lotsofvalues": {
+		"41x_compatible_1": {
+			fabricSettings: FabricSettings{
+				AntiAffinityPolicy: &AntiAffinityPolicy{
+					Algorithm:                AlgorithmHeuristic,
+					MaxLinksPerPort:          2,
+					MaxLinksPerSlot:          2,
+					MaxPerSystemLinksPerPort: 2,
+					MaxPerSystemLinksPerSlot: 2,
+					Mode:                     AntiAffinityModeEnabledStrict,
+				},
+				EsiMacMsb:                   toPtr(uint8(4)),
+				EvpnGenerateType5HostRoutes: &FeatureSwitchEnumEnabled,
+				ExternalRouterMtu:           toPtr(uint16(9002)),
+				Ipv6Enabled:                 toPtr(false),
+				MaxEvpnRoutes:               toPtr(uint32(10000)),
+				MaxExternalRoutes:           toPtr(uint32(11000)),
+				MaxFabricRoutes:             toPtr(uint32(12000)),
+				MaxMlagRoutes:               toPtr(uint32(13000)),
+			},
+		},
+		"412_compatible_2": {
+			fabricSettings: FabricSettings{
+				AntiAffinityPolicy: &AntiAffinityPolicy{
+					Algorithm:                AlgorithmHeuristic,
+					MaxLinksPerPort:          3,
+					MaxLinksPerSlot:          3,
+					MaxPerSystemLinksPerPort: 3,
+					MaxPerSystemLinksPerSlot: 3,
+					Mode:                     AntiAffinityModeEnabledLoose,
+				},
+				EsiMacMsb:                   toPtr(uint8(6)),
+				EvpnGenerateType5HostRoutes: &FeatureSwitchEnumDisabled,
+				ExternalRouterMtu:           toPtr(uint16(9004)),
+				Ipv6Enabled:                 toPtr(false),
+				MaxEvpnRoutes:               toPtr(uint32(20000)),
+				MaxExternalRoutes:           toPtr(uint32(21000)),
+				MaxFabricRoutes:             toPtr(uint32(22000)),
+				MaxMlagRoutes:               toPtr(uint32(23000)),
+			},
+		},
+		"lots_of_values": {
 			versionConstraint: version.MustConstraints(version.NewConstraint(">" + apstra412)),
 			fabricSettings: FabricSettings{
 				JunosEvpnDuplicateMacRecoveryTime:     toPtr(uint16(16)),
@@ -182,7 +218,7 @@ func TestSetGetFabricSettings(t *testing.T) {
 				DefaultSviL3Mtu:                       toPtr(uint16(9050)),
 				JunosEvpnMaxNexthopAndInterfaceNumber: &FeatureSwitchEnumEnabled,
 				FabricL3Mtu:                           toPtr(uint16(9176)),
-				Ipv6Enabled:                           toPtr(true),
+				Ipv6Enabled:                           toPtr(false),
 				ExternalRouterMtu:                     toPtr(uint16(9050)),
 				MaxEvpnRoutes:                         toPtr(uint32(92332)),
 				AntiAffinityPolicy: &AntiAffinityPolicy{
@@ -198,6 +234,7 @@ func TestSetGetFabricSettings(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
+		client := client
 		bpClient, bpDel := testBlueprintC(ctx, t, client.client)
 		defer func() {
 			err = bpDel(ctx)
@@ -205,22 +242,6 @@ func TestSetGetFabricSettings(t *testing.T) {
 				t.Fatal(err)
 			}
 		}()
-
-		t.Run("initial fetch", func(t *testing.T) {
-			if !version.MustConstraints(version.NewConstraint(">=" + apstra420)).Check(bpClient.client.apiVersion) {
-				t.Skipf("skipping test %q due to mismatch version %q", "initial fetch", bpClient.client.apiVersion)
-			}
-
-			log.Printf("testing GetFabricSettings() against %s %s (%s)", client.clientType, clientName, bpClient.client.apiVersion)
-			fs, err := bpClient.GetFabricSettings(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if (fs.OverlayControlProtocol != nil) && (*fs.OverlayControlProtocol != OverlayControlProtocolEvpn) {
-				t.Fatalf("expected OverlayControlProtocol %q, got %q", OverlayControlProtocolEvpn, fs.OverlayControlProtocol)
-			}
-		})
 
 		for tName, tCase := range testCases {
 			tName, tCase := tName, tCase
@@ -240,12 +261,61 @@ func TestSetGetFabricSettings(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				err = compareFabricSettings(tCase.fabricSettings, *fs)
-				if err != nil {
-					t.Fatal(err)
-				}
+				compareFabricSettings(t, tCase.fabricSettings, *fs)
 			})
 		}
+	}
+}
 
+func TestSetGetFabricSettingsV6(t *testing.T) {
+	ctx := context.Background()
+	clients, err := getTestClients(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for clientName, client := range clients {
+		client := client
+
+		bpClient, bpDel := testBlueprintC(ctx, t, client.client)
+		defer func() {
+			err = bpDel(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		t.Run("enable_and_check_ipv6", func(t *testing.T) {
+			fsSet := &FabricSettings{
+				AntiAffinityPolicy: &AntiAffinityPolicy{
+					Algorithm:                AlgorithmHeuristic,
+					MaxLinksPerPort:          2,
+					MaxLinksPerSlot:          2,
+					MaxPerSystemLinksPerPort: 2,
+					MaxPerSystemLinksPerSlot: 2,
+					Mode:                     AntiAffinityModeEnabledStrict,
+				},
+				EsiMacMsb:                   toPtr(uint8(4)),
+				EvpnGenerateType5HostRoutes: &FeatureSwitchEnumEnabled,
+				ExternalRouterMtu:           toPtr(uint16(9002)),
+				Ipv6Enabled:                 toPtr(true),
+				MaxEvpnRoutes:               toPtr(uint32(10000)),
+				MaxExternalRoutes:           toPtr(uint32(11000)),
+				MaxFabricRoutes:             toPtr(uint32(12000)),
+				MaxMlagRoutes:               toPtr(uint32(13000)),
+			}
+			log.Printf("testing SetFabricSettings() against %s %s (%s)", client.clientType, clientName, bpClient.client.apiVersion)
+			err = bpClient.SetFabricSettings(ctx, fsSet)
+			if err != nil {
+				t.Fatal(err)
+			}
+			log.Printf("testing GetFabricSettings() against %s %s (%s)", client.clientType, clientName, bpClient.client.apiVersion)
+			fsGet, err := bpClient.GetFabricSettings(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			compareFabricSettings(t, *fsSet, *fsGet)
+		})
 	}
 }

--- a/apstra/two_stage_l3_clos_fabric_settings_test.go
+++ b/apstra/two_stage_l3_clos_fabric_settings_test.go
@@ -130,7 +130,6 @@ func TestSetGetFabricSettings(t *testing.T) {
 
 	testCases := map[string]testCase{
 		"no_fabric_settings": {
-			//versionConstraint: version.MustConstraints(version.NewConstraint(">" + apstra412)),
 			fabricSettings: FabricSettings{},
 		},
 		"41x_compatible_1": {
@@ -146,7 +145,7 @@ func TestSetGetFabricSettings(t *testing.T) {
 				EsiMacMsb:                   toPtr(uint8(4)),
 				EvpnGenerateType5HostRoutes: &FeatureSwitchEnumEnabled,
 				ExternalRouterMtu:           toPtr(uint16(9002)),
-				Ipv6Enabled:                 toPtr(false),
+				Ipv6Enabled:                 toPtr(false), // do not enable because it's a one-way trip
 				MaxEvpnRoutes:               toPtr(uint32(10000)),
 				MaxExternalRoutes:           toPtr(uint32(11000)),
 				MaxFabricRoutes:             toPtr(uint32(12000)),
@@ -166,7 +165,7 @@ func TestSetGetFabricSettings(t *testing.T) {
 				EsiMacMsb:                   toPtr(uint8(6)),
 				EvpnGenerateType5HostRoutes: &FeatureSwitchEnumDisabled,
 				ExternalRouterMtu:           toPtr(uint16(9004)),
-				Ipv6Enabled:                 toPtr(false),
+				Ipv6Enabled:                 toPtr(false), // do not enable because it's a one-way trip
 				MaxEvpnRoutes:               toPtr(uint32(20000)),
 				MaxExternalRoutes:           toPtr(uint32(21000)),
 				MaxFabricRoutes:             toPtr(uint32(22000)),
@@ -189,7 +188,7 @@ func TestSetGetFabricSettings(t *testing.T) {
 				DefaultSviL3Mtu:                       toPtr(uint16(9100)),
 				JunosEvpnMaxNexthopAndInterfaceNumber: &FeatureSwitchEnumDisabled,
 				FabricL3Mtu:                           toPtr(uint16(9178)),
-				Ipv6Enabled:                           toPtr(false),
+				Ipv6Enabled:                           toPtr(false), // do not enable because it's a one-way trip
 				ExternalRouterMtu:                     toPtr(uint16(9100)),
 				MaxEvpnRoutes:                         toPtr(uint32(92342)),
 				AntiAffinityPolicy: &AntiAffinityPolicy{
@@ -218,7 +217,7 @@ func TestSetGetFabricSettings(t *testing.T) {
 				DefaultSviL3Mtu:                       toPtr(uint16(9050)),
 				JunosEvpnMaxNexthopAndInterfaceNumber: &FeatureSwitchEnumEnabled,
 				FabricL3Mtu:                           toPtr(uint16(9176)),
-				Ipv6Enabled:                           toPtr(false),
+				Ipv6Enabled:                           toPtr(false), // do not enable because it's a one-way trip
 				ExternalRouterMtu:                     toPtr(uint16(9050)),
 				MaxEvpnRoutes:                         toPtr(uint32(92332)),
 				AntiAffinityPolicy: &AntiAffinityPolicy{
@@ -247,7 +246,8 @@ func TestSetGetFabricSettings(t *testing.T) {
 			tName, tCase := tName, tCase
 			t.Run(tName, func(t *testing.T) {
 				if tCase.versionConstraint != nil && !tCase.versionConstraint.Check(bpClient.client.apiVersion) {
-					t.Skipf("skipping test %q due to mismatch version %q", tName, bpClient.client.apiVersion)
+					t.Skipf("skipping test %q due to version constraints: %q. API version %q",
+						tName, tCase.versionConstraint, bpClient.client.apiVersion)
 				}
 
 				log.Printf("testing SetFabricSettings() against %s %s (%s)", client.clientType, clientName, bpClient.client.apiVersion)

--- a/apstra/two_stage_l3_clos_virtual_network_policy.go
+++ b/apstra/two_stage_l3_clos_virtual_network_policy.go
@@ -12,23 +12,19 @@ const (
 )
 
 type rawVirtualNetworkPolicy420 struct {
+	DefaultSviL3Mtu                       *uint16 `json:"default_svi_l3_mtu,omitempty"`
+	EvpnGenerateType5HostRoutes           *string `json:"evpn_generate_type5_host_routes,omitempty"`
+	ExternalRouterMtu                     *uint16 `json:"external_router_mtu,omitempty"`
 	JunosEvpnDuplicateMacRecoveryTime     *uint16 `json:"junos_evpn_duplicate_mac_recovery_time,omitempty"`
+	JunosEvpnMaxNexthopAndInterfaceNumber *string `json:"junos_evpn_max_nexthop_and_interface_number,omitempty"`
+	JunosEvpnRoutingInstanceType          *string `json:"junos_evpn_routing_instance_type,omitempty"`
+	JunosExOverlayEcmp                    *string `json:"junos_ex_overlay_ecmp,omitempty"`
+	JunosGracefulRestart                  *string `json:"junos_graceful_restart,omitempty"`
+	MaxEvpnRoutes                         *uint32 `json:"max_evpn_routes,omitempty"`
 	MaxExternalRoutes                     *uint32 `json:"max_external_routes,omitempty"`
-	JunosGracefulRestart                  *string `json:"junos_graceful_restart,omitempty"`           // enabled/disabled
-	JunosEvpnRoutingInstanceType          *string `json:"junos_evpn_routing_instance_type,omitempty"` // default/vlan_aware
-	EvpnGenerateType5HostRoutes           *string `json:"evpn_generate_type5_host_routes,omitempty"`  // enabled/disabled
 	MaxFabricRoutes                       *uint32 `json:"max_fabric_routes,omitempty"`
 	MaxMlagRoutes                         *uint32 `json:"max_mlag_routes,omitempty"`
-	JunosExOverlayEcmp                    *string `json:"junos_ex_overlay_ecmp,omitempty"` // enabled/disabled
-	DefaultSviL3Mtu                       *uint16 `json:"default_svi_l3_mtu,omitempty"`
-	JunosEvpnMaxNexthopAndInterfaceNumber *string `json:"junos_evpn_max_nexthop_and_interface_number,omitempty"` // enabled/disabled
-	ExternalRouterMtu                     *uint16 `json:"external_router_mtu,omitempty"`
-	MaxEvpnRoutes                         *uint32 `json:"max_evpn_routes,omitempty"`
 	OverlayControlProtocol                *string `json:"overlay_control_protocol,omitempty"`
-	//FrrRdVlanOffset                       string `json:"frr_rd_vlan_offset,omitempty"` // not exposed in web UI
-	//CumulusBridgeMacDerivation            string `json:"cumulus_bridge_mac_derivation,omitempty"`   // skipping cumulus support
-	//DefaultFabricEviRouteTarget           string `json:"default_fabric_evi_route_target,omitempty"` // undocumented
-	//CumulusVxlanArpSuppression            string `json:"cumulus_vxlan_arp_suppression,omitempty"`   // skipping cumulus support
 }
 
 func (o *TwoStageL3ClosClient) getVirtualNetworkPolicy420(ctx context.Context) (*rawVirtualNetworkPolicy420, error) {
@@ -51,18 +47,18 @@ func (o *TwoStageL3ClosClient) getVirtualNetworkPolicy420(ctx context.Context) (
 }
 
 func (o *TwoStageL3ClosClient) setVirtualNetworkPolicy420(ctx context.Context, in *rawFabricSettings) error {
-	if in.JunosEvpnDuplicateMacRecoveryTime == nil &&
-		in.MaxExternalRoutes == nil &&
-		in.JunosGracefulRestart == nil &&
-		in.JunosEvpnRoutingInstanceType == nil &&
+	if in.DefaultSviL3Mtu == nil &&
 		in.EvpnGenerateType5HostRoutes == nil &&
-		in.MaxFabricRoutes == nil &&
-		in.MaxMlagRoutes == nil &&
-		in.JunosExOverlayEcmp == nil &&
-		in.DefaultSviL3Mtu == nil &&
-		in.JunosEvpnMaxNexthopAndInterfaceNumber == nil &&
 		in.ExternalRouterMtu == nil &&
-		in.MaxEvpnRoutes == nil {
+		in.JunosEvpnDuplicateMacRecoveryTime == nil &&
+		in.JunosEvpnMaxNexthopAndInterfaceNumber == nil &&
+		in.JunosEvpnRoutingInstanceType == nil &&
+		in.JunosExOverlayEcmp == nil &&
+		in.JunosGracefulRestart == nil &&
+		in.MaxEvpnRoutes == nil &&
+		in.MaxExternalRoutes == nil &&
+		in.MaxFabricRoutes == nil &&
+		in.MaxMlagRoutes == nil {
 		return nil // nothing to do if all relevant input fields are nil
 	}
 
@@ -71,18 +67,82 @@ func (o *TwoStageL3ClosClient) setVirtualNetworkPolicy420(ctx context.Context, i
 	}
 
 	apiInput := rawVirtualNetworkPolicy420{
-		JunosEvpnDuplicateMacRecoveryTime:     in.JunosEvpnDuplicateMacRecoveryTime,
-		MaxExternalRoutes:                     in.MaxExternalRoutes,
-		JunosGracefulRestart:                  in.JunosGracefulRestart,
-		JunosEvpnRoutingInstanceType:          in.JunosEvpnRoutingInstanceType,
+		DefaultSviL3Mtu:                       in.DefaultSviL3Mtu,
 		EvpnGenerateType5HostRoutes:           in.EvpnGenerateType5HostRoutes,
+		ExternalRouterMtu:                     in.ExternalRouterMtu,
+		JunosEvpnDuplicateMacRecoveryTime:     in.JunosEvpnDuplicateMacRecoveryTime,
+		JunosEvpnMaxNexthopAndInterfaceNumber: in.JunosEvpnMaxNexthopAndInterfaceNumber,
+		JunosEvpnRoutingInstanceType:          in.JunosEvpnRoutingInstanceType,
+		JunosExOverlayEcmp:                    in.JunosExOverlayEcmp,
+		JunosGracefulRestart:                  in.JunosGracefulRestart,
+		MaxEvpnRoutes:                         in.MaxEvpnRoutes,
+		MaxExternalRoutes:                     in.MaxExternalRoutes,
 		MaxFabricRoutes:                       in.MaxFabricRoutes,
 		MaxMlagRoutes:                         in.MaxMlagRoutes,
-		JunosExOverlayEcmp:                    in.JunosExOverlayEcmp,
-		DefaultSviL3Mtu:                       in.DefaultSviL3Mtu,
-		JunosEvpnMaxNexthopAndInterfaceNumber: in.JunosEvpnMaxNexthopAndInterfaceNumber,
-		ExternalRouterMtu:                     in.ExternalRouterMtu,
-		MaxEvpnRoutes:                         in.MaxEvpnRoutes,
+	}
+
+	err := o.client.talkToApstra(ctx, &talkToApstraIn{
+		method:   http.MethodPatch,
+		urlStr:   fmt.Sprintf(apiUrlBlueprintVirtualNetworkPolicy, o.blueprintId),
+		apiInput: &apiInput,
+	})
+	if err != nil {
+		return convertTtaeToAceWherePossible(err)
+	}
+
+	return nil
+}
+
+type rawVirtualNetworkPolicy41x struct {
+	EvpnGenerateType5HostRoutes *string `json:"evpn_generate_type5_host_routes"`
+	ExternalRouterMtu           *uint16 `json:"external_router_mtu"`
+	MaxFabricRoutes             *uint32 `json:"max_fabric_routes"`
+	MaxMlagRoutes               *uint32 `json:"max_mlag_routes"`
+	MaxEvpnRoutes               *uint32 `json:"max_evpn_routes"`
+	MaxExternalRoutes           *uint32 `json:"max_external_routes"`
+	OverlayControlProtocol      *string `json:"overlay_control_protocol"`
+}
+
+func (o *TwoStageL3ClosClient) getVirtualNetworkPolicy41x(ctx context.Context) (*rawVirtualNetworkPolicy41x, error) {
+	vnpNodeIds, err := o.NodeIdsByType(ctx, NodeTypeVirtualNetworkPolicy)
+	if err != nil {
+		return nil, err
+	}
+	if len(vnpNodeIds) != 1 {
+		return nil, fmt.Errorf("expected 1 %s node, got %d", NodeTypeVirtualNetworkPolicy.String(), len(vnpNodeIds))
+	}
+
+	var result rawVirtualNetworkPolicy41x
+
+	err = o.client.GetNode(ctx, o.blueprintId, vnpNodeIds[0], &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+func (o *TwoStageL3ClosClient) setVirtualNetworkPolicy41x(ctx context.Context, in *rawFabricSettings) error {
+	if in.EvpnGenerateType5HostRoutes == nil &&
+		in.ExternalRouterMtu == nil &&
+		in.MaxEvpnRoutes == nil &&
+		in.MaxExternalRoutes == nil &&
+		in.MaxFabricRoutes == nil &&
+		in.MaxMlagRoutes == nil {
+		return nil // nothing to do if all relevant input fields are nil
+	}
+
+	if !o.client.apiVersion.Equal(version.Must(version.NewVersion(apstra412))) {
+		return fmt.Errorf("setRawVirtualNetworkPolicy412() must not be invoked with apstra %s", o.client.apiVersion)
+	}
+
+	apiInput := rawVirtualNetworkPolicy41x{
+		EvpnGenerateType5HostRoutes: in.EvpnGenerateType5HostRoutes,
+		ExternalRouterMtu:           in.ExternalRouterMtu,
+		MaxEvpnRoutes:               in.MaxEvpnRoutes,
+		MaxExternalRoutes:           in.MaxExternalRoutes,
+		MaxFabricRoutes:             in.MaxFabricRoutes,
+		MaxMlagRoutes:               in.MaxMlagRoutes,
 	}
 
 	err := o.client.talkToApstra(ctx, &talkToApstraIn{


### PR DESCRIPTION
Apstra 4.2.1 introduced new blueprint settings and collected various settings into a single API endpoint: `/api/blueprints/<id>/fabric-settings` with GET and PATCH methods.

We've previously introduced support for it with the `FabricSettings` struct and related SDK methods.

This PR allows clients to use that same struct and SDK methods when talking to older versions of Apstra.

On `Set`, we inspect the request and then tickle the various endpoints and graph nodes as appropriate.

We do something similar on `Get`.

With this work complete, we can sunset some of the older endpoint-specific features and simplify the terraform provider.

I'm pretty sure the tests exercise every feature (to the extent that each Apstra release can make use of them), but would appreciate some thoughtful review of the tests, because they turned out to be easier than I'd expected. Am I missing something?