### PR TITLE
Add DeployMode to `SystemNodeInfo`

### DIFF
--- a/apstra/api_systems.go
+++ b/apstra/api_systems.go
@@ -79,76 +79,6 @@ func (o rawSystemAdminState) parse() (int, error) {
 	}
 }
 
-type NodeDeployMode int
-type nodeDeployMode string
-
-const (
-	NodeDeployModeNone = NodeDeployMode(iota)
-	NodeDeployModeDeploy
-	NodeDeployModeUndeploy
-	NodeDeployModeReady
-	NodeDeployModeDrain
-	NodeDeployModeUnknown = "unknown node deploy mode '%s'"
-
-	nodeDeployModeNone     = nodeDeployMode("")
-	nodeDeployModeDeploy   = nodeDeployMode("deploy")
-	nodeDeployModeUndeploy = nodeDeployMode("undeploy")
-	nodeDeployModeReady    = nodeDeployMode("ready")
-	nodeDeployModeDrain    = nodeDeployMode("drain")
-	nodeDeployModeUnknown  = "unknown node deploy mode '%d'"
-)
-
-func (o NodeDeployMode) Int() int {
-	return int(o)
-}
-
-func (o NodeDeployMode) String() string {
-	switch o {
-	case NodeDeployModeNone:
-		return string(nodeDeployModeNone)
-	case NodeDeployModeDeploy:
-		return string(nodeDeployModeDeploy)
-	case NodeDeployModeUndeploy:
-		return string(nodeDeployModeUndeploy)
-	case NodeDeployModeReady:
-		return string(nodeDeployModeReady)
-	case NodeDeployModeDrain:
-		return string(nodeDeployModeDrain)
-	default:
-		return fmt.Sprintf(nodeDeployModeUnknown, o)
-	}
-}
-
-func (o *NodeDeployMode) FromString(in string) error {
-	i, err := nodeDeployMode(in).parse()
-	if err != nil {
-		return err
-	}
-	*o = NodeDeployMode(i)
-	return nil
-}
-
-func (o nodeDeployMode) string() string {
-	return string(o)
-}
-
-func (o nodeDeployMode) parse() (int, error) {
-	switch o {
-	case nodeDeployModeNone:
-		return int(NodeDeployModeNone), nil
-	case nodeDeployModeDeploy:
-		return int(NodeDeployModeDeploy), nil
-	case nodeDeployModeUndeploy:
-		return int(NodeDeployModeUndeploy), nil
-	case nodeDeployModeReady:
-		return int(NodeDeployModeReady), nil
-	case nodeDeployModeDrain:
-		return int(NodeDeployModeDrain), nil
-	default:
-		return 0, fmt.Errorf(NodeDeployModeUnknown, o)
-	}
-}
-
 type SystemId string
 
 type optionsSystemsResponse struct {
@@ -390,18 +320,4 @@ func (o *Client) deleteSystem(ctx context.Context, id SystemId) error {
 		method: method,
 		url:    apstraUrl,
 	})
-}
-
-func AllNodeDeployModes() []NodeDeployMode {
-	i := 0
-	var result []NodeDeployMode
-	for {
-		var ndm NodeDeployMode
-		err := ndm.FromString(NodeDeployMode(i).String())
-		if err != nil {
-			return result[:i]
-		}
-		result = append(result, ndm)
-		i++
-	}
 }

--- a/apstra/api_systems_test.go
+++ b/apstra/api_systems_test.go
@@ -97,12 +97,6 @@ func TestSystemsStrings(t *testing.T) {
 		{stringVal: "normal", intType: SystemAdminStateNormal, stringType: systemAdminStateNormal},
 		{stringVal: "decomm", intType: SystemAdminStateDecomm, stringType: systemAdminStateDecomm},
 		{stringVal: "maint", intType: SystemAdminStateMaint, stringType: systemAdminStateMaint},
-
-		{stringVal: "", intType: NodeDeployModeNone, stringType: nodeDeployModeNone},
-		{stringVal: "deploy", intType: NodeDeployModeDeploy, stringType: nodeDeployModeDeploy},
-		{stringVal: "undeploy", intType: NodeDeployModeUndeploy, stringType: nodeDeployModeUndeploy},
-		{stringVal: "ready", intType: NodeDeployModeReady, stringType: nodeDeployModeReady},
-		{stringVal: "drain", intType: NodeDeployModeDrain, stringType: nodeDeployModeDrain},
 	}
 
 	for i, td := range testData {
@@ -119,13 +113,5 @@ func TestSystemsStrings(t *testing.T) {
 			t.Fatalf("test index %d mismatch: %d %d '%s' '%s' '%s'",
 				i, ii, sp, is, ss, td.stringVal)
 		}
-	}
-}
-
-func TestAllNodeDeployModes(t *testing.T) {
-	all := AllNodeDeployModes()
-	expected := 5
-	if len(all) != expected {
-		t.Fatalf("expected %d node deploy modes, got %d", expected, len(all))
 	}
 }


### PR DESCRIPTION
This PR converts `DeployMode` from our old iota type to an enum, and adds support for deploy mode to the `SystemNodeInfo` struct.

This is being done because the `apstra_datacenter_generic_system` resource already calls `GetSystemNodeInfo()`, so including this detail will save a step in the generic system's `Read()` method.

The int/iota -> enum change will be a breaking change for the terraform provider, but it's one we want, so I'll absorb it in a provider PR.