### PR TITLE
Pod based template elements as map

### DIFF
--- a/apstra/api_design_templates_test.go
+++ b/apstra/api_design_templates_test.go
@@ -7,11 +7,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/go-version"
 	"log"
 	"math/rand"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/go-version"
 )
 
 func TestUnmarshalTemplate(t *testing.T) {
@@ -299,7 +300,6 @@ func TestUnmarshalTemplate(t *testing.T) {
 	}
 
 	log.Println(tType)
-
 }
 
 func TestTemplateStrings(t *testing.T) {
@@ -611,11 +611,11 @@ func TestCreateGetDeletePodBasedTemplate(t *testing.T) {
 				SuperspinePerPlane: 4,
 				LogicalDeviceId:    "AOS-4x40_8x10-1",
 			},
-			RackBasedTemplateIds: []ObjectId{rbtid},
-			RackBasedTemplateCounts: []RackBasedTemplateCount{{
-				RackBasedTemplateId: rbtid,
-				Count:               1,
-			}},
+			PodInfos: map[ObjectId]TemplatePodBasedInfo{
+				rbtid: {
+					Count: 1,
+				},
+			},
 			AntiAffinityPolicy: &AntiAffinityPolicy{
 				Algorithm:                AlgorithmHeuristic,
 				MaxLinksPerPort:          1,
@@ -677,8 +677,6 @@ func TestCreateGetDeleteL3CollapsedTemplate(t *testing.T) {
 			RackTypeId: "L3_collapsed_acs",
 			Count:      1,
 		}},
-		//DhcpServiceIntent:    DhcpServiceIntent{},
-		//AntiAffinityPolicy:   AntiAffinityPolicy{},
 		VirtualNetworkPolicy: VirtualNetworkPolicy{OverlayControlProtocol: OverlayControlProtocolEvpn},
 	}
 
@@ -1199,9 +1197,7 @@ func TestRackBasedTemplateMethods(t *testing.T) {
 	for clientName, client := range clients {
 		apiVersionString = client.client.apiVersion.String()
 		for i, tc := range testCases {
-
 			t.Run(fmt.Sprintf("Test-%d", i), func(t *testing.T) {
-
 				if !tc.versionConstraints.Check(client.client.apiVersion) {
 					t.Skipf("skipping testcase %d because of versionConstraint %s, version %s", i, tc.versionConstraints, client.client.apiVersion)
 				}

--- a/apstra/compatibility.go
+++ b/apstra/compatibility.go
@@ -7,18 +7,19 @@ import (
 )
 
 const (
-	apstra410 = "4.1.0"
-	apstra411 = "4.1.1"
-	apstra412 = "4.1.2"
-	apstra420 = "4.2.0"
-	apstra421 = "4.2.1"
+	apstra410  = "4.1.0"
+	apstra411  = "4.1.1"
+	apstra412  = "4.1.2"
+	apstra420  = "4.2.0"
+	apstra421  = "4.2.1"
+	apstra4211 = "4.2.1.1"
 
 	apstraSupportedApiVersions = "4.1.0, 4.1.1, 4.1.2, 4.2.0, 4.2.1"
 	apstraSupportedVersionSep  = ","
 
-	podBasedTemplateFabricAddressingPolicyForbiddenVersions = "4.1.1, 4.1.2, 4.2.0, 4.2.1"
+	podBasedTemplateFabricAddressingPolicyForbiddenVersions = "4.1.1, 4.1.2, 4.2.0, 4.2.1, 4.2.1.1"
 
-	rackBasedTemplateFabricAddressingPolicyForbiddenVersions = "4.1.1, 4.1.2, 4.2.0, 4.2.1"
+	rackBasedTemplateFabricAddressingPolicyForbiddenVersions = "4.1.1, 4.1.2, 4.2.0, 4.2.1, 4.2.1.1"
 
 	fabricL3MtuForbiddenError = "fabric_l3_mtu permitted only with Apstra 4.2.0 and later"
 


### PR DESCRIPTION
This PR converts pod details of a pod-based template from a pair of slices (API sytle) to a map keyed by pod ID (much easier to consume, and how rack-based templates already work)