### PR TITLE
Make it possible to clear AgentProfile string attributes

### DIFF
--- a/apstra/api_system_agent_profiles.go
+++ b/apstra/api_system_agent_profiles.go
@@ -40,7 +40,7 @@ type AgentProfileConfig struct {
 	Label       string
 	Username    string
 	Password    string
-	Platform    string
+	Platform    *string
 	Packages    AgentPackages
 	OpenOptions map[string]string
 }
@@ -67,7 +67,7 @@ type rawAgentProfileConfig struct {
 	Label       string            `json:"label,omitempty"`
 	Username    string            `json:"username,omitempty"`
 	Password    string            `json:"password,omitempty"`
-	Platform    string            `json:"platform,omitempty"`
+	Platform    *string           `json:"platform,omitempty"`
 	Packages    rawAgentPackages  `json:"packages,omitempty"`
 	OpenOptions map[string]string `json:"open_options,omitempty"`
 }

--- a/apstra/api_system_agent_profiles.go
+++ b/apstra/api_system_agent_profiles.go
@@ -38,8 +38,8 @@ type AssignAgentProfileRequest struct {
 // AgentProfileConfig is used when creating or updating an Agent Profile
 type AgentProfileConfig struct {
 	Label       string
-	Username    string
-	Password    string
+	Username    *string
+	Password    *string
 	Platform    *string
 	Packages    AgentPackages
 	OpenOptions map[string]string
@@ -65,8 +65,8 @@ func (o *AgentProfileConfig) raw() *rawAgentProfileConfig {
 // Packages is really a map, but k,v are string-joined with "==" here.
 type rawAgentProfileConfig struct {
 	Label       string            `json:"label,omitempty"`
-	Username    string            `json:"username,omitempty"`
-	Password    string            `json:"password,omitempty"`
+	Username    *string           `json:"username,omitempty"`
+	Password    *string           `json:"password,omitempty"`
 	Platform    *string           `json:"platform,omitempty"`
 	Packages    rawAgentPackages  `json:"packages,omitempty"`
 	OpenOptions map[string]string `json:"open_options,omitempty"`

--- a/apstra/api_system_agent_profiles_test.go
+++ b/apstra/api_system_agent_profiles_test.go
@@ -26,11 +26,12 @@ func TestCreateListGetDeleteSystemAgentProfile(t *testing.T) {
 			apstraAgentPlatformJunos,
 			apstraAgentPlatformNXOS,
 		} {
+			platform := p
 			cfgs = append(cfgs, &AgentProfileConfig{
 				Label:    randString(10, "hex"),
 				Username: randString(10, "hex"),
 				Password: randString(10, "hex"),
-				Platform: p,
+				Platform: &platform,
 				Packages: map[string]string{
 					randString(10, "hex"): randString(10, "hex"),
 					randString(10, "hex"): randString(10, "hex"),
@@ -98,10 +99,40 @@ func TestCreateListGetDeleteSystemAgentProfile(t *testing.T) {
 	}
 }
 
+func TestClient_UpdateAgentProfile_NoPlatform(t *testing.T) {
+	ctx := context.Background()
+
+	clients, err := getTestClients(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for clientName, client := range clients {
+		log.Printf("testing CreateAgentProfile() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		id, err := client.client.CreateAgentProfile(ctx, &AgentProfileConfig{
+			Label:    randString(5, "hex"),
+			Platform: toPtr("junos"),
+		})
+		require.NoError(t, err)
+
+		log.Printf("testing UpdateAgentProfile() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		err = client.client.UpdateAgentProfile(ctx, id, &AgentProfileConfig{Platform: toPtr("")})
+		require.NoError(t, err)
+
+		ap, err := client.client.GetAgentProfile(ctx, id)
+		require.NoError(t, err)
+		require.Equal(t, "", ap.Platform)
+
+		log.Printf("testing DeleteAgentProfile() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+		err = client.client.DeleteAgentProfile(ctx, id)
+		require.NoError(t, err)
+	}
+}
+
 func TestClient_UpdateAgentProfile(t *testing.T) {
 	ctx := context.Background()
 
-	clients, err := getTestClients(context.Background(), t)
+	clients, err := getTestClients(ctx, t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -139,7 +170,7 @@ func TestClient_UpdateAgentProfile(t *testing.T) {
 
 		err = client.client.UpdateAgentProfile(ctx, profile.Id, &AgentProfileConfig{
 			Label:    profile.Label,
-			Platform: "",
+			Platform: nil,
 		})
 		require.Error(t, err)
 		var ace ClientErr

--- a/apstra/api_system_agent_profiles_test.go
+++ b/apstra/api_system_agent_profiles_test.go
@@ -29,8 +29,8 @@ func TestCreateListGetDeleteSystemAgentProfile(t *testing.T) {
 			platform := p
 			cfgs = append(cfgs, &AgentProfileConfig{
 				Label:    randString(10, "hex"),
-				Username: randString(10, "hex"),
-				Password: randString(10, "hex"),
+				Username: toPtr(randString(10, "hex")),
+				Password: toPtr(randString(10, "hex")),
 				Platform: &platform,
 				Packages: map[string]string{
 					randString(10, "hex"): randString(10, "hex"),
@@ -99,7 +99,7 @@ func TestCreateListGetDeleteSystemAgentProfile(t *testing.T) {
 	}
 }
 
-func TestClient_UpdateAgentProfile_NoPlatform(t *testing.T) {
+func TestClient_UpdateAgentProfile_ClearStringFields(t *testing.T) {
 	ctx := context.Background()
 
 	clients, err := getTestClients(ctx, t)
@@ -111,16 +111,24 @@ func TestClient_UpdateAgentProfile_NoPlatform(t *testing.T) {
 		log.Printf("testing CreateAgentProfile() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		id, err := client.client.CreateAgentProfile(ctx, &AgentProfileConfig{
 			Label:    randString(5, "hex"),
+			Username: toPtr(randString(5, "hex")),
+			Password: toPtr(randString(5, "hex")),
 			Platform: toPtr("junos"),
 		})
 		require.NoError(t, err)
 
 		log.Printf("testing UpdateAgentProfile() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		err = client.client.UpdateAgentProfile(ctx, id, &AgentProfileConfig{Platform: toPtr("")})
+		err = client.client.UpdateAgentProfile(ctx, id, &AgentProfileConfig{
+			Username: toPtr(""),
+			Password: toPtr(""),
+			Platform: toPtr(""),
+		})
 		require.NoError(t, err)
 
 		ap, err := client.client.GetAgentProfile(ctx, id)
 		require.NoError(t, err)
+		require.Equal(t, false, ap.HasUsername)
+		require.Equal(t, false, ap.HasPassword)
 		require.Equal(t, "", ap.Platform)
 
 		log.Printf("testing DeleteAgentProfile() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())


### PR DESCRIPTION
This PR makes it possible to clear the `Platform`, `Username` and `Password` fields from of an `AgentProfile` by converting the attribute from `string` to `*string`.

We now have two "no value" conditions:
- pointer to empty string -> clears the value from the API
- pointer to nothing -> omit / no change