### PR TITLE
Introduce custom enum type

### DIFF
--- a/apstra/enum/enum.go
+++ b/apstra/enum/enum.go
@@ -4,8 +4,6 @@ import (
 	olEnum "github.com/orsinium-labs/enum"
 )
 
-var enumTypeToFuncs = enumFuncsToMapByType()
-
 type EnumType int
 
 func (o EnumType) Values() []Value {
@@ -36,7 +34,6 @@ type Value interface {
 	Equal(instance Value) bool
 	String() string
 	Type() EnumType
-	member() olEnum.Member[string]
 }
 
 func newInstance(t EnumType, s string) Value {
@@ -69,17 +66,13 @@ func (o value) Type() EnumType {
 	return o.enumType
 }
 
-func (o value) member() olEnum.Member[string] {
-	return *o.value
-}
-
 // New returns n Value based on t and s, or nil if t, s or the
 // t, s combination is invalid.
 func New(t EnumType, s string) Value {
 	if valueFuncs, ok := enumTypeToFuncs[t]; ok {
 		members := make([]olEnum.Member[string], len(valueFuncs))
 		for i, valueFunc := range valueFuncs {
-			members[i] = valueFunc().(value).member()
+			members[i] = *valueFunc().(value).value
 		}
 
 		e := olEnum.New(members...).Parse(s)
@@ -96,7 +89,7 @@ func New(t EnumType, s string) Value {
 	return nil // t not a valid enum type
 }
 
-func enumFuncsToMapByType() map[EnumType][]func() Value {
+var enumTypeToFuncs = func() map[EnumType][]func() Value {
 	result := make(map[EnumType][]func() Value)
 	for _, f := range enumFuncs {
 		current := result[f().Type()]
@@ -104,4 +97,4 @@ func enumFuncsToMapByType() map[EnumType][]func() Value {
 		result[f().Type()] = current
 	}
 	return result
-}
+}()

--- a/apstra/enum/enum.go
+++ b/apstra/enum/enum.go
@@ -6,6 +6,30 @@ import (
 
 type EnumType int
 
+func (o EnumType) Values() []Value {
+	if memberFuncs, ok := enumTypeToFuncs[o]; ok {
+		result := make([]Value, len(memberFuncs))
+		for i, f := range memberFuncs {
+			result[i] = f()
+		}
+		return result
+	}
+
+	return nil
+}
+
+func (o EnumType) Strings() []string {
+	if memberFuncs, ok := enumTypeToFuncs[o]; ok {
+		result := make([]string, len(memberFuncs))
+		for i, f := range memberFuncs {
+			result[i] = f().String()
+		}
+		return result
+	}
+
+	return nil
+}
+
 type Value interface {
 	Equal(instance Value) bool
 	String() string

--- a/apstra/enum/enum.go
+++ b/apstra/enum/enum.go
@@ -66,7 +66,7 @@ func (o value) Type() EnumType {
 	return o.enumType
 }
 
-// New returns n Value based on t and s, or nil if t, s or the
+// New returns a Value based on t and s, or nil if t, s or the
 // t, s combination is invalid.
 func New(t EnumType, s string) Value {
 	if valueFuncs, ok := enumTypeToFuncs[t]; ok {

--- a/apstra/enum/enum.go
+++ b/apstra/enum/enum.go
@@ -4,6 +4,8 @@ import (
 	olEnum "github.com/orsinium-labs/enum"
 )
 
+var enumTypeToFuncs = enumFuncsToMapByType()
+
 type EnumType int
 
 func (o EnumType) Values() []Value {
@@ -92,4 +94,14 @@ func New(t EnumType, s string) Value {
 	}
 
 	return nil // t not a valid enum type
+}
+
+func enumFuncsToMapByType() map[EnumType][]func() Value {
+	result := make(map[EnumType][]func() Value)
+	for _, f := range enumFuncs {
+		current := result[f().Type()]
+		current = append(current, f)
+		result[f().Type()] = current
+	}
+	return result
 }

--- a/apstra/enum/enum.go
+++ b/apstra/enum/enum.go
@@ -1,0 +1,52 @@
+package enum
+
+import (
+	ole "github.com/orsinium-labs/enum"
+)
+
+const (
+	ValueStateUnknown = valueState(iota)
+	ValueStateNull
+	ValueStateKnown
+
+	Unknown = Type(iota)
+	FeatureSwitchx
+)
+
+type valueState uint8
+
+type Type int
+
+type enum struct {
+	enumType Type
+	state    valueState
+	value    ole.Member[string]
+}
+
+func (o enum) String() string {
+	return o.value.Value
+}
+
+func (o enum) IsNull() bool {
+	return o.state == ValueStateNull
+}
+
+func (o enum) IsUnknown() bool {
+	return o.state == ValueStateUnknown
+}
+
+type FeatureSwitch enum
+
+var (
+	featureSwitchValues = ole.New(
+		ole.Member[string]{Value: "disabled"},
+		ole.Member[string]{Value: "enabled"},
+	)
+)
+
+func NewFeatureSwitchFromString(s string) (FeatureSwitch, error) {
+	e := featureSwitchValues.Parse(s)
+	if e == nil {
+		return
+	}
+}

--- a/apstra/enum/enum_test.go
+++ b/apstra/enum/enum_test.go
@@ -1,0 +1,114 @@
+package enum_test
+
+import (
+	"testing"
+
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+)
+
+func TestEnumValues(t *testing.T) {
+	type testCase struct {
+		enum1   enum.Value
+		string1 string
+		enum2   enum.Value
+		string2 string
+		equal   bool
+	}
+
+	testCases := map[string]testCase{
+		"identical": {
+			enum1:   enum.SizeLarge(),
+			string1: "large",
+			enum2:   enum.SizeLarge(),
+			string2: "large",
+			equal:   true,
+		},
+		"same_type": {
+			enum1:   enum.SizeSmall(),
+			string1: "small",
+			enum2:   enum.SizeLarge(),
+			string2: "large",
+			equal:   false,
+		},
+		"same_value": {
+			enum1:   enum.FlavorChocolate(),
+			string1: "chocolate",
+			enum2:   enum.SauceChocolate(),
+			string2: "chocolate",
+			equal:   false,
+		},
+	}
+
+	checkString := func(t testing.TB, d string, s string, e enum.Value) {
+		t.Helper()
+		if s != e.String() {
+			t.Errorf("%s: expected %s, got %s", d, s, e.String())
+		}
+	}
+
+	checkEqual := func(t testing.TB, d string, e bool, a, b enum.Value) {
+		t.Helper()
+		if e && !a.Equal(b) {
+			t.Errorf("%s expected enum %q of type %q to be equal enum %q of type %q, but it is not", d, a.String(), a.Type(), b.String(), b.Type())
+		}
+		if !e && a.Equal(b) {
+			t.Errorf("%s did not expect enum %q of type %q to be equal enum %q of type %q, but it is", d, a.String(), a.Type(), b.String(), b.Type())
+		}
+	}
+
+	for tName, tCase := range testCases {
+		tName, tCase := tName, tCase
+		t.Run(tName, func(t *testing.T) {
+			t.Parallel()
+			checkString(t, "enum1 string", tCase.string1, tCase.enum1)
+			checkString(t, "enum2 string", tCase.string2, tCase.enum2)
+			checkEqual(t, "testCase enum1 and enum2", tCase.equal, tCase.enum1, tCase.enum2)
+			e := enum.New(tCase.enum1.Type(), tCase.string1)
+			checkEqual(t, "testCase enum1 and enum from string", true, tCase.enum1, e)
+			e = enum.New(tCase.enum2.Type(), tCase.string2)
+			checkEqual(t, "testCase enum2 and enum from string", true, tCase.enum2, e)
+		})
+	}
+}
+
+func TestNewEnum(t *testing.T) {
+	type testCase struct {
+		t      enum.EnumType
+		s      string
+		expNil bool
+	}
+
+	testCases := map[string]testCase{
+		"valid": {
+			t:      enum.Size,
+			s:      "small",
+			expNil: false,
+		},
+		"bad_string": {
+			t:      enum.Size,
+			s:      "bogus",
+			expNil: true,
+		},
+		"bad_type": {
+			t:      -1,
+			s:      "small",
+			expNil: true,
+		},
+		"bad_both": {
+			t:      -1,
+			s:      "bogus",
+			expNil: true,
+		},
+	}
+
+	for tName, tCase := range testCases {
+		tName, tCase := tName, tCase
+		t.Run(tName, func(t *testing.T) {
+			t.Parallel()
+			e := enum.New(tCase.t, tCase.s)
+			if tCase.expNil != (e == nil) {
+				t.Errorf("expected e == nil: %t, got %t", tCase.expNil, e == nil)
+			}
+		})
+	}
+}

--- a/apstra/enum/enum_test.go
+++ b/apstra/enum/enum_test.go
@@ -43,17 +43,17 @@ func TestEnumValues(t *testing.T) {
 	checkString := func(t testing.TB, d string, s string, e enum.Value) {
 		t.Helper()
 		if s != e.String() {
-			t.Errorf("%s: expected %s, got %s", d, s, e.String())
+			t.Fatalf("%s: expected %s, got %s", d, s, e.String())
 		}
 	}
 
 	checkEqual := func(t testing.TB, d string, e bool, a, b enum.Value) {
 		t.Helper()
 		if e && !a.Equal(b) {
-			t.Errorf("%s expected enum %q of type %q to be equal enum %q of type %q, but it is not", d, a.String(), a.Type(), b.String(), b.Type())
+			t.Fatalf("%s expected enum %q of type %q to be equal enum %q of type %q, but it is not", d, a.String(), a.Type(), b.String(), b.Type())
 		}
 		if !e && a.Equal(b) {
-			t.Errorf("%s did not expect enum %q of type %q to be equal enum %q of type %q, but it is", d, a.String(), a.Type(), b.String(), b.Type())
+			t.Fatalf("%s did not expect enum %q of type %q to be equal enum %q of type %q, but it is", d, a.String(), a.Type(), b.String(), b.Type())
 		}
 	}
 
@@ -108,7 +108,7 @@ func TestNewEnum(t *testing.T) {
 			t.Parallel()
 			e := enum.New(tCase.t, tCase.s)
 			if tCase.expNil != (e == nil) {
-				t.Errorf("expected e == nil: %t, got %t", tCase.expNil, e == nil)
+				t.Fatalf("expected e == nil: %t, got %t", tCase.expNil, e == nil)
 			}
 		})
 	}
@@ -135,18 +135,18 @@ func TestEnumTypes(t *testing.T) {
 		t.Helper()
 
 		if (a == nil) != (b == nil) {
-			t.Errorf("a == nil: %t; b == nil: %t", a == nil, b == nil)
+			t.Fatalf("a == nil: %t; b == nil: %t", a == nil, b == nil)
 		}
 
 		if len(a) != len(b) {
-			t.Errorf("a has %d items, b has %d items", len(a), len(b))
+			t.Fatalf("a has %d items, b has %d items", len(a), len(b))
 		}
 
 		sort.Strings(a)
 		sort.Strings(b)
 		for i := 0; i < len(a); i++ {
 			if a[i] != b[i] {
-				t.Errorf("a[%d] == %q; b[%d] == %q", i, a[i], i, b[i])
+				t.Fatalf("a[%d] == %q; b[%d] == %q", i, a[i], i, b[i])
 			}
 		}
 	}
@@ -161,7 +161,10 @@ func TestEnumTypes(t *testing.T) {
 				t.Fatalf("Values() returned nil: %t; expected nil: %t", values == nil, tCase.strings == nil)
 			}
 
-			stringsFromValues := make([]string, len(values))
+			var stringsFromValues []string
+			if values != nil {
+				stringsFromValues = make([]string, len(values))
+			}
 			for i, v := range values {
 				stringsFromValues[i] = v.String()
 			}

--- a/apstra/enum/enum_test.go
+++ b/apstra/enum/enum_test.go
@@ -1,6 +1,7 @@
 package enum_test
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra/enum"
@@ -109,6 +110,62 @@ func TestNewEnum(t *testing.T) {
 			if tCase.expNil != (e == nil) {
 				t.Errorf("expected e == nil: %t, got %t", tCase.expNil, e == nil)
 			}
+		})
+	}
+}
+
+func TestEnumTypes(t *testing.T) {
+	type testCase struct {
+		enumType enum.EnumType
+		strings  []string
+	}
+
+	testCases := map[string]testCase{
+		"valid": {
+			enumType: enum.Size,
+			strings:  []string{"small", "medium", "large"},
+		},
+		"invalid": {
+			enumType: -1,
+			strings:  nil,
+		},
+	}
+
+	compareStringSlices := func(t testing.TB, a, b []string) {
+		t.Helper()
+
+		if (a == nil) != (b == nil) {
+			t.Errorf("a == nil: %t; b == nil: %t", a == nil, b == nil)
+		}
+
+		if len(a) != len(b) {
+			t.Errorf("a has %d items, b has %d items", len(a), len(b))
+		}
+
+		sort.Strings(a)
+		sort.Strings(b)
+		for i := 0; i < len(a); i++ {
+			if a[i] != b[i] {
+				t.Errorf("a[%d] == %q; b[%d] == %q", i, a[i], i, b[i])
+			}
+		}
+	}
+
+	for tName, tCase := range testCases {
+		tName, tCase := tName, tCase
+		t.Run(tName, func(t *testing.T) {
+			t.Parallel()
+			compareStringSlices(t, tCase.strings, tCase.enumType.Strings())
+			values := tCase.enumType.Values()
+			if (values == nil) != (tCase.strings == nil) {
+				t.Fatalf("Values() returned nil: %t; expected nil: %t", values == nil, tCase.strings == nil)
+			}
+
+			stringsFromValues := make([]string, len(values))
+			for i, v := range values {
+				stringsFromValues[i] = v.String()
+			}
+			compareStringSlices(t, tCase.strings, stringsFromValues)
 		})
 	}
 }

--- a/apstra/enum/enum_values.go
+++ b/apstra/enum/enum_values.go
@@ -1,0 +1,35 @@
+package enum
+
+const (
+	Flavor = EnumType(iota)
+	Size
+	Sauce
+)
+
+var enumTypeToFuncs = map[EnumType][]func() Value{
+	Flavor: {
+		FlavorChocolate,
+		FlavorStrawberry,
+		FlavorVanilla,
+	},
+	Size: {
+		SizeSmall,
+		SizeMedium,
+		SizeLarge,
+	},
+	Sauce: {
+		SauceChocolate,
+		SauceCaramel,
+	},
+}
+
+func FlavorChocolate() Value  { return newInstance(Flavor, "chocolate") }
+func FlavorStrawberry() Value { return newInstance(Flavor, "strawberry") }
+func FlavorVanilla() Value    { return newInstance(Flavor, "vanilla") }
+
+func SizeSmall() Value  { return newInstance(Size, "small") }
+func SizeMedium() Value { return newInstance(Size, "medium") }
+func SizeLarge() Value  { return newInstance(Size, "large") }
+
+func SauceChocolate() Value { return newInstance(Sauce, "chocolate") }
+func SauceCaramel() Value   { return newInstance(Sauce, "caramel") }

--- a/apstra/enum/values.go
+++ b/apstra/enum/values.go
@@ -6,21 +6,17 @@ const (
 	Sauce
 )
 
-var enumTypeToFuncs = map[EnumType][]func() Value{
-	Flavor: {
-		FlavorChocolate,
-		FlavorStrawberry,
-		FlavorVanilla,
-	},
-	Size: {
-		SizeSmall,
-		SizeMedium,
-		SizeLarge,
-	},
-	Sauce: {
-		SauceChocolate,
-		SauceCaramel,
-	},
+var enumFuncs = []func() Value{
+	FlavorChocolate,
+	FlavorStrawberry,
+	FlavorVanilla,
+
+	SizeSmall,
+	SizeMedium,
+	SizeLarge,
+
+	SauceChocolate,
+	SauceCaramel,
 }
 
 func FlavorChocolate() Value  { return newInstance(Flavor, "chocolate") }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.17.8
 	github.com/aws/aws-sdk-go-v2/config v1.18.21
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.19.3
-	github.com/google/go-licenses v1.6.0
+	github.com/chrismarget-j/go-licenses v0.0.0-20230424163011-d60082a506e0
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl/v2 v2.19.1
@@ -28,11 +28,11 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.18.9 // indirect
 	github.com/aws/smithy-go v1.13.5 // indirect
-	github.com/chrismarget-j/go-licenses v0.0.0-20230424163011-d60082a506e0 // indirect
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/go-logr/logr v1.2.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
+	github.com/google/go-licenses v1.6.0 // indirect
 	github.com/google/licenseclassifier v0.0.0-20210722185704-3043a050f148 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect


### PR DESCRIPTION
We've previously used a combination of iotas/strings/functions (clunky) and enums from a 3rd party package `github.com/orsinium-labs/enum` (somewhat clunky to configure, necessarily mutable) when we needed enumerated string types.

This PR introduces a new `enum` package to the project. The goals are:
- simple to extend when adding new types and values
- immutable (our consumers cannot add or change values)
- easy for consumers to instantiate a new static value
- easy for consumers to instantiate a new value from a string
- easy for consumers to extract a slice of all members as values or strings

For sdk maintainers, extending the types [is demonstrated in](https://github.com/Juniper/apstra-go-sdk/blob/enum/apstra/enum/values.go) `enum/values.go`

Some examples of how consumers can use this package:
```go
// get a fixed value (type: size, value: small)
fixedSize := enum.SizeSmall()

// parse a string into a value of type Size
parsedSize := enum.New(enum.Size, "small")

// compare two enums
fixedSize.Equal(parsedSize) // returns true

// get all sizes as enum values:
var sizes []enum.Value
sizes = enum.Size.Values()

// get all sizes as strings
log.Println(strings.Join(enum.Size.Strings(), ", "))
```