### PR TITLE
Add support for creating blueprint with a `FabricSettings` (back ported to 4.2.0 support)

### DIFF
--- a/apstra/api_blueprints.go
+++ b/apstra/api_blueprints.go
@@ -61,8 +61,10 @@ type rawBlueprintRequestFabricAddressingPolicy struct {
 	FabricL3Mtu          *uint16          `json:"fabric_l3_mtu,omitempty"`
 }
 
-type RefDesign int
-type refDesign string
+type (
+	RefDesign int
+	refDesign string
+)
 
 func (o RefDesign) String() string {
 	switch o {
@@ -250,7 +252,6 @@ type rawBlueprintStatus struct {
 	//     "drain": 0,
 	//     "deploy": 0
 	//   },
-
 }
 
 func (o *rawBlueprintStatus) polish() (*BlueprintStatus, error) {

--- a/apstra/api_blueprints_integration_test.go
+++ b/apstra/api_blueprints_integration_test.go
@@ -344,6 +344,55 @@ func TestCreateDeleteBlueprintNew(t *testing.T) {
 				},
 			},
 		},
+		"4.1.2_specific_test": {
+			// set fabricMTU in the fabricSettings object.
+			versionConstraints: version.MustConstraints(version.NewConstraint(apstra412)),
+			req: CreateBlueprintFromTemplateRequest{
+				RefDesign:  RefDesignTwoStageL3Clos,
+				Label:      randString(5, "hex"),
+				TemplateId: "L2_Virtual_EVPN",
+				FabricSettings: &FabricSettings{
+					SpineLeafLinks:       toPtr(AddressingSchemeIp46),
+					SpineSuperspineLinks: toPtr(AddressingSchemeIp46),
+					FabricL3Mtu:          toPtr(uint16(9178)),
+				},
+			},
+		},
+		"lots_of_values": {
+			// 4.2.1 put all the goodies in there from fabric_settings
+			versionConstraints: version.MustConstraints(version.NewConstraint(">" + apstra412)),
+			req: CreateBlueprintFromTemplateRequest{
+				RefDesign:  RefDesignTwoStageL3Clos,
+				Label:      randString(5, "hex"),
+				TemplateId: "L2_Virtual_EVPN",
+				FabricSettings: &FabricSettings{
+					JunosEvpnDuplicateMacRecoveryTime:     toPtr(uint16(16)),
+					MaxExternalRoutes:                     toPtr(uint32(239832)),
+					EsiMacMsb:                             toPtr(uint8(32)),
+					JunosGracefulRestart:                  &FeatureSwitchEnumDisabled,
+					OptimiseSzFootprint:                   &FeatureSwitchEnumEnabled,
+					JunosEvpnRoutingInstanceVlanAware:     &FeatureSwitchEnumEnabled,
+					EvpnGenerateType5HostRoutes:           &FeatureSwitchEnumEnabled,
+					MaxFabricRoutes:                       toPtr(uint32(84231)),
+					MaxMlagRoutes:                         toPtr(uint32(76112)),
+					JunosExOverlayEcmp:                    &FeatureSwitchEnumDisabled,
+					DefaultSviL3Mtu:                       toPtr(uint16(9100)),
+					JunosEvpnMaxNexthopAndInterfaceNumber: &FeatureSwitchEnumDisabled,
+					FabricL3Mtu:                           toPtr(uint16(9178)),
+					Ipv6Enabled:                           toPtr(false), // do not enable because it's a one-way trip
+					ExternalRouterMtu:                     toPtr(uint16(9100)),
+					MaxEvpnRoutes:                         toPtr(uint32(92342)),
+					AntiAffinityPolicy: &AntiAffinityPolicy{
+						Algorithm:                AlgorithmHeuristic,
+						MaxLinksPerPort:          2,
+						MaxLinksPerSlot:          2,
+						MaxPerSystemLinksPerPort: 2,
+						MaxPerSystemLinksPerSlot: 2,
+						Mode:                     AntiAffinityModeEnabledLoose,
+					},
+				},
+			},
+		},
 	}
 
 	fetchFabricAddressingScheme := func(t testing.TB, client *TwoStageL3ClosClient) (AddressingScheme, AddressingScheme) {

--- a/apstra/api_blueprints_integration_test.go
+++ b/apstra/api_blueprints_integration_test.go
@@ -6,11 +6,12 @@ package apstra
 import (
 	"context"
 	"encoding/json"
-	"github.com/hashicorp/go-version"
-	"github.com/stretchr/testify/require"
 	"log"
 	"math/rand"
 	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/stretchr/testify/require"
 )
 
 func TestListAllBlueprintIds(t *testing.T) {

--- a/apstra/api_blueprints_integration_test.go
+++ b/apstra/api_blueprints_integration_test.go
@@ -6,6 +6,8 @@ package apstra
 import (
 	"context"
 	"encoding/json"
+	"github.com/hashicorp/go-version"
+	"github.com/stretchr/testify/require"
 	"log"
 	"math/rand"
 	"testing"
@@ -58,24 +60,24 @@ func TestCreateDeleteBlueprint(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		var blueprintFabricAddressingPolicy *BlueprintRequestFabricAddressingPolicy
+		var fabricSettings *FabricSettings
 		if rackBasedTemplateFabricAddressingPolicyForbidden().Includes(client.client.apiVersion.String()) {
 			// forbidden in the template means we can use this feature in the blueprint
-			blueprintFabricAddressingPolicy = &BlueprintRequestFabricAddressingPolicy{}
+			fabricSettings = &FabricSettings{}
 
 			if !fabricL3MtuForbidden.Check(client.client.apiVersion) {
 				fabricL3Mtu := uint16(rand.Intn(550)*2 + 8000) // even number 8000 - 9100
-				blueprintFabricAddressingPolicy.FabricL3Mtu = &fabricL3Mtu
-				blueprintFabricAddressingPolicy.SpineLeafLinks = AddressingSchemeIp46
-				blueprintFabricAddressingPolicy.SpineSuperspineLinks = AddressingSchemeIp46
+				fabricSettings.FabricL3Mtu = &fabricL3Mtu
+				fabricSettings.SpineLeafLinks = toPtr(AddressingSchemeIp46)
+				fabricSettings.SpineSuperspineLinks = toPtr(AddressingSchemeIp46)
 			}
 		}
 
 		req := CreateBlueprintFromTemplateRequest{
-			RefDesign:              RefDesignTwoStageL3Clos,
-			Label:                  randString(10, "hex"),
-			TemplateId:             "L2_Virtual_EVPN",
-			FabricAddressingPolicy: blueprintFabricAddressingPolicy,
+			RefDesign:      RefDesignTwoStageL3Clos,
+			Label:          randString(10, "hex"),
+			TemplateId:     "L2_Virtual_EVPN",
+			FabricSettings: fabricSettings,
 		}
 
 		log.Printf("testing createBlueprintFromTemplate() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
@@ -102,13 +104,13 @@ func TestCreateDeleteBlueprint(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if req.FabricAddressingPolicy != nil && req.FabricAddressingPolicy.FabricL3Mtu != nil {
+		if req.FabricSettings != nil && req.FabricSettings.FabricL3Mtu != nil {
 			fap, err := bpClient.GetFabricAddressingPolicy(ctx)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if *req.FabricAddressingPolicy.FabricL3Mtu != *fap.FabricL3Mtu {
-				t.Fatalf("expected fabric MTU %d, got %d", *req.FabricAddressingPolicy.FabricL3Mtu, *fap.FabricL3Mtu)
+			if *req.FabricSettings.FabricL3Mtu != *fap.FabricL3Mtu {
+				t.Fatalf("expected fabric MTU %d, got %d", *req.FabricSettings.FabricL3Mtu, *fap.FabricL3Mtu)
 			}
 		}
 
@@ -308,5 +310,128 @@ func TestPatchNodes(t *testing.T) {
 				t.Fatalf("patch expected label %s, got label %s", n.(node).Label, result.Label)
 			}
 		}
+	}
+}
+
+func TestCreateDeleteBlueprintNew(t *testing.T) {
+	ctx := context.Background()
+
+	clients, err := getTestClients(ctx, t)
+	require.NoError(t, err)
+
+	type testCase struct {
+		req                CreateBlueprintFromTemplateRequest
+		versionConstraints version.Constraints
+	}
+
+	testCases := map[string]testCase{
+		"simple": {
+			req: CreateBlueprintFromTemplateRequest{
+				RefDesign:  RefDesignTwoStageL3Clos,
+				Label:      randString(5, "hex"),
+				TemplateId: "L2_Virtual_EVPN",
+			},
+		},
+		"4.1.1_and_later": {
+			versionConstraints: version.MustConstraints(version.NewConstraint(">" + apstra410)),
+			req: CreateBlueprintFromTemplateRequest{
+				RefDesign:  RefDesignTwoStageL3Clos,
+				Label:      randString(5, "hex"),
+				TemplateId: "L2_Virtual_EVPN",
+				FabricSettings: &FabricSettings{
+					SpineLeafLinks:       toPtr(AddressingSchemeIp46),
+					SpineSuperspineLinks: toPtr(AddressingSchemeIp46),
+				},
+			},
+		},
+	}
+
+	fetchFabricAddressingScheme := func(t testing.TB, client *TwoStageL3ClosClient) (AddressingScheme, AddressingScheme) {
+		t.Helper()
+
+		query := new(PathQuery).
+			SetClient(client.client).
+			SetBlueprintId(client.blueprintId)
+		if version.MustConstraints(version.NewConstraint(">=" + apstra421)).Check(client.client.apiVersion) {
+			query.Node([]QEEAttribute{
+				NodeTypeFabricPolicy.QEEAttribute(),
+				{Key: "name", Value: QEStringVal("node")},
+			})
+		} else {
+			query.Node([]QEEAttribute{
+				NodeTypeFabricAddressingPolicy.QEEAttribute(),
+				{Key: "name", Value: QEStringVal("node")},
+			})
+		}
+
+		var queryResponse struct {
+			Items []struct {
+				Node struct {
+					SpineLeafLinks       addressingScheme `json:"spine_leaf_links"`
+					SpineSuperspineLinks addressingScheme `json:"spine_superspine_links"`
+				} `json:"node"`
+			} `json:"items"`
+		}
+
+		err := query.Do(ctx, &queryResponse)
+		require.NoError(t, err)
+
+		if len(queryResponse.Items) != 1 {
+			t.Fatalf("got %d responses when querying for fabric addressing", len(queryResponse.Items))
+		}
+
+		spineLeaf, err := queryResponse.Items[0].Node.SpineLeafLinks.parse()
+		require.NoError(t, err)
+		spineSuperspine, err := queryResponse.Items[0].Node.SpineLeafLinks.parse()
+		require.NoError(t, err)
+
+		return AddressingScheme(spineLeaf), AddressingScheme(spineSuperspine)
+	}
+
+	for tName, tCase := range testCases {
+		tName, tCase := tName, tCase
+
+		t.Run(tName, func(t *testing.T) {
+			t.Parallel()
+
+			for clientName, client := range clients {
+				if tCase.versionConstraints != nil && !tCase.versionConstraints.Check(client.client.apiVersion) {
+					t.Skipf("skipping test case %q with Apstra %s due to version constraint %q", tName, client.client.apiVersion, tCase.versionConstraints)
+				}
+
+				t.Logf("testing CreateBlueprintFromTemplate() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+				id, err := client.client.CreateBlueprintFromTemplate(ctx, &tCase.req)
+				require.NoError(t, err)
+
+				t.Logf("testing NewTwoStageL3ClosClient() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+				bpClient, err := client.client.NewTwoStageL3ClosClient(ctx, id)
+				require.NoError(t, err)
+
+				if tCase.req.FabricSettings != nil {
+					t.Logf("testing GetFabricSettings() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+					fabricSettings, err := bpClient.GetFabricSettings(ctx)
+					require.NoError(t, err)
+
+					t.Logf("comparing create-time vs. fetched blueprint fabric settings against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+					compareFabricSettings(t, *tCase.req.FabricSettings, *fabricSettings)
+
+					if tCase.req.FabricSettings.SpineLeafLinks != nil || tCase.req.FabricSettings.SpineSuperspineLinks != nil {
+						spineLeaf, spineSuperspine := fetchFabricAddressingScheme(t, bpClient)
+
+						if tCase.req.FabricSettings.SpineLeafLinks != nil && *tCase.req.FabricSettings.SpineLeafLinks != spineLeaf {
+							t.Fatalf("expected spine leaf addressing: %q, got %q", *tCase.req.FabricSettings.SpineLeafLinks, spineLeaf)
+						}
+
+						if tCase.req.FabricSettings.SpineLeafLinks != nil && *tCase.req.FabricSettings.SpineLeafLinks != spineLeaf {
+							t.Fatalf("expected spine superspine addressing: %q, got %q", *tCase.req.FabricSettings.SpineSuperspineLinks, spineSuperspine)
+						}
+					}
+				}
+
+				t.Logf("testing DeleteBlueprint() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+				err = client.client.DeleteBlueprint(ctx, id)
+				require.NoError(t, err)
+			}
+		})
 	}
 }

--- a/apstra/api_blueprints_integration_test.go
+++ b/apstra/api_blueprints_integration_test.go
@@ -393,6 +393,41 @@ func TestCreateDeleteBlueprintNew(t *testing.T) {
 				},
 			},
 		},
+		"different_values": {
+			// 4.2.1 put all the goodies in there from fabric_settings
+			versionConstraints: version.MustConstraints(version.NewConstraint(">" + apstra412)),
+			req: CreateBlueprintFromTemplateRequest{
+				RefDesign:  RefDesignTwoStageL3Clos,
+				Label:      randString(5, "hex"),
+				TemplateId: "L2_Virtual_EVPN",
+				FabricSettings: &FabricSettings{
+					JunosEvpnDuplicateMacRecoveryTime:     toPtr(uint16(14)),
+					MaxExternalRoutes:                     toPtr(uint32(233832)),
+					EsiMacMsb:                             toPtr(uint8(50)),
+					JunosGracefulRestart:                  &FeatureSwitchEnumEnabled,
+					OptimiseSzFootprint:                   &FeatureSwitchEnumDisabled,
+					JunosEvpnRoutingInstanceVlanAware:     &FeatureSwitchEnumDisabled,
+					EvpnGenerateType5HostRoutes:           &FeatureSwitchEnumEnabled,
+					MaxFabricRoutes:                       toPtr(uint32(82231)),
+					MaxMlagRoutes:                         toPtr(uint32(74112)),
+					JunosExOverlayEcmp:                    &FeatureSwitchEnumDisabled,
+					DefaultSviL3Mtu:                       toPtr(uint16(9070)),
+					JunosEvpnMaxNexthopAndInterfaceNumber: &FeatureSwitchEnumDisabled,
+					FabricL3Mtu:                           toPtr(uint16(9172)),
+					Ipv6Enabled:                           toPtr(false), // do not enable because it's a one-way trip
+					ExternalRouterMtu:                     toPtr(uint16(9080)),
+					MaxEvpnRoutes:                         toPtr(uint32(91342)),
+					AntiAffinityPolicy: &AntiAffinityPolicy{
+						Algorithm:                AlgorithmHeuristic,
+						MaxLinksPerPort:          4,
+						MaxLinksPerSlot:          4,
+						MaxPerSystemLinksPerPort: 4,
+						MaxPerSystemLinksPerSlot: 4,
+						Mode:                     AntiAffinityModeEnabledLoose,
+					},
+				},
+			},
+		},
 	}
 
 	fetchFabricAddressingScheme := func(t testing.TB, client *TwoStageL3ClosClient) (AddressingScheme, AddressingScheme) {

--- a/apstra/client.go
+++ b/apstra/client.go
@@ -746,12 +746,18 @@ func (o *Client) GetAllBlueprintStatus(ctx context.Context) ([]BlueprintStatus, 
 
 // CreateBlueprintFromTemplate creates a blueprint using the supplied reference design and template
 func (o *Client) CreateBlueprintFromTemplate(ctx context.Context, req *CreateBlueprintFromTemplateRequest) (ObjectId, error) {
-	if req.FabricAddressingPolicy != nil &&
-		req.FabricAddressingPolicy.FabricL3Mtu != nil &&
+	if req.FabricSettings != nil &&
+		req.FabricSettings.FabricL3Mtu != nil &&
 		fabricL3MtuForbidden.Check(o.apiVersion) {
 		return "", errors.New(fabricL3MtuForbiddenError)
 	}
-	return o.createBlueprintFromTemplate(ctx, req.raw())
+
+	switch {
+	case version.MustConstraints(version.NewConstraint(">=" + apstra421)).Check(o.apiVersion):
+		return o.createBlueprintFromTemplate(ctx, req.raw())
+	default:
+		return o.createBlueprintFromTemplate420(ctx, req.raw420())
+	}
 }
 
 // GetBlueprintStatus returns *BlueprintStatus for the specified blueprint ID

--- a/apstra/compatibility.go
+++ b/apstra/compatibility.go
@@ -35,6 +35,8 @@ const (
 )
 
 var (
+	geApstra411 = version.MustConstraints(version.NewConstraint(">=" + apstra411))
+	geApstra420 = version.MustConstraints(version.NewConstraint(">=" + apstra420))
 	geApstra421 = version.MustConstraints(version.NewConstraint(">=" + apstra421))
 	leApstra412 = version.MustConstraints(version.NewConstraint("<=" + apstra412))
 

--- a/apstra/helpers.go
+++ b/apstra/helpers.go
@@ -3,12 +3,13 @@ package apstra
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/google/uuid"
 	"io"
 	"net"
 	"reflect"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 func pp(in interface{}, out io.Writer) error {
@@ -53,8 +54,10 @@ func itemInSlice[A comparable](item A, slice []A) bool {
 	return false
 }
 
-var uuidInit bool
-var uuidInitMutex sync.Mutex
+var (
+	uuidInit      bool
+	uuidInitMutex sync.Mutex
+)
 
 // initUUID sets the "hardware address" used for generating UUIDv1 strings to "apstra"
 func initUUID() {

--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -360,9 +360,9 @@ func testBlueprintH(ctx context.Context, t *testing.T, client *Client) (*TwoStag
 	}
 
 	if rackBasedTemplateFabricAddressingPolicyForbidden().Includes(client.apiVersion.String()) {
-		bpRequest.FabricAddressingPolicy = &BlueprintRequestFabricAddressingPolicy{
-			SpineSuperspineLinks: AddressingSchemeIp46,
-			SpineLeafLinks:       AddressingSchemeIp46,
+		bpRequest.FabricSettings = &FabricSettings{
+			SpineSuperspineLinks: toPtr(AddressingSchemeIp46),
+			SpineLeafLinks:       toPtr(AddressingSchemeIp46),
 		}
 	}
 
@@ -562,9 +562,9 @@ func testBlueprintG(ctx context.Context, t *testing.T, client *Client) (*TwoStag
 		RefDesign:  RefDesignTwoStageL3Clos,
 		Label:      randString(5, "hex"),
 		TemplateId: templateId,
-		FabricAddressingPolicy: &BlueprintRequestFabricAddressingPolicy{
-			SpineSuperspineLinks: AddressingSchemeIp46,
-			SpineLeafLinks:       AddressingSchemeIp46,
+		FabricSettings: &FabricSettings{
+			SpineSuperspineLinks: toPtr(AddressingSchemeIp46),
+			SpineLeafLinks:       toPtr(AddressingSchemeIp46),
 		},
 	})
 	if err != nil {

--- a/apstra/two_stage_l3_clos_client.go
+++ b/apstra/two_stage_l3_clos_client.go
@@ -6,10 +6,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/go-version"
 	"net"
 	"net/url"
 	"time"
+
+	"github.com/hashicorp/go-version"
 )
 
 const (
@@ -18,8 +19,10 @@ const (
 	dcClientRetryBackoff = 100 * time.Millisecond
 )
 
-type BlueprintType int
-type blueprintType string
+type (
+	BlueprintType int
+	blueprintType string
+)
 
 const (
 	BlueprintTypeNone = BlueprintType(iota)
@@ -785,8 +788,7 @@ func (o *TwoStageL3ClosClient) GetAllIbaPredefinedProbes(ctx context.Context) ([
 }
 
 // GetIbaPredefinedProbeByName locates a predefined probe by name
-func (o *TwoStageL3ClosClient) GetIbaPredefinedProbeByName(ctx context.Context, name string) (*IbaPredefinedProbe,
-	error) {
+func (o *TwoStageL3ClosClient) GetIbaPredefinedProbeByName(ctx context.Context, name string) (*IbaPredefinedProbe, error) {
 	return o.client.getIbaPredefinedProbeByName(ctx, o.blueprintId, name)
 }
 
@@ -861,7 +863,6 @@ func (o *TwoStageL3ClosClient) GetIbaDashboardByLabel(ctx context.Context, label
 // CreateIbaDashboard creates an IBA Dashboard and returns the id of the created dashboard on success,
 // or a blank and error on failure
 func (o *TwoStageL3ClosClient) CreateIbaDashboard(ctx context.Context, data *IbaDashboardData) (ObjectId, error) {
-
 	id, err := o.client.createIbaDashboard(ctx, o.blueprintId, data.raw())
 	if err != nil {
 		return "", err
@@ -1014,7 +1015,6 @@ func (o *TwoStageL3ClosClient) GetFabricSettings(ctx context.Context) (*FabricSe
 	}
 
 	return raw.polish()
-
 }
 
 // SetFabricSettings sets the specified fabric settings

--- a/apstra/two_stage_l3_clos_client.go
+++ b/apstra/two_stage_l3_clos_client.go
@@ -1019,6 +1019,10 @@ func (o *TwoStageL3ClosClient) GetFabricSettings(ctx context.Context) (*FabricSe
 
 // SetFabricSettings sets the specified fabric settings
 func (o *TwoStageL3ClosClient) SetFabricSettings(ctx context.Context, in *FabricSettings) error {
+	if in.SpineLeafLinks != nil || in.SpineSuperspineLinks != nil {
+		return errors.New("SpineLeafLinks and SpineSuperspineLinks must be nil in SetFabricSettings()")
+	}
+
 	switch {
 	case fabricSettingsApiOk.Check(o.client.apiVersion):
 		return o.setFabricSettings(ctx, in.raw())

--- a/apstra/two_stage_l3_clos_fabric_settings.go
+++ b/apstra/two_stage_l3_clos_fabric_settings.go
@@ -3,9 +3,10 @@ package apstra
 import (
 	"context"
 	"fmt"
+	"net/http"
+
 	"github.com/hashicorp/go-version"
 	"github.com/orsinium-labs/enum"
-	"net/http"
 )
 
 const (

--- a/apstra/two_stage_l3_clos_fabric_settings.go
+++ b/apstra/two_stage_l3_clos_fabric_settings.go
@@ -58,6 +58,16 @@ func (o FabricSettings) raw() *rawFabricSettings {
 		}
 	}
 
+	var spineLeafLinks *addressingScheme
+	if o.SpineLeafLinks != nil {
+		spineLeafLinks = toPtr(addressingScheme(o.SpineLeafLinks.String()))
+	}
+
+	var spineSuperspineLinks *addressingScheme
+	if o.SpineSuperspineLinks != nil {
+		spineSuperspineLinks = toPtr(addressingScheme(o.SpineSuperspineLinks.String()))
+	}
+
 	return &rawFabricSettings{
 		AntiAffinity:                          antiAffinityPolicy,
 		DefaultSviL3Mtu:                       o.DefaultSviL3Mtu,
@@ -77,8 +87,8 @@ func (o FabricSettings) raw() *rawFabricSettings {
 		MaxMlagRoutes:                         o.MaxMlagRoutes,
 		OptimiseSzFootprint:                   stringerPtrToStringPtr(o.OptimiseSzFootprint),
 		OverlayControlProtocol:                stringerPtrToStringPtr(o.OverlayControlProtocol),
-		SpineLeafLinks:                        addressingScheme(o.SpineLeafLinks.String()),
-		SpineSuperspineLinks:                  addressingScheme(o.SpineSuperspineLinks.String()),
+		SpineLeafLinks:                        spineLeafLinks,
+		SpineSuperspineLinks:                  spineSuperspineLinks,
 	}
 }
 
@@ -119,8 +129,8 @@ type rawFabricSettings struct {
 	MaxMlagRoutes                         *uint32                `json:"max_mlag_routes,omitempty"`
 	OptimiseSzFootprint                   *string                `json:"optimise_sz_footprint,omitempty"`
 	OverlayControlProtocol                *string                `json:"overlay_control_protocol,omitempty"`
-	SpineLeafLinks                        addressingScheme       `json:"spine_leaf_links,omitempty"`       // ['ipv4', 'ipv6', 'ipv4_ipv6'],
-	SpineSuperspineLinks                  addressingScheme       `json:"spine_superspine_links,omitempty"` // ['ipv4', 'ipv6', 'ipv4_ipv6']
+	SpineLeafLinks                        *addressingScheme      `json:"spine_leaf_links,omitempty"`       // ['ipv4', 'ipv6', 'ipv4_ipv6'],
+	SpineSuperspineLinks                  *addressingScheme      `json:"spine_superspine_links,omitempty"` // ['ipv4', 'ipv6', 'ipv4_ipv6']
 	// leaf_loopbacks ['ipv4', 'ipv4_ipv6']
 	// spine_loopbacks ['ipv4', 'ipv4_ipv6']
 	// mlag_svi_subnets ['ipv4', 'ipv4_ipv6']
@@ -157,7 +167,7 @@ func (o rawFabricSettings) polish() (*FabricSettings, error) {
 	}
 
 	var spineLeafLinks *AddressingScheme
-	if o.SpineLeafLinks != "" {
+	if o.SpineLeafLinks != nil {
 		i, err := o.SpineLeafLinks.parse()
 		if err != nil {
 			return nil, err
@@ -166,7 +176,7 @@ func (o rawFabricSettings) polish() (*FabricSettings, error) {
 	}
 
 	var spineSuperspineLinks *AddressingScheme
-	if o.SpineSuperspineLinks != "" {
+	if o.SpineSuperspineLinks != nil {
 		i, err := o.SpineSuperspineLinks.parse()
 		if err != nil {
 			return nil, err

--- a/apstra/two_stage_l3_clos_fabric_settings_test.go
+++ b/apstra/two_stage_l3_clos_fabric_settings_test.go
@@ -5,9 +5,10 @@ package apstra
 
 import (
 	"context"
-	"github.com/hashicorp/go-version"
 	"log"
 	"testing"
+
+	"github.com/hashicorp/go-version"
 )
 
 func compareAntiAffinityPolicy(t testing.TB, set, get AntiAffinityPolicy) {


### PR DESCRIPTION
Apstra 4.2.1 blueprint creation supports a `fabric_policy` element (our `FabricSettings` object) instead of `fabric_addressing_policy`.

This PR changes the blueprint creation request to use a `fabric_policy`. Special handling sends the right stuff to older versions of Apstra.

Tests for blueprint fabric settings:

- get
- set
- create blueprint