### PR TITLE
Introduce `SetGenericSystemLoopbackIPs()` single-call setting of IPv4 and IPv6 loopback addresses

### DIFF
--- a/apstra/api_anomalies_integration_test.go
+++ b/apstra/api_anomalies_integration_test.go
@@ -35,13 +35,7 @@ func TestGetBlueprintAnomalies(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		bpClient, bpDelete := testBlueprintB(ctx, t, client.client)
-		defer func() {
-			err := bpDelete(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient := testBlueprintB(ctx, t, client.client)
 
 		log.Printf("testing GetBlueprintAnomalies() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		anomalies, err := client.client.GetBlueprintAnomalies(ctx, bpClient.Id())
@@ -62,13 +56,7 @@ func TestGetBlueprintNodeAnomalyCounts(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		bpClient, bpDelete := testBlueprintB(ctx, t, client.client)
-		defer func() {
-			err := bpDelete(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient := testBlueprintB(ctx, t, client.client)
 
 		log.Printf("testing GetBlueprintAnomalies() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		anomalies, err := client.client.GetBlueprintNodeAnomalyCounts(ctx, bpClient.Id())
@@ -89,13 +77,7 @@ func TestGetBlueprintServiceAnomalyCounts(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		bpClient, bpDelete := testBlueprintB(ctx, t, client.client)
-		defer func() {
-			err := bpDelete(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient := testBlueprintB(ctx, t, client.client)
 
 		log.Printf("testing GetBlueprintAnomalies() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		anomalies, err := client.client.GetBlueprintServiceAnomalyCounts(ctx, bpClient.Id())

--- a/apstra/api_blueprints_integration_test.go
+++ b/apstra/api_blueprints_integration_test.go
@@ -132,13 +132,7 @@ func TestGetPatchGetPatchNode(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		bpClient, bpDel := testBlueprintA(ctx, t, client.client)
-		defer func() {
-			err = bpDel(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient := testBlueprintA(ctx, t, client.client)
 
 		type metadataNode struct {
 			Tags         interface{} `json:"tags,omitempty"`
@@ -211,13 +205,7 @@ func TestGetNodes(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		bpClient, bpDel := testBlueprintB(ctx, t, client.client)
-		defer func() {
-			err = bpDel(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient := testBlueprintB(ctx, t, client.client)
 
 		type node struct {
 			Id         ObjectId `json:"id"`
@@ -262,13 +250,7 @@ func TestPatchNodes(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		bpClient, bpDel := testBlueprintB(ctx, t, client.client)
-		defer func() {
-			err = bpDel(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient := testBlueprintB(ctx, t, client.client)
 
 		type node struct {
 			Id         ObjectId `json:"id"`

--- a/apstra/api_design_templates.go
+++ b/apstra/api_design_templates.go
@@ -15,21 +15,25 @@ const (
 	apiUrlDesignTemplateById    = apiUrlDesignTemplatesPrefix + "%s"
 )
 
-type AntiAffninityAlgorithm int
-type antiAffinityAlgorithm string
-type AntiAffinityMode int
-type antiAffinityMode string
-type TemplateType int
-type templateType string
-type AsnAllocationScheme int
-type asnAllocationScheme string
-type AddressingScheme int
-type addressingScheme string
+type (
+	AntiAffninityAlgorithm int
+	antiAffinityAlgorithm  string
+	AntiAffinityMode       int
+	antiAffinityMode       string
+	TemplateType           int
+	templateType           string
+	AsnAllocationScheme    int
+	asnAllocationScheme    string
+	AddressingScheme       int
+	addressingScheme       string
+)
 
-type OverlayControlProtocol int
-type overlayControlProtocol string
-type TemplateCapability int
-type templateCapability string
+type (
+	OverlayControlProtocol int
+	overlayControlProtocol string
+	TemplateCapability     int
+	templateCapability     string
+)
 
 const (
 	AntiAffinityModeDisabled = AntiAffinityMode(iota)
@@ -366,6 +370,7 @@ func (o *OverlayControlProtocol) FromString(in string) error {
 func (o overlayControlProtocol) string() string {
 	return string(o)
 }
+
 func (o overlayControlProtocol) parse() (int, error) {
 	switch o {
 	case overlayControlProtocolNone:
@@ -380,6 +385,7 @@ func (o overlayControlProtocol) parse() (int, error) {
 func (o TemplateCapability) Int() int {
 	return int(o)
 }
+
 func (o TemplateCapability) String() string {
 	switch o {
 	case TemplateCapabilityBlueprint:
@@ -392,9 +398,11 @@ func (o TemplateCapability) String() string {
 		return fmt.Sprintf(templateCapabilityUnknown, o)
 	}
 }
+
 func (o templateCapability) string() string {
 	return string(o)
 }
+
 func (o templateCapability) parse() (int, error) {
 	switch o {
 	case templateCapabilityBlueprint:
@@ -454,7 +462,6 @@ func (o *rawAntiAffinityPolicy) polish() (*AntiAffinityPolicy, error) {
 		MaxPerSystemLinksPerSlot: o.MaxPerSystemLinksPerSlot,
 		Mode:                     AntiAffinityMode(mode),
 	}, nil
-
 }
 
 type VirtualNetworkPolicy struct {
@@ -1196,7 +1203,7 @@ func (o *Client) getPodBasedTemplate(ctx context.Context, id ObjectId) (*rawTemp
 		switch rbt.Type {
 		case "":
 			result.RackBasedTemplates[i].Type = templateTypeRackBased
-		case templateTypeRackBased: //fallthrough
+		case templateTypeRackBased: // fallthrough
 		default:
 			return nil, fmt.Errorf("rack-based template '%s' within pod-based template '%s' claims to be type '%s', expected '%s'",
 				rbt.DisplayName, result.Id, rbt.Type, templateTypeRackBased)
@@ -1366,8 +1373,8 @@ func (o *CreateRackBasedTemplateRequest) raw(ctx context.Context, client *Client
 	switch {
 	case o.Spine == nil:
 		return nil, errors.New("spine cannot be <nil> when creating a rack-based template")
-	case o.AntiAffinityPolicy == nil:
-		return nil, errors.New("anti-affinity policy cannot be <nil> when creating a rack-based template")
+	case o.AntiAffinityPolicy == nil && leApstra420.Check(client.apiVersion):
+		return nil, fmt.Errorf("anti-affinity policy cannot be <nil> when creating a rack-based template with Apstra %s", leApstra420)
 	case o.AsnAllocationPolicy == nil:
 		return nil, errors.New("asn allocation policy cannot be <nil> when creating a rack-based template")
 	case o.VirtualNetworkPolicy == nil:

--- a/apstra/api_iba_dashboards_test.go
+++ b/apstra/api_iba_dashboards_test.go
@@ -21,8 +21,8 @@ func TestCreateReadUpdateDeleteIbaDashboards(t *testing.T) {
 		log.Printf("testing IBA Dashboard code against %s %s (%s)", client.clientType, clientName,
 			client.client.ApiVersion())
 
-		bpClient, bpDelete := testBlueprintA(ctx, t, client.client)
-		defer bpDelete(ctx)
+		bpClient := testBlueprintA(ctx, t, client.client)
+
 		widgetAId, _, widgetBId, _ := testWidgetsAB(ctx, t, bpClient)
 
 		data := IbaDashboardData{

--- a/apstra/api_iba_predefined_probes_test.go
+++ b/apstra/api_iba_predefined_probes_test.go
@@ -6,6 +6,7 @@ package apstra //
 import (
 	"context"
 	"encoding/json"
+	"github.com/stretchr/testify/require"
 	"log"
 	"testing"
 )
@@ -20,12 +21,9 @@ func TestIbaPredefinedProbes(t *testing.T) {
 		log.Printf("testing Predefined Probes against %s %s (%s)", client.clientType, clientName,
 			client.client.ApiVersion())
 
-		bpClient, bpDelete := testBlueprintA(ctx, t, client.client)
-		defer bpDelete(ctx)
+		bpClient := testBlueprintA(ctx, t, client.client)
 		pdps, err := bpClient.GetAllIbaPredefinedProbes(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		expectedToFail := map[string]bool{
 			"external_ecmp_imbalance":            true,
 			"evpn_vxlan_type5":                   true,

--- a/apstra/api_iba_probes_test.go
+++ b/apstra/api_iba_probes_test.go
@@ -20,8 +20,7 @@ func TestIbaProbes(t *testing.T) {
 		log.Printf("testing Predefined Probes against %s %s (%s)", client.clientType, clientName,
 			client.client.ApiVersion())
 
-		bpClient, bpDelete := testBlueprintA(ctx, t, client.client)
-		defer bpDelete(ctx)
+		bpClient := testBlueprintA(ctx, t, client.client)
 		pdps, err := bpClient.GetAllIbaPredefinedProbes(ctx)
 		if err != nil {
 			t.Fatal(err)

--- a/apstra/api_iba_widgets_test.go
+++ b/apstra/api_iba_widgets_test.go
@@ -19,8 +19,7 @@ func TestIbaWidgets(t *testing.T) {
 		log.Printf("testing IBA Widget Code against %s %s (%s)", client.clientType, clientName,
 			client.client.ApiVersion())
 
-		bpClient, bpDelete := testBlueprintA(ctx, t, client.client)
-		defer bpDelete(ctx)
+		bpClient := testBlueprintA(ctx, t, client.client)
 
 		widgetAId, widgetA, widgetBId, widgetB := testWidgetsAB(ctx, t, bpClient)
 

--- a/apstra/client.go
+++ b/apstra/client.go
@@ -753,6 +753,10 @@ func (o *Client) CreateBlueprintFromTemplate(ctx context.Context, req *CreateBlu
 		return "", errors.New(fabricL3MtuForbiddenError)
 	}
 
+	if req.FabricSettings != nil && req.FabricSettings.Ipv6Enabled != nil && *req.FabricSettings.Ipv6Enabled {
+		return "", errors.New("IPv6 cannot be enabled during blueprint creation")
+	}
+
 	var id ObjectId
 	var err error
 	switch {

--- a/apstra/client_test.go
+++ b/apstra/client_test.go
@@ -95,12 +95,10 @@ func TestGetBlueprintOverlayControlProtocol(t *testing.T) {
 	ctx := context.Background()
 
 	clients, err := getTestClients(context.Background(), t)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	type testCase struct {
-		bpFunc      func(context.Context, *testing.T, *Client) (*TwoStageL3ClosClient, func(context.Context) error)
+		bpFunc      func(context.Context, *testing.T, *Client) *TwoStageL3ClosClient
 		expectedOcp OverlayControlProtocol
 	}
 
@@ -111,19 +109,11 @@ func TestGetBlueprintOverlayControlProtocol(t *testing.T) {
 
 	for clientName, client := range clients {
 		for i := range testCases {
-			bpClient, bpDel := testCases[i].bpFunc(ctx, t, client.client)
-			defer func() {
-				err := bpDel(ctx)
-				if err != nil {
-					t.Fatal(err)
-				}
-			}()
+			bpClient := testCases[i].bpFunc(ctx, t, client.client)
 
 			log.Printf("testing BlueprintOverlayControlProtocol() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 			ocp, err := bpClient.client.BlueprintOverlayControlProtocol(ctx, bpClient.blueprintId)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			if ocp != testCases[i].expectedOcp {
 				t.Fatalf("expected overlay control protocol %q, got %q", testCases[i].expectedOcp.String(), ocp.String())

--- a/apstra/compatibility.go
+++ b/apstra/compatibility.go
@@ -39,6 +39,7 @@ var (
 	geApstra420 = version.MustConstraints(version.NewConstraint(">=" + apstra420))
 	geApstra421 = version.MustConstraints(version.NewConstraint(">=" + apstra421))
 	leApstra412 = version.MustConstraints(version.NewConstraint("<=" + apstra412))
+	leApstra420 = version.MustConstraints(version.NewConstraint("<=" + apstra420))
 
 	fabricSettingsApiOk  = geApstra421
 	fabricL3MtuForbidden = leApstra412

--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"log"
 	"math/rand"
 	"net"
@@ -14,6 +13,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func randBool() bool {
@@ -24,8 +25,8 @@ func randBool() bool {
 }
 
 func randString(n int, style string) string {
-	var b64Letters = []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-")
-	var hexLetters = []rune("0123456789abcdef")
+	b64Letters := []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-")
+	hexLetters := []rune("0123456789abcdef")
 	var letters []rune
 	b := make([]rune, n)
 	switch style {
@@ -99,11 +100,11 @@ func keyLogWriterFromEnv(keyLogEnv string) (*os.File, error) {
 		fileName = filepath.Join(dirname, fileName[2:])
 	}
 
-	err := os.MkdirAll(filepath.Dir(fileName), os.FileMode(0600))
+	err := os.MkdirAll(filepath.Dir(fileName), os.FileMode(0o600))
 	if err != nil {
 		return nil, err
 	}
-	return os.OpenFile(fileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	return os.OpenFile(fileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 }
 
 // First tick should come immediately, certainly
@@ -151,7 +152,7 @@ func TestImmediateTickerSecondTick(t *testing.T) {
 func testBlueprintA(ctx context.Context, t *testing.T, client *Client) *TwoStageL3ClosClient {
 	t.Helper()
 
-	bpId, err := client.CreateBlueprintFromTemplate(context.Background(), &CreateBlueprintFromTemplateRequest{
+	bpId, err := client.CreateBlueprintFromTemplate(ctx, &CreateBlueprintFromTemplateRequest{
 		RefDesign:  RefDesignTwoStageL3Clos,
 		Label:      randString(5, "hex"),
 		TemplateId: "L3_Collapsed_ESI",
@@ -169,7 +170,7 @@ func testBlueprintA(ctx context.Context, t *testing.T, client *Client) *TwoStage
 func testBlueprintB(ctx context.Context, t *testing.T, client *Client) *TwoStageL3ClosClient {
 	t.Helper()
 
-	bpId, err := client.CreateBlueprintFromTemplate(context.Background(), &CreateBlueprintFromTemplateRequest{
+	bpId, err := client.CreateBlueprintFromTemplate(ctx, &CreateBlueprintFromTemplateRequest{
 		RefDesign:  RefDesignTwoStageL3Clos,
 		Label:      randString(5, "hex"),
 		TemplateId: "L2_Virtual",
@@ -183,7 +184,7 @@ func testBlueprintB(ctx context.Context, t *testing.T, client *Client) *TwoStage
 }
 
 func testBlueprintC(ctx context.Context, t *testing.T, client *Client) (*TwoStageL3ClosClient, func(context.Context) error) {
-	bpId, err := client.CreateBlueprintFromTemplate(context.Background(), &CreateBlueprintFromTemplateRequest{
+	bpId, err := client.CreateBlueprintFromTemplate(ctx, &CreateBlueprintFromTemplateRequest{
 		RefDesign:  RefDesignTwoStageL3Clos,
 		Label:      randString(5, "hex"),
 		TemplateId: "L2_Virtual_EVPN",
@@ -205,7 +206,7 @@ func testBlueprintC(ctx context.Context, t *testing.T, client *Client) (*TwoStag
 }
 
 func testBlueprintD(ctx context.Context, t *testing.T, client *Client) (*TwoStageL3ClosClient, func(context.Context) error) {
-	bpId, err := client.CreateBlueprintFromTemplate(context.Background(), &CreateBlueprintFromTemplateRequest{
+	bpId, err := client.CreateBlueprintFromTemplate(ctx, &CreateBlueprintFromTemplateRequest{
 		RefDesign:  RefDesignTwoStageL3Clos,
 		Label:      randString(5, "hex"),
 		TemplateId: "L2_Virtual_ESI_2x_Links",
@@ -259,7 +260,7 @@ func testBlueprintD(ctx context.Context, t *testing.T, client *Client) (*TwoStag
 }
 
 func testBlueprintE(ctx context.Context, t *testing.T, client *Client) (*TwoStageL3ClosClient, func(context.Context) error) {
-	bpId, err := client.CreateBlueprintFromTemplate(context.Background(), &CreateBlueprintFromTemplateRequest{
+	bpId, err := client.CreateBlueprintFromTemplate(ctx, &CreateBlueprintFromTemplateRequest{
 		RefDesign:  RefDesignTwoStageL3Clos,
 		Label:      randString(5, "hex"),
 		TemplateId: "L2_ESI_Access",
@@ -357,7 +358,7 @@ func testBlueprintH(ctx context.Context, t *testing.T, client *Client) (*TwoStag
 		}
 	}
 
-	bpId, err := client.CreateBlueprintFromTemplate(context.Background(), &bpRequest)
+	bpId, err := client.CreateBlueprintFromTemplate(ctx, &bpRequest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -525,7 +526,7 @@ func testBlueprintF(ctx context.Context, t *testing.T, client *Client) (*TwoStag
 		return templateDeleteFunc(ctx)
 	}
 
-	bpId, err := client.CreateBlueprintFromTemplate(context.Background(), &CreateBlueprintFromTemplateRequest{
+	bpId, err := client.CreateBlueprintFromTemplate(ctx, &CreateBlueprintFromTemplateRequest{
 		RefDesign:  RefDesignTwoStageL3Clos,
 		Label:      randString(5, "hex"),
 		TemplateId: templateId,
@@ -550,20 +551,21 @@ func testBlueprintG(ctx context.Context, t *testing.T, client *Client) *TwoStage
 
 	templateId := testTemplateB(ctx, t, client)
 
-	bpId, err := client.CreateBlueprintFromTemplate(context.Background(), &CreateBlueprintFromTemplateRequest{
+	bpId, err := client.CreateBlueprintFromTemplate(ctx, &CreateBlueprintFromTemplateRequest{
 		RefDesign:  RefDesignTwoStageL3Clos,
 		Label:      randString(5, "hex"),
 		TemplateId: templateId,
 		FabricSettings: &FabricSettings{
 			SpineSuperspineLinks: toPtr(AddressingSchemeIp46),
 			SpineLeafLinks:       toPtr(AddressingSchemeIp46),
-			Ipv6Enabled:          toPtr(true),
 		},
 	})
 	require.NoError(t, err)
 
 	bpClient, err := client.NewTwoStageL3ClosClient(ctx, bpId)
 	require.NoError(t, err)
+
+	require.NoError(t, bpClient.SetFabricSettings(ctx, &FabricSettings{Ipv6Enabled: toPtr(true)}))
 
 	t.Cleanup(func() { require.NoError(t, client.DeleteBlueprint(ctx, bpId)) })
 
@@ -592,7 +594,6 @@ func testWidgetsAB(ctx context.Context, t *testing.T, bpClient *TwoStageL3ClosCl
 			"Threshold": 100000
 		}`),
 	})
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/apstra/query_engine_test.go
+++ b/apstra/query_engine_test.go
@@ -131,13 +131,7 @@ func TestParsingQueryInfo(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		bpClient, bpDel := testBlueprintA(ctx, t, client.client)
-		defer func() {
-			err = bpDel(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient := testBlueprintA(ctx, t, client.client)
 
 		// the type of info we expect the query to return (a slice of these)
 		var qResponse struct {
@@ -503,13 +497,7 @@ func TestRawQueryWithBlueprint(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		bpClient, bpDel := testBlueprintA(ctx, t, client.client)
-		defer func() {
-			err = bpDel(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient := testBlueprintA(ctx, t, client.client)
 
 		query := new(RawQuery).
 			SetBlueprintType(BlueprintTypeStaging).

--- a/apstra/two_stage_l3_clos_cabling_map_integration_test.go
+++ b/apstra/two_stage_l3_clos_cabling_map_integration_test.go
@@ -29,13 +29,7 @@ func TestGetCablingMapLinks(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		bpClient, bpDel := testBlueprintB(ctx, t, client.client)
-		defer func() {
-			err := bpDel(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient := testBlueprintB(ctx, t, client.client)
 
 		log.Printf("testing GetCablingMapLinks() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		links, err := bpClient.GetCablingMapLinks(ctx)

--- a/apstra/two_stage_l3_clos_client_integration_test.go
+++ b/apstra/two_stage_l3_clos_client_integration_test.go
@@ -19,13 +19,7 @@ func TestNodeIdsByType(t *testing.T) {
 
 	for clientName, client := range clients {
 		testBlueprintANodeCount := 4
-		bpClient, bpDel := testBlueprintA(ctx, t, client.client)
-		defer func() {
-			err = bpDel(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient := testBlueprintA(ctx, t, client.client)
 
 		if len(bpClient.nodeIdsByType) != 0 {
 			t.Fatal("nodeIdsByType should be empty with a new blueprint client")

--- a/apstra/two_stage_l3_clos_configlet_integration_test.go
+++ b/apstra/two_stage_l3_clos_configlet_integration_test.go
@@ -42,13 +42,7 @@ func TestImportGetUpdateGetDeleteConfiglet(t *testing.T) {
 			}
 		}()
 
-		bpClient, bpDel := testBlueprintA(ctx, t, client.client)
-		defer func() {
-			err = bpDel(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient := testBlueprintA(ctx, t, client.client)
 
 		log.Printf("testing ImportConfigletById() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		bpConfigletId, err := bpClient.ImportConfigletById(ctx, catalogConfigletId, `role in ["spine", "leaf"]`, "")

--- a/apstra/two_stage_l3_clos_connectivity_template_integration_test.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_integration_test.go
@@ -147,16 +147,7 @@ func TestCreateGetUpdateDeleteCT(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		bpClient, bpDel := testBlueprintA(ctx, t, client.client)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer func() {
-			err := bpDel(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient := testBlueprintA(ctx, t, client.client)
 
 		apiVersion := version.Must(version.NewVersion(bpClient.client.apiVersion.String()))
 
@@ -348,16 +339,7 @@ func TestCtLayout(t *testing.T) {
 	}
 
 	for _, client := range clients {
-		bpClient, bpDel := testBlueprintA(ctx, t, client.client)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer func() {
-			err := bpDel(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient := testBlueprintA(ctx, t, client.client)
 
 		ipv6Enabled := true
 		err = bpClient.SetFabricAddressingPolicy(ctx, &TwoStageL3ClosFabricAddressingPolicy{Ipv6Enabled: &ipv6Enabled})
@@ -503,13 +485,7 @@ func TestConnectivityTemplate404(t *testing.T) {
 
 	for clientName, client := range clients {
 		log.Printf("begin tests against %s, (%s)", clientName, client.client.apiVersion)
-		bpClient, bpDel := testBlueprintA(ctx, t, client.client)
-		defer func() {
-			err := bpDel(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient := testBlueprintA(ctx, t, client.client)
 
 		_, err = bpClient.GetConnectivityTemplate(ctx, "bogus")
 		if err == nil {

--- a/apstra/two_stage_l3_clos_fabric_addressing_policy_integration_test.go
+++ b/apstra/two_stage_l3_clos_fabric_addressing_policy_integration_test.go
@@ -23,16 +23,7 @@ func TestGetSetGetFAP(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		bpClient, bpDel := testBlueprintA(ctx, t, client.client)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer func() {
-			err := bpDel(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient := testBlueprintA(ctx, t, client.client)
 
 		log.Printf("testing GetFabricAddressingPolicy() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		fap, err := bpClient.GetFabricAddressingPolicy(ctx)

--- a/apstra/two_stage_l3_clos_generic_system_loopback.go
+++ b/apstra/two_stage_l3_clos_generic_system_loopback.go
@@ -18,6 +18,7 @@ type GenericSystemLoopback struct {
 	Ipv4Addr       *net.IPNet
 	Ipv6Addr       *net.IPNet
 	LoopbackNodeId ObjectId
+	LoopbackId     uint32
 	SecurityZoneId ObjectId
 }
 

--- a/apstra/two_stage_l3_clos_interface_map_test.go
+++ b/apstra/two_stage_l3_clos_interface_map_test.go
@@ -17,13 +17,7 @@ func TestGetSetInterfaceMapAssignments(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		bpClient, bpDel := testBlueprintA(ctx, t, client.client)
-		defer func() {
-			err = bpDel(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient := testBlueprintA(ctx, t, client.client)
 
 		log.Printf("testing GetInterfaceMapAssignments() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		ifMapAss, err := bpClient.GetInterfaceMapAssignments(ctx)

--- a/apstra/two_stage_l3_clos_policies_test.go
+++ b/apstra/two_stage_l3_clos_policies_test.go
@@ -100,13 +100,7 @@ func TestGetAllPolicies(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		bpClient, bpDel := testBlueprintA(ctx, t, client.client)
-		defer func() {
-			err = bpDel(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient := testBlueprintA(ctx, t, client.client)
 
 		log.Printf("testing getAllPolicies() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		policies, err := bpClient.getAllPolicies(ctx)
@@ -246,13 +240,7 @@ func TestCreateDatacenterPolicy(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		bp, bpDel := testBlueprintA(ctx, t, client.client)
-		defer func() {
-			err = bpDel(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bp := testBlueprintA(ctx, t, client.client)
 
 		// collect leaf switch IDs
 		leafIds, err := getSystemIdsByRole(ctx, bp, "leaf")
@@ -373,13 +361,7 @@ func TestAddDeletePolicyRule(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		bp, bpDelete := testBlueprintA(ctx, t, client.client)
-		defer func() {
-			err := bpDelete(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bp := testBlueprintA(ctx, t, client.client)
 
 		// collect leaf switch IDs
 		leafIds, err := getSystemIdsByRole(ctx, bp, "leaf")

--- a/apstra/two_stage_l3_clos_remote_gateways_test.go
+++ b/apstra/two_stage_l3_clos_remote_gateways_test.go
@@ -130,13 +130,7 @@ func TestCreateDeleteRemoteGateway(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		bp, bpDel := testBlueprintA(ctx, t, client.client)
-		defer func() {
-			err = bpDel(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bp := testBlueprintA(ctx, t, client.client)
 
 		// populate blueprint-specific facts into config slice
 		localGwNodes, err := getSystemIdsByRole(ctx, bp, "leaf")

--- a/apstra/two_stage_l3_clos_resources_test.go
+++ b/apstra/two_stage_l3_clos_resources_test.go
@@ -28,12 +28,8 @@ func TestSetGetResourceAllocation(t *testing.T) {
 		asnPoolWait := sync.WaitGroup{}
 		bpWait := sync.WaitGroup{}
 		bpWait.Add(1)
-		bpClient, bpDel := testBlueprintB(ctx, t, client.client)
+		bpClient := testBlueprintB(ctx, t, client.client)
 		defer func() {
-			err = bpDel(ctx)
-			if err != nil {
-				t.Error(err)
-			}
 			bpWait.Done()      // resource pool deletion is waiting for this
 			asnPoolWait.Wait() // wait for resource pool deletion to complete
 		}()

--- a/apstra/two_stage_l3_clos_routing_policies_integration_test.go
+++ b/apstra/two_stage_l3_clos_routing_policies_integration_test.go
@@ -112,13 +112,7 @@ func TestRoutingPolicies(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		bpClient, bpDel := testBlueprintA(ctx, t, client.client)
-		defer func() {
-			err := bpDel(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient := testBlueprintA(ctx, t, client.client)
 
 		log.Printf("testing GetDefaultRoutingPolicy() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		defaultPolicy, err := bpClient.GetDefaultRoutingPolicy(ctx)
@@ -417,13 +411,7 @@ func TestRoutingPolicy404(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		bpClient, bpDel := testBlueprintA(ctx, t, client.client)
-		defer func() {
-			err := bpDel(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient := testBlueprintA(ctx, t, client.client)
 
 		log.Printf("testing GetDefaultRoutingPolicy() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		_, err := bpClient.GetRoutingPolicy(ctx, "bogus")

--- a/apstra/two_stage_l3_clos_security_zones_integration_test.go
+++ b/apstra/two_stage_l3_clos_security_zones_integration_test.go
@@ -23,13 +23,7 @@ func TestCreateUpdateDeleteRoutingZone(t *testing.T) {
 	vrfName := "test-" + randStr
 
 	for clientName, client := range clients {
-		bpClient, bpDel := testBlueprintA(ctx, t, client.client)
-		defer func() {
-			err := bpDel(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient := testBlueprintA(ctx, t, client.client)
 
 		log.Printf("testing CreateSecurityZone() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		zoneId, err := bpClient.CreateSecurityZone(ctx, &SecurityZoneData{
@@ -188,13 +182,7 @@ func TestGetDefaultRoutingZone(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		bpClient, bpDel := testBlueprintA(ctx, t, client.client)
-		defer func() {
-			err := bpDel(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient := testBlueprintA(ctx, t, client.client)
 
 		log.Printf("testing GetSecurityZoneByVrfName() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		sz, err := bpClient.GetSecurityZoneByVrfName(ctx, "default")
@@ -214,13 +202,7 @@ func TestGetSetSecurityZoneDHCPServers(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		bpClient, bpDel := testBlueprintA(ctx, t, client.client)
-		defer func() {
-			err := bpDel(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient := testBlueprintA(ctx, t, client.client)
 
 		log.Printf("testing GetSecurityZoneByVrfName() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		sz, err := bpClient.GetSecurityZoneByVrfName(ctx, "default")

--- a/apstra/two_stage_l3_clos_system_node_info.go
+++ b/apstra/two_stage_l3_clos_system_node_info.go
@@ -194,7 +194,7 @@ func (o *TwoStageL3ClosClient) SetGenericSystemLoopbackIPs(ctx context.Context, 
 
 		maskOnes, maskBits := gslo.Ipv4Addr.Mask.Size()
 		if maskBits != 32 || maskOnes != maskBits {
-			return errors.New("ip4 does not contain a valid mask - " + gslo.Ipv4Addr.Mask.String())
+			return errors.New("ip4 value does not contain a valid mask for loopback interfaces - " + gslo.Ipv4Addr.Mask.String())
 		}
 
 		apiInput.Ipv4Addr = toPtr(gslo.Ipv4Addr.String())
@@ -207,7 +207,7 @@ func (o *TwoStageL3ClosClient) SetGenericSystemLoopbackIPs(ctx context.Context, 
 
 		maskOnes, maskBits := gslo.Ipv6Addr.Mask.Size()
 		if maskBits != 128 || maskOnes != maskBits {
-			return errors.New("ip6 does not contain a valid mask - " + gslo.Ipv6Addr.Mask.String())
+			return errors.New("ip6 value does not contain a valid mask for loopback interfaces - " + gslo.Ipv6Addr.Mask.String())
 		}
 
 		apiInput.Ipv6Addr = toPtr(gslo.Ipv6Addr.String())

--- a/apstra/two_stage_l3_clos_system_node_info_integration_test.go
+++ b/apstra/two_stage_l3_clos_system_node_info_integration_test.go
@@ -8,8 +8,12 @@ import (
 	"log"
 	"math/rand"
 	"net"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSystemNodeInfo(t *testing.T) {
@@ -22,21 +26,15 @@ func TestSystemNodeInfo(t *testing.T) {
 	for clientName, client := range clients {
 		log.Printf("testing ListAllBlueprintIds() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		bpIds, err := client.client.ListAllBlueprintIds(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		var bpClient *TwoStageL3ClosClient
 		if len(bpIds) > 0 {
 			log.Printf("testing NewTwoStageL3ClosClient() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 			bpClient, err = client.client.NewTwoStageL3ClosClient(ctx, bpIds[0])
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 		} else {
-			var deleteFunc func(ctx2 context.Context) error
-			bpClient, deleteFunc = testBlueprintA(ctx, t, client.client)
-			defer deleteFunc(ctx)
+			bpClient = testBlueprintA(ctx, t, client.client)
 		}
 
 		log.Printf("testing GetAllSystemNodeInfos() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
@@ -48,9 +46,7 @@ func TestSystemNodeInfo(t *testing.T) {
 		for nodeId := range nodeInfos {
 			log.Printf("testing GetSystemNodeInfo() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 			nodeInfo, err := bpClient.GetSystemNodeInfo(ctx, nodeId)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			log.Println(nodeInfo.Id)
 		}
 	}
@@ -67,8 +63,7 @@ func TestSetSystemAsn(t *testing.T) {
 		if client.client.ApiVersion() == "4.1.0" {
 			continue
 		}
-		bpClient, deleteFunc := testBlueprintB(ctx, t, client.client)
-		defer deleteFunc(ctx)
+		bpClient := testBlueprintB(ctx, t, client.client)
 
 		time.Sleep(2 * time.Second) // todo: fix this terrible workaround for 404s from
 		//  /api/blueprints/<id>/experience/web/system-info
@@ -169,14 +164,7 @@ func TestSetSystemLoopbackIpv4v6(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		bpClient, deleteFunc := testBlueprintG(ctx, t, client.client)
-		defer deleteFunc(ctx)
-
-		ipv6Enabled := true
-		err = bpClient.SetFabricAddressingPolicy(ctx, &TwoStageL3ClosFabricAddressingPolicy{Ipv6Enabled: &ipv6Enabled})
-		if err != nil {
-			t.Fatal(err)
-		}
+		bpClient := testBlueprintG(ctx, t, client.client)
 
 		log.Printf("testing GetAllSystemNodeInfos() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		nodeInfos, err := bpClient.GetAllSystemNodeInfos(ctx)
@@ -184,16 +172,16 @@ func TestSetSystemLoopbackIpv4v6(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		var systemIds []ObjectId
+		var genericIDs []ObjectId
 		for id, info := range nodeInfos {
 			if info.Role == SystemRoleGeneric {
-				systemIds = append(systemIds, id)
+				genericIDs = append(genericIDs, id)
 			}
 		}
 
-		ipv4Map := make(map[ObjectId]net.IPNet, len(systemIds))
-		ipv6Map := make(map[ObjectId]net.IPNet, len(systemIds))
-		for _, id := range systemIds {
+		ipv4Map := make(map[ObjectId]net.IPNet, len(genericIDs))
+		ipv6Map := make(map[ObjectId]net.IPNet, len(genericIDs))
+		for _, id := range genericIDs {
 			ipv4Map[id] = net.IPNet{
 				IP:   randomIpv4(),
 				Mask: net.CIDRMask(rand.Intn(9)+24, 32),
@@ -273,7 +261,7 @@ func TestSetSystemLoopbackIpv4v6(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		for _, id := range systemIds {
+		for _, id := range genericIDs {
 			if nodeInfos[id].LoopbackIpv4 != nil {
 				t.Fatalf("expected node %q to have no Loopback IPv4, got %s", id, nodeInfos[id].LoopbackIpv4)
 			}
@@ -293,8 +281,7 @@ func TestSetSystemPortChannelIdMinMax(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		bpClient, deleteFunc := testBlueprintG(ctx, t, client.client)
-		defer deleteFunc(ctx)
+		bpClient := testBlueprintG(ctx, t, client.client)
 
 		log.Printf("testing GetAllSystemNodeInfos() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		nodeInfos, err := bpClient.GetAllSystemNodeInfos(ctx)
@@ -351,5 +338,96 @@ func TestSetSystemPortChannelIdMinMax(t *testing.T) {
 					nodeInfos[nodeId].PortChannelIdMax, nodeId, channelIdMaxMap[nodeId])
 			}
 		}
+	}
+}
+
+func TestSetGenericSystemLoopbackIPs(t *testing.T) {
+	ctx := context.Background()
+	clients, err := getTestClients(ctx, t)
+	require.NoError(t, err)
+
+	// this struct represents each test environment we'll run test cases against
+	type testBlueprint struct {
+		name           string
+		testClient     testClient
+		bpClient       *TwoStageL3ClosClient
+		genericSystems []ObjectId
+	}
+
+	wg := new(sync.WaitGroup)
+	wg.Add(len(clients))
+
+	testBlueprints := make([]testBlueprint, len(clients))
+
+	var i int
+	for name, client := range clients {
+		name, client := name, client
+		go func(i int) {
+			defer wg.Done()
+
+			testBlueprints[i].name = name
+			testBlueprints[i].testClient = client
+			testBlueprints[i].bpClient = testBlueprintG(ctx, t, client.client)
+
+			nodeInfos, err := testBlueprints[i].bpClient.GetAllSystemNodeInfos(ctx)
+			require.NoError(t, err)
+			for id, info := range nodeInfos {
+				if info.Role == SystemRoleGeneric {
+					testBlueprints[i].genericSystems = append(testBlueprints[i].genericSystems, id)
+				}
+			}
+			if len(testBlueprints[i].genericSystems) == 0 {
+				t.Fatal("no generic systems found in blueprint")
+			}
+		}(i)
+		i++
+	}
+
+	wg.Wait()
+
+	type testCase struct {
+		ip4           *net.IPNet
+		ip6           *net.IPNet
+		expectedError string
+	}
+
+	testCases := map[string]testCase{
+		"a": {},
+	}
+
+	for tName, tCase := range testCases {
+		tName, tCase := tName, tCase
+		t.Run(tName, func(t *testing.T) {
+			for _, testBlueprint := range testBlueprints {
+				tCase := tCase
+				testBlueprint := testBlueprint
+				t.Run(testBlueprint.name, func(t *testing.T) {
+					// t.Parallel()
+
+					gsNodeId := testBlueprint.genericSystems[0]
+					bp := testBlueprint.bpClient
+
+					err := bp.SetGenericSystemLoopbackIPs(ctx, gsNodeId, GenericSystemLoopback{
+						Ipv4Addr: tCase.ip4,
+						Ipv6Addr: tCase.ip6,
+					})
+					if len(tCase.expectedError) == 0 {
+						require.NoError(t, err)
+					} else {
+						assert.ErrorContains(t, err, tCase.expectedError)
+					}
+
+					lo, err := bp.GetGenericSystemLoopback(ctx, gsNodeId, 0)
+					require.NoError(t, err)
+
+					if !(tCase.ip4.String() == lo.Ipv4Addr.String()) {
+						t.Errorf("expected %s / got %s", tCase.ip4, lo.Ipv4Addr)
+					}
+					if !(tCase.ip6.String() == lo.Ipv6Addr.String()) {
+						t.Errorf("expected %s / got %s", tCase.ip6, lo.Ipv6Addr)
+					}
+				})
+			}
+		})
 	}
 }


### PR DESCRIPTION
This PR introduces `SetGenericSystemLoopbackIPs()` to the `TwoStageL3ClosClient` struct.

It allows us to set both IPv4 and IPv6 addresses in a single function call, rather than calling the Apstra API for each address family.