### PR TITLE
`FabricSettings`: `max_*_routes` struct elements must be sent when `nil`

### DIFF
--- a/apstra/two_stage_l3_clos_fabric_settings.go
+++ b/apstra/two_stage_l3_clos_fabric_settings.go
@@ -124,10 +124,10 @@ type rawFabricSettings struct {
 	JunosEvpnRoutingInstanceType          *string                `json:"junos_evpn_routing_instance_type,omitempty"`
 	JunosExOverlayEcmp                    *string                `json:"junos_ex_overlay_ecmp,omitempty"`
 	JunosGracefulRestart                  *string                `json:"junos_graceful_restart,omitempty"`
-	MaxEvpnRoutes                         *uint32                `json:"max_evpn_routes,omitempty"`
-	MaxExternalRoutes                     *uint32                `json:"max_external_routes,omitempty"`
-	MaxFabricRoutes                       *uint32                `json:"max_fabric_routes,omitempty"`
-	MaxMlagRoutes                         *uint32                `json:"max_mlag_routes,omitempty"`
+	MaxEvpnRoutes                         *uint32                `json:"max_evpn_routes"`
+	MaxExternalRoutes                     *uint32                `json:"max_external_routes"`
+	MaxFabricRoutes                       *uint32                `json:"max_fabric_routes"`
+	MaxMlagRoutes                         *uint32                `json:"max_mlag_routes"`
 	OptimiseSzFootprint                   *string                `json:"optimise_sz_footprint,omitempty"`
 	OverlayControlProtocol                *string                `json:"overlay_control_protocol,omitempty"`
 	SpineLeafLinks                        *addressingScheme      `json:"spine_leaf_links,omitempty"`       // ['ipv4', 'ipv6', 'ipv4_ipv6'],

--- a/apstra/two_stage_l3_clos_fabric_settings_integration_test.go
+++ b/apstra/two_stage_l3_clos_fabric_settings_integration_test.go
@@ -90,18 +90,30 @@ func compareFabricSettings(t testing.TB, set, get FabricSettings) {
 		t.Errorf("set JunosGracefulRestart %s got %s", *set.JunosGracefulRestart, *get.JunosGracefulRestart)
 	}
 
+	if (set.MaxEvpnRoutes == nil) != (get.MaxEvpnRoutes == nil) {
+		t.Errorf("set MaxEvpnRoutes - set nil: %t got nil: %t", set.MaxEvpnRoutes == nil, get.MaxEvpnRoutes == nil)
+	}
 	if set.MaxEvpnRoutes != nil && *set.MaxEvpnRoutes != *get.MaxEvpnRoutes {
 		t.Errorf("set MaxEvpnRoutes %d got %d", *set.MaxEvpnRoutes, *get.MaxEvpnRoutes)
 	}
 
+	if (set.MaxExternalRoutes == nil) != (get.MaxExternalRoutes == nil) {
+		t.Errorf("set MaxExternalRoutes - set nil: %t got nil: %t", set.MaxExternalRoutes == nil, get.MaxExternalRoutes == nil)
+	}
 	if set.MaxExternalRoutes != nil && *set.MaxExternalRoutes != *get.MaxExternalRoutes {
 		t.Errorf("set MaxExternalRoutes %d got %d", *set.MaxExternalRoutes, *get.MaxExternalRoutes)
 	}
 
+	if (set.MaxFabricRoutes == nil) != (get.MaxFabricRoutes == nil) {
+		t.Errorf("set MaxFabricRoutes - set nil: %t got nil: %t", set.MaxFabricRoutes == nil, get.MaxFabricRoutes == nil)
+	}
 	if set.MaxFabricRoutes != nil && *set.MaxFabricRoutes != *get.MaxFabricRoutes {
 		t.Errorf("set MaxFabricRoutes %d got %d", *set.MaxFabricRoutes, *get.MaxFabricRoutes)
 	}
 
+	if (set.MaxMlagRoutes == nil) != (get.MaxMlagRoutes == nil) {
+		t.Errorf("set MaxMlagRoutes - set nil: %t got nil: %t", set.MaxMlagRoutes == nil, get.MaxMlagRoutes == nil)
+	}
 	if set.MaxMlagRoutes != nil && *set.MaxMlagRoutes != *get.MaxMlagRoutes {
 		t.Errorf("set MaxMlagRoutes %d got %d", *set.MaxMlagRoutes, *get.MaxMlagRoutes)
 	}

--- a/apstra/two_stage_l3_clos_fabric_settings_test.go
+++ b/apstra/two_stage_l3_clos_fabric_settings_test.go
@@ -42,53 +42,24 @@ func compareAntiAffinityPolicy(t testing.TB, set, get AntiAffinityPolicy) {
 func compareFabricSettings(t testing.TB, set, get FabricSettings) {
 	t.Helper()
 
-	if set.JunosEvpnDuplicateMacRecoveryTime != nil &&
-		*set.JunosEvpnDuplicateMacRecoveryTime != *get.JunosEvpnDuplicateMacRecoveryTime {
-		t.Errorf("set junosEvpnDuplicateMacRecoveryTime %d got %d", *set.JunosEvpnDuplicateMacRecoveryTime, *get.JunosEvpnDuplicateMacRecoveryTime)
-	}
-
-	if set.MaxExternalRoutes != nil && *set.MaxExternalRoutes != *get.MaxExternalRoutes {
-		t.Errorf("set MaxExternalRoutes %d got %d", *set.MaxExternalRoutes, *get.MaxExternalRoutes)
-	}
-
-	if set.EsiMacMsb != nil && *set.EsiMacMsb != *get.EsiMacMsb {
-		t.Errorf("set EsiMacMsb %d got %d", *set.EsiMacMsb, *get.EsiMacMsb)
-	}
-
-	if set.JunosGracefulRestart != nil && *set.JunosGracefulRestart != *get.JunosGracefulRestart {
-		t.Errorf("set JunosGracefulRestart %s got %s", *set.JunosGracefulRestart, *get.JunosGracefulRestart)
-	}
-
-	if set.OptimiseSzFootprint != nil && *set.OptimiseSzFootprint != *get.OptimiseSzFootprint {
-		t.Errorf("set OptimiseSzFootprint %s got %s", *set.OptimiseSzFootprint, *get.OptimiseSzFootprint)
-	}
-
-	if set.JunosEvpnRoutingInstanceVlanAware != nil && *set.JunosEvpnRoutingInstanceVlanAware != *get.JunosEvpnRoutingInstanceVlanAware {
-		t.Errorf("set JunosEvpnRoutingInstanceVlanAware %s got %s", *set.JunosEvpnRoutingInstanceVlanAware, *get.JunosEvpnRoutingInstanceVlanAware)
-	}
-
-	if set.EvpnGenerateType5HostRoutes != nil && *set.EvpnGenerateType5HostRoutes != *get.EvpnGenerateType5HostRoutes {
-		t.Errorf("set EvpnGenerateType5HostRoutes %s got %s", *set.EvpnGenerateType5HostRoutes, *get.EvpnGenerateType5HostRoutes)
-	}
-
-	if set.MaxFabricRoutes != nil && *set.MaxFabricRoutes != *get.MaxFabricRoutes {
-		t.Errorf("set MaxFabricRoutes %d got %d", *set.MaxFabricRoutes, *get.MaxFabricRoutes)
-	}
-
-	if set.MaxMlagRoutes != nil && *set.MaxMlagRoutes != *get.MaxMlagRoutes {
-		t.Errorf("set MaxMlagRoutes %d got %d", *set.MaxMlagRoutes, *get.MaxMlagRoutes)
-	}
-
-	if set.JunosEvpnRoutingInstanceVlanAware != nil && *set.JunosEvpnRoutingInstanceVlanAware != *get.JunosEvpnRoutingInstanceVlanAware {
-		t.Errorf("set JunosEvpnRoutingInstanceVlanAware %s got %s", *set.JunosEvpnRoutingInstanceVlanAware, *get.JunosEvpnRoutingInstanceVlanAware)
+	if set.AntiAffinityPolicy != nil {
+		compareAntiAffinityPolicy(t, *get.AntiAffinityPolicy, *set.AntiAffinityPolicy)
 	}
 
 	if set.DefaultSviL3Mtu != nil && *set.DefaultSviL3Mtu != *get.DefaultSviL3Mtu {
 		t.Errorf("set DefaultSviL3Mtu  %d got %d", *set.DefaultSviL3Mtu, *get.DefaultSviL3Mtu)
 	}
 
-	if set.JunosEvpnMaxNexthopAndInterfaceNumber != nil && *set.JunosEvpnMaxNexthopAndInterfaceNumber != *get.JunosEvpnMaxNexthopAndInterfaceNumber {
-		t.Errorf("set JunosEvpnMaxNexthopAndInterfaceNumber %s got %s", *set.JunosEvpnMaxNexthopAndInterfaceNumber, *get.JunosEvpnMaxNexthopAndInterfaceNumber)
+	if set.EsiMacMsb != nil && *set.EsiMacMsb != *get.EsiMacMsb {
+		t.Errorf("set EsiMacMsb %d got %d", *set.EsiMacMsb, *get.EsiMacMsb)
+	}
+
+	if set.EvpnGenerateType5HostRoutes != nil && *set.EvpnGenerateType5HostRoutes != *get.EvpnGenerateType5HostRoutes {
+		t.Errorf("set EvpnGenerateType5HostRoutes %s got %s", *set.EvpnGenerateType5HostRoutes, *get.EvpnGenerateType5HostRoutes)
+	}
+
+	if set.ExternalRouterMtu != nil && *set.ExternalRouterMtu != *get.ExternalRouterMtu {
+		t.Errorf("set ExternalRouterMtu %d got %d", *set.ExternalRouterMtu, *get.ExternalRouterMtu)
 	}
 
 	if set.FabricL3Mtu != nil && *set.FabricL3Mtu != *get.FabricL3Mtu {
@@ -99,22 +70,50 @@ func compareFabricSettings(t testing.TB, set, get FabricSettings) {
 		t.Errorf("set Ipv6Enabled %t got %t", *set.Ipv6Enabled, *get.Ipv6Enabled)
 	}
 
-	// don't check overlay control protocol - it's an immutable value. attempts to set it have no effect.
-	//if set.OverlayControlProtocol != get.OverlayControlProtocol {
-	//	t.Errorf("set OverlayControlProtocol %s got %s", set.OverlayControlProtocol, get.OverlayControlProtocol)
-	//}
+	if set.JunosEvpnDuplicateMacRecoveryTime != nil && *set.JunosEvpnDuplicateMacRecoveryTime != *get.JunosEvpnDuplicateMacRecoveryTime {
+		t.Errorf("set junosEvpnDuplicateMacRecoveryTime %d got %d", *set.JunosEvpnDuplicateMacRecoveryTime, *get.JunosEvpnDuplicateMacRecoveryTime)
+	}
 
-	if set.ExternalRouterMtu != nil && *set.ExternalRouterMtu != *get.ExternalRouterMtu {
-		t.Errorf("set ExternalRouterMtu %d got %d", *set.ExternalRouterMtu, *get.ExternalRouterMtu)
+	if set.JunosEvpnRoutingInstanceVlanAware != nil && *set.JunosEvpnRoutingInstanceVlanAware != *get.JunosEvpnRoutingInstanceVlanAware {
+		t.Errorf("set JunosEvpnRoutingInstanceVlanAware %s got %s", *set.JunosEvpnRoutingInstanceVlanAware, *get.JunosEvpnRoutingInstanceVlanAware)
+	}
+
+	if set.JunosEvpnMaxNexthopAndInterfaceNumber != nil && *set.JunosEvpnMaxNexthopAndInterfaceNumber != *get.JunosEvpnMaxNexthopAndInterfaceNumber {
+		t.Errorf("set JunosEvpnMaxNexthopAndInterfaceNumber %s got %s", *set.JunosEvpnMaxNexthopAndInterfaceNumber, *get.JunosEvpnMaxNexthopAndInterfaceNumber)
+	}
+
+	if set.JunosExOverlayEcmp != nil && *set.JunosExOverlayEcmp != *get.JunosExOverlayEcmp {
+		t.Errorf("set JunosExOverlayEcmp %s got %s", *set.JunosExOverlayEcmp, *get.JunosExOverlayEcmp)
+	}
+
+	if set.JunosGracefulRestart != nil && *set.JunosGracefulRestart != *get.JunosGracefulRestart {
+		t.Errorf("set JunosGracefulRestart %s got %s", *set.JunosGracefulRestart, *get.JunosGracefulRestart)
 	}
 
 	if set.MaxEvpnRoutes != nil && *set.MaxEvpnRoutes != *get.MaxEvpnRoutes {
 		t.Errorf("set MaxEvpnRoutes %d got %d", *set.MaxEvpnRoutes, *get.MaxEvpnRoutes)
 	}
 
-	if set.AntiAffinityPolicy != nil {
-		compareAntiAffinityPolicy(t, *get.AntiAffinityPolicy, *set.AntiAffinityPolicy)
+	if set.MaxExternalRoutes != nil && *set.MaxExternalRoutes != *get.MaxExternalRoutes {
+		t.Errorf("set MaxExternalRoutes %d got %d", *set.MaxExternalRoutes, *get.MaxExternalRoutes)
 	}
+
+	if set.MaxFabricRoutes != nil && *set.MaxFabricRoutes != *get.MaxFabricRoutes {
+		t.Errorf("set MaxFabricRoutes %d got %d", *set.MaxFabricRoutes, *get.MaxFabricRoutes)
+	}
+
+	if set.MaxMlagRoutes != nil && *set.MaxMlagRoutes != *get.MaxMlagRoutes {
+		t.Errorf("set MaxMlagRoutes %d got %d", *set.MaxMlagRoutes, *get.MaxMlagRoutes)
+	}
+
+	if set.OptimiseSzFootprint != nil && *set.OptimiseSzFootprint != *get.OptimiseSzFootprint {
+		t.Errorf("set OptimiseSzFootprint %s got %s", *set.OptimiseSzFootprint, *get.OptimiseSzFootprint)
+	}
+
+	// don't check overlay control protocol - it's an immutable value. attempts to set it have no effect.
+	//if set.OverlayControlProtocol != get.OverlayControlProtocol {
+	//	t.Errorf("set OverlayControlProtocol %s got %s", set.OverlayControlProtocol, get.OverlayControlProtocol)
+	//}
 }
 
 func TestSetGetFabricSettings(t *testing.T) {

--- a/apstra/two_stage_l3_clos_virtual_network_policy.go
+++ b/apstra/two_stage_l3_clos_virtual_network_policy.go
@@ -20,10 +20,10 @@ type rawVirtualNetworkPolicy420 struct {
 	JunosEvpnRoutingInstanceType          *string `json:"junos_evpn_routing_instance_type,omitempty"`
 	JunosExOverlayEcmp                    *string `json:"junos_ex_overlay_ecmp,omitempty"`
 	JunosGracefulRestart                  *string `json:"junos_graceful_restart,omitempty"`
-	MaxEvpnRoutes                         *uint32 `json:"max_evpn_routes,omitempty"`
-	MaxExternalRoutes                     *uint32 `json:"max_external_routes,omitempty"`
-	MaxFabricRoutes                       *uint32 `json:"max_fabric_routes,omitempty"`
-	MaxMlagRoutes                         *uint32 `json:"max_mlag_routes,omitempty"`
+	MaxEvpnRoutes                         *uint32 `json:"max_evpn_routes"`
+	MaxExternalRoutes                     *uint32 `json:"max_external_routes"`
+	MaxFabricRoutes                       *uint32 `json:"max_fabric_routes"`
+	MaxMlagRoutes                         *uint32 `json:"max_mlag_routes"`
 	OverlayControlProtocol                *string `json:"overlay_control_protocol,omitempty"`
 }
 
@@ -47,21 +47,6 @@ func (o *TwoStageL3ClosClient) getVirtualNetworkPolicy420(ctx context.Context) (
 }
 
 func (o *TwoStageL3ClosClient) setVirtualNetworkPolicy420(ctx context.Context, in *rawFabricSettings) error {
-	if in.DefaultSviL3Mtu == nil &&
-		in.EvpnGenerateType5HostRoutes == nil &&
-		in.ExternalRouterMtu == nil &&
-		in.JunosEvpnDuplicateMacRecoveryTime == nil &&
-		in.JunosEvpnMaxNexthopAndInterfaceNumber == nil &&
-		in.JunosEvpnRoutingInstanceType == nil &&
-		in.JunosExOverlayEcmp == nil &&
-		in.JunosGracefulRestart == nil &&
-		in.MaxEvpnRoutes == nil &&
-		in.MaxExternalRoutes == nil &&
-		in.MaxFabricRoutes == nil &&
-		in.MaxMlagRoutes == nil {
-		return nil // nothing to do if all relevant input fields are nil
-	}
-
 	if !o.client.apiVersion.Equal(version.Must(version.NewVersion(apstra420))) {
 		return fmt.Errorf("setRawVirtualNetworkPolicy420() must not be invoked with apstra %s", o.client.apiVersion)
 	}
@@ -96,10 +81,10 @@ func (o *TwoStageL3ClosClient) setVirtualNetworkPolicy420(ctx context.Context, i
 type rawVirtualNetworkPolicy41x struct {
 	EvpnGenerateType5HostRoutes *string `json:"evpn_generate_type5_host_routes,omitempty"`
 	ExternalRouterMtu           *uint16 `json:"external_router_mtu,omitempty"`
-	MaxFabricRoutes             *uint32 `json:"max_fabric_routes,omitempty"`
-	MaxMlagRoutes               *uint32 `json:"max_mlag_routes,omitempty"`
-	MaxEvpnRoutes               *uint32 `json:"max_evpn_routes,omitempty"`
-	MaxExternalRoutes           *uint32 `json:"max_external_routes,omitempty"`
+	MaxFabricRoutes             *uint32 `json:"max_fabric_routes"`
+	MaxMlagRoutes               *uint32 `json:"max_mlag_routes"`
+	MaxEvpnRoutes               *uint32 `json:"max_evpn_routes"`
+	MaxExternalRoutes           *uint32 `json:"max_external_routes"`
 	OverlayControlProtocol      *string `json:"overlay_control_protocol,omitempty"`
 }
 
@@ -123,15 +108,6 @@ func (o *TwoStageL3ClosClient) getVirtualNetworkPolicy41x(ctx context.Context) (
 }
 
 func (o *TwoStageL3ClosClient) setVirtualNetworkPolicy41x(ctx context.Context, in *rawFabricSettings) error {
-	if in.EvpnGenerateType5HostRoutes == nil &&
-		in.ExternalRouterMtu == nil &&
-		in.MaxEvpnRoutes == nil &&
-		in.MaxExternalRoutes == nil &&
-		in.MaxFabricRoutes == nil &&
-		in.MaxMlagRoutes == nil {
-		return nil // nothing to do if all relevant input fields are nil
-	}
-
 	patch := rawVirtualNetworkPolicy41x{
 		EvpnGenerateType5HostRoutes: in.EvpnGenerateType5HostRoutes,
 		ExternalRouterMtu:           in.ExternalRouterMtu,


### PR DESCRIPTION
The `max_*_routes` parameters in `rawFabricSettings` and the 4.1.x and 4.2.0 stand-ins for this struct must be sent, even when `nil`/`null`. This is because there are 3 conditions for this element:

- `0`: will never apply a limit to number of permitted routes (overriding NOS default if needed)
- positive integer: will set a maximum limit of routes in BGP config
- `null`/`nil`: will not render any maximum-route commands on BGP sessions

This PR:
- clears `omitempty` from the various version-specific private structs which include this element
- modifies `fabric_settings` tests to ensure that the `nil`/`null` condition is tested
- adds blueprint creation tests for 4.2.1 (uses `fabric_settings`) to ensure blueprint creation distinguishes `null` vs. `0`
- alphabetizes the test `compare` function (found a bug while doing so and fixed)
- eliminates the "all fields are `nil`" shortcut in 4.2.0 and 4.1.x -specific code to ensure we send `null` as needed