### PR TITLE
Add error type for 'No value in either user config or profile'

### DIFF
--- a/apstra/client.go
+++ b/apstra/client.go
@@ -35,6 +35,7 @@ const (
 	ErrReadOnly
 	ErrCtAssignedToLink
 	ErrTimeout
+	ErrAgentProfilePlatformRequired
 
 	clientPollingIntervalMs = 1000
 

--- a/apstra/talk_to_apstra.go
+++ b/apstra/talk_to_apstra.go
@@ -64,6 +64,8 @@ func convertTtaeToAceWherePossible(err error) error {
 			return ClientErr{errType: ErrConflict, err: errors.New(ttae.Msg)}
 		case http.StatusUnprocessableEntity:
 			switch {
+			case strings.Contains(ttae.Msg, "No value in either user config or profile"):
+				return ClientErr{errType: ErrAgentProfilePlatformRequired, err: errors.New(ttae.Msg)}
 			case strings.Contains(ttae.Msg, "already exists"):
 				return ClientErr{errType: ErrExists, err: errors.New(ttae.Msg)}
 			case strings.Contains(ttae.Msg, "No node with id: "):


### PR DESCRIPTION
When clearing the `platform` field of an Agent Profile, a confusing error is produced if there are any existing agents which rely o the profile's `platform` field.

This PR introduces a new error type iota which will be returned in that case.