### PR TITLE
Handle 'subinterfaces' link deletion error

### DIFF
--- a/apstra/talk_to_apstra.go
+++ b/apstra/talk_to_apstra.go
@@ -23,10 +23,10 @@ const (
 	errResponseStringLimit          = 1024
 	peekSizeForApstraTaskIdResponse = math.MaxUint8
 
-	linkHasCtAssignedErrRegexString = "Link with id (.*) can not be deleted since some of its interfaces have connectivity templates assigned"
-	lagHasCtAssignedErrRegexString  = "Deleting all links forming a LAG is not allowed since the LAG has assigned structures: \\[.*'connectivity template'.*]. Link ids: \\[(.*)]"
-	linkHasVnEndpointErrRegexString = "Link with id (.*) can not be deleted since some of its interfaces have VN endpoints"
-	//lagHasAssignedStructuresRegexString = "Operation is not permitted because link group (.*) has assigned structures (VN endpoints, subinterfaces, endpoint templates etc.). Either at least one link from this group should preserve original group label, or all its links should change group label to the same new value, keeping aggregation (LAG / NO LAG) and without other link being added to it."
+	linkHasCtAssignedErrRegexString     = "Link with id (.*) can not be deleted since some of its interfaces have connectivity templates assigned"
+	lagHasCtAssignedErrRegexString      = "Deleting all links forming a LAG is not allowed since the LAG has assigned structures: \\[.*'connectivity template'.*]. Link ids: \\[(.*)]"
+	linkHasVnEndpointErrRegexString     = "Link with id (.*) can not be deleted since some of its interfaces have VN endpoints"
+	linkHasSubinterfacesErrRegexString  = "Link with id (.*) can not be deleted since some of its interfaces have subinterfaces"
 	lagHasAssignedStructuresRegexString = "Operation is not permitted because link group (.*) has assigned structures"
 )
 
@@ -36,6 +36,7 @@ var (
 	regexpLinkHasCtAssignedErr          = regexp.MustCompile(linkHasCtAssignedErrRegexString)
 	regexpLagHasCtAssignedErr           = regexp.MustCompile(lagHasCtAssignedErrRegexString)
 	regexpLinkHasVnEndpoint             = regexp.MustCompile(linkHasVnEndpointErrRegexString)
+	regexpLinkHasSubinterfaces          = regexp.MustCompile(linkHasSubinterfacesErrRegexString)
 	regexpLagHasAssignedStructures      = regexp.MustCompile(lagHasAssignedStructuresRegexString)
 )
 

--- a/apstra/two_stage_l3_clos_switch_system_links.go
+++ b/apstra/two_stage_l3_clos_switch_system_links.go
@@ -275,6 +275,8 @@ func (o *TwoStageL3ClosClient) DeleteLinksFromSystem(ctx context.Context, ids []
 			lagErrs = append(lagErrs, le)
 		case regexpLinkHasVnEndpoint.MatchString(le):
 			// do nothing - this condition should trigger the regexpLinkHasCtAssignedErr also
+		case regexpLinkHasSubinterfaces.MatchString(le):
+			// do nothing - this condition should trigger the regexpLinkHasCtAssignedErr also
 		default: // cannot handle error - surface it to the user
 			return fmt.Errorf("cannot handle link error %q - %w", le, err)
 		}


### PR DESCRIPTION
Deleting a generic system link with `ip_link` (L3 handoff) connectivity template produces an error we hadn't noticed before:

```
Link with id XXX can not be deleted since some of its interfaces have subinterfaces
```

Add regex to handle this error gracefully.