### PR TITLE
Update `Client.BlueprintOverlayControlProtocol()` for Apstra 4.2.1

### DIFF
--- a/apstra/compatibility.go
+++ b/apstra/compatibility.go
@@ -1,8 +1,9 @@
 package apstra
 
 import (
-	"github.com/hashicorp/go-version"
 	"strings"
+
+	"github.com/hashicorp/go-version"
 )
 
 const (
@@ -34,8 +35,11 @@ const (
 )
 
 var (
-	fabricSettingsApiOk  = version.MustConstraints(version.NewConstraint(">=" + apstra421))
-	fabricL3MtuForbidden = version.MustConstraints(version.NewConstraint("<=" + apstra412))
+	geApstra421 = version.MustConstraints(version.NewConstraint(">=" + apstra421))
+	leApstra412 = version.MustConstraints(version.NewConstraint("<=" + apstra412))
+
+	fabricSettingsApiOk  = geApstra421
+	fabricL3MtuForbidden = leApstra412
 )
 
 // SupportedApiVersions returns []string with each element representing an Apstra version number like "4.2.0"

--- a/apstra/query_node.go
+++ b/apstra/query_node.go
@@ -10,6 +10,7 @@ const (
 	NodeTypeEpEndpointPolicy
 	NodeTypeEpGroup
 	NodeTypeFabricAddressingPolicy
+	NodeTypeFabricPolicy
 	NodeTypeInterface
 	NodeTypeInterfaceMap
 	NodeTypeLink
@@ -37,6 +38,7 @@ const (
 	nodeTypeEpEndpointPolicy       = nodeType("ep_endpoint_policy")
 	nodeTypeEpGroup                = nodeType("ep_group")
 	nodeTypeFabricAddressingPolicy = nodeType("fabric_addressing_policy")
+	nodeTypeFabricPolicy           = nodeType("fabric_policy")
 	nodeTypeInterface              = nodeType("interface")
 	nodeTypeInterfaceMap           = nodeType("interface_map")
 	nodeTypeLink                   = nodeType("link")
@@ -58,8 +60,10 @@ const (
 	nodeTypeUnknown                = "unknown node type %d"
 )
 
-type NodeType int
-type nodeType string
+type (
+	NodeType int
+	nodeType string
+)
 
 func (o NodeType) String() string {
 	switch o {
@@ -77,6 +81,8 @@ func (o NodeType) String() string {
 		return string(nodeTypeEpGroup)
 	case NodeTypeFabricAddressingPolicy:
 		return string(nodeTypeFabricAddressingPolicy)
+	case NodeTypeFabricPolicy:
+		return string(nodeTypeFabricPolicy)
 	case NodeTypeInterface:
 		return string(nodeTypeInterface)
 	case NodeTypeInterfaceMap:

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl/v2 v2.19.1
 	github.com/orsinium-labs/enum v1.3.0
+	github.com/stretchr/testify v1.8.1
 	google.golang.org/protobuf v1.30.0
 )
 
@@ -37,6 +38,7 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
 	github.com/otiai10/copy v1.10.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
@@ -48,5 +50,6 @@ require (
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
 	golang.org/x/tools v0.14.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.90.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -191,6 +191,7 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
 google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
The `overlay_control_protocol` graph node attribute has moved from the `virtual_network_policy` node to the `fabric_policy` node.

This PR ensures that the `Client.BlueprintOverlayControlProtocol()` inspects the correct node based on the API version reported by the client.