### PR TITLE
Fix test fabric settings errors

### DIFF
--- a/apstra/api_blueprints_integration_test.go
+++ b/apstra/api_blueprints_integration_test.go
@@ -67,7 +67,7 @@ func TestCreateDeleteBlueprint(t *testing.T) {
 			fabricSettings = &FabricSettings{}
 
 			if !fabricL3MtuForbidden.Check(client.client.apiVersion) {
-				fabricL3Mtu := uint16(rand.Intn(550)*2 + 8000) // even number 8000 - 9100
+				fabricL3Mtu := uint16(rand.Intn(50)*2 + 9100) // even number 9100 - 9200
 				fabricSettings.FabricL3Mtu = &fabricL3Mtu
 				fabricSettings.SpineLeafLinks = toPtr(AddressingSchemeIp46)
 				fabricSettings.SpineSuperspineLinks = toPtr(AddressingSchemeIp46)
@@ -106,7 +106,7 @@ func TestCreateDeleteBlueprint(t *testing.T) {
 		}
 
 		if req.FabricSettings != nil && req.FabricSettings.FabricL3Mtu != nil {
-			fap, err := bpClient.GetFabricAddressingPolicy(ctx)
+			fap, err := bpClient.GetFabricSettings(ctx)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/apstra/compatibility.go
+++ b/apstra/compatibility.go
@@ -13,7 +13,7 @@ const (
 	apstra420 = "4.2.0"
 	apstra421 = "4.2.1"
 
-	apstraSupportedApiVersions = "4.1.0, 4.1.1, 4.1.2, 4.2.0"
+	apstraSupportedApiVersions = "4.1.0, 4.1.1, 4.1.2, 4.2.0, 4.2.1"
 	apstraSupportedVersionSep  = ","
 
 	podBasedTemplateFabricAddressingPolicyForbiddenVersions = "4.1.1, 4.1.2, 4.2.0, 4.2.1"
@@ -52,6 +52,7 @@ func SupportedApiVersions() []string {
 		apstra411,
 		apstra412,
 		apstra420,
+		apstra421,
 	}
 }
 

--- a/apstra/two_stage_l3_clos_connectivity_template_integration_test.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_integration_test.go
@@ -342,7 +342,7 @@ func TestCtLayout(t *testing.T) {
 		bpClient := testBlueprintA(ctx, t, client.client)
 
 		ipv6Enabled := true
-		err = bpClient.SetFabricAddressingPolicy(ctx, &TwoStageL3ClosFabricAddressingPolicy{Ipv6Enabled: &ipv6Enabled})
+		err = bpClient.SetFabricSettings(ctx, &FabricSettings{Ipv6Enabled: &ipv6Enabled})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/apstra/two_stage_l3_clos_fabric_addressing_policy_integration_test.go
+++ b/apstra/two_stage_l3_clos_fabric_addressing_policy_integration_test.go
@@ -23,6 +23,10 @@ func TestGetSetGetFAP(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
+		if geApstra421.Check(client.client.apiVersion) {
+			continue
+		}
+
 		bpClient := testBlueprintA(ctx, t, client.client)
 
 		log.Printf("testing GetFabricAddressingPolicy() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())


### PR DESCRIPTION
we had a few tests that were failing due to calls to fabricAddressing (old) vs fabricSettings(new)