### PR TITLE
Introduce detailed error handling when orphaning generic system LAGs

### DIFF
--- a/apstra/client.go
+++ b/apstra/client.go
@@ -34,6 +34,7 @@ const (
 	ErrWrongType
 	ErrReadOnly
 	ErrCtAssignedToLink
+	ErrLagHasAssignedStructrues
 	ErrTimeout
 	ErrAgentProfilePlatformRequired
 
@@ -45,6 +46,10 @@ const (
 
 type ErrCtAssignedToLinkDetail struct {
 	LinkIds []ObjectId
+}
+
+type ErrLagHasAssignedStructuresDetail struct {
+	GroupLabels []string
 }
 
 type ClientErr struct {

--- a/apstra/talk_to_apstra.go
+++ b/apstra/talk_to_apstra.go
@@ -26,13 +26,17 @@ const (
 	linkHasCtAssignedErrRegexString = "Link with id (.*) can not be deleted since some of its interfaces have connectivity templates assigned"
 	lagHasCtAssignedErrRegexString  = "Deleting all links forming a LAG is not allowed since the LAG has assigned structures: \\[.*'connectivity template'.*]. Link ids: \\[(.*)]"
 	linkHasVnEndpointErrRegexString = "Link with id (.*) can not be deleted since some of its interfaces have VN endpoints"
+	//lagHasAssignedStructuresRegexString = "Operation is not permitted because link group (.*) has assigned structures (VN endpoints, subinterfaces, endpoint templates etc.). Either at least one link from this group should preserve original group label, or all its links should change group label to the same new value, keeping aggregation (LAG / NO LAG) and without other link being added to it."
+	lagHasAssignedStructuresRegexString = "Operation is not permitted because link group (.*) has assigned structures"
 )
 
 var (
 	regexpApiUrlDeleteSwitchSystemLinks = regexp.MustCompile(strings.ReplaceAll(apiUrlDeleteSwitchSystemLinks, "%s", ".*"))
+	regexpApiUrlLeafServerLinkLabels    = regexp.MustCompile(strings.ReplaceAll(apiUrlLeafServerLinkLabels, "%s", ".*"))
 	regexpLinkHasCtAssignedErr          = regexp.MustCompile(linkHasCtAssignedErrRegexString)
 	regexpLagHasCtAssignedErr           = regexp.MustCompile(lagHasCtAssignedErrRegexString)
 	regexpLinkHasVnEndpoint             = regexp.MustCompile(linkHasVnEndpointErrRegexString)
+	regexpLagHasAssignedStructures      = regexp.MustCompile(lagHasAssignedStructuresRegexString)
 )
 
 // talkToApstraIn is the input structure for the Client.talkToApstra() function
@@ -92,6 +96,8 @@ func convertTtaeToAceWherePossible(err error) error {
 				case regexpLagHasCtAssignedErr.MatchString(ttae.Msg):
 					return ClientErr{errType: ErrCtAssignedToLink, err: errors.New(ttae.Msg)}
 				}
+			case regexpApiUrlLeafServerLinkLabels.MatchString(ttae.Request.URL.Path):
+				return ClientErr{errType: ErrLagHasAssignedStructrues, err: errors.New(ttae.Msg)}
 			}
 		case http.StatusInternalServerError:
 			switch {

--- a/apstra/two_stage_l3_clos_switch_system_links.go
+++ b/apstra/two_stage_l3_clos_switch_system_links.go
@@ -235,7 +235,7 @@ func (o *TwoStageL3ClosClient) DeleteLinksFromSystem(ctx context.Context, ids []
 		apiInput: &apiInput,
 	})
 	if err == nil {
-		return nil
+		return nil // success!
 	}
 
 	// if we got here, then we have an error


### PR DESCRIPTION
"Orphaning" a generic system LAG by changing all LAG member "group labels" to a new value produces an error like:

`Operation is not permitted because link group XXX has assigned structures (VN endpoints, subinterfaces, endpoint templates etc.). Either at least one link from this group should preserve original group label, or all its links should change group label to the same new value, keeping aggregation (LAG / NO LAG) and without other link being added to it.`

This PR  ensures that the error returned in this case produces a detail struct (`type ErrLagHasAssignedStructuresDetail`) which enumerates the problem group labels for handling by the calling application.