### PR TITLE
review #271

### DIFF
--- a/apstra/api_iba_predefined_probes.go
+++ b/apstra/api_iba_predefined_probes.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
-	"reflect"
 	"time"
 )
 
@@ -64,42 +63,52 @@ func (o *Client) getIbaPredefinedProbeByName(ctx context.Context, bpId ObjectId,
 }
 
 func (o *Client) instantiatePredefinedIbaProbe(ctx context.Context, bpId ObjectId, in *IbaPredefinedProbeRequest) (ObjectId, error) {
-	response := &objectIdResponse{}
-
+	var response objectIdResponse
 	err := o.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodPost,
 		urlStr:      fmt.Sprintf(apiUrlIbaPredefinedProbesByName, bpId, in.Name),
 		apiInput:    in.Data,
-		apiResponse: response,
+		apiResponse: &response,
 	})
 	if err == nil {
 		return response.Id, nil
 	}
-	ce := convertTtaeToAceWherePossible(err)
-	if !(reflect.TypeOf(ce) == reflect.TypeOf(ClientErr{}) && ce.(ClientErr).IsRetryable()) {
-		return "", err
+
+	err = convertTtaeToAceWherePossible(err)
+
+	var ace ClientErr
+	if !(errors.As(err, &ace) && ace.IsRetryable()) {
+		return "", err // fatal error
 	}
 
-	for i := 0; i < dcClientMaxRetries; i++ {
+	retryMax := o.GetTuningParam("ibaPredefinedProbeMaxRetries")
+	retryInterval := time.Duration(o.GetTuningParam("ibaPredefinedProbeRetryIntervalMs")) * time.Millisecond
+
+	for i := 0; i < retryMax; i++ {
 		// Make a random wait, in case multiple threads are running
-		if rand.Int()/2 == 0 {
-			time.Sleep(dcClientRetryBackoff)
+		if rand.Int()%2 == 0 {
+			time.Sleep(retryInterval)
 		}
-		time.Sleep(dcClientRetryBackoff * time.Duration(i))
+
+		time.Sleep(retryInterval * time.Duration(i))
+
 		e := o.talkToApstra(ctx, &talkToApstraIn{
 			method:      http.MethodPost,
 			urlStr:      fmt.Sprintf(apiUrlIbaPredefinedProbesByName, bpId, in.Name),
 			apiInput:    in.Data,
-			apiResponse: response,
+			apiResponse: &response,
 		})
-		if err == nil {
-			return response.Id, nil
+		if e == nil {
+			return response.Id, nil // success!
 		}
-		ce := convertTtaeToAceWherePossible(err)
-		if !(reflect.TypeOf(ce) == reflect.TypeOf(ClientErr{}) && ce.(ClientErr).IsRetryable()) {
-			return "", err
+
+		e = convertTtaeToAceWherePossible(e)
+		if !(errors.As(err, &ace) && ace.IsRetryable()) {
+			return "", e // return the fatal error
 		}
-		err = errors.Join(err, e)
+
+		err = errors.Join(err, e) // the error is retryable; stack it with the rest
 	}
-	return "", err
+
+	return "", errors.Join(err, fmt.Errorf("reached retry limit %d", retryMax))
 }

--- a/apstra/api_iba_probes.go
+++ b/apstra/api_iba_probes.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
-	"reflect"
 	"time"
 )
 
@@ -135,10 +134,8 @@ func (o *Client) deleteIbaProbe(ctx context.Context, bpId ObjectId, id ObjectId)
 	}))
 }
 
-func (o *Client) createIbaProbeFromJson(ctx context.Context, bpId ObjectId, probeJson json.RawMessage) (ObjectId,
-	error) {
-
-	response := objectIdResponse{}
+func (o *Client) createIbaProbeFromJson(ctx context.Context, bpId ObjectId, probeJson json.RawMessage) (ObjectId, error) {
+	var response objectIdResponse
 	err := o.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodPost,
 		urlStr:      fmt.Sprintf(apiUrlIbaProbes, bpId),
@@ -148,31 +145,42 @@ func (o *Client) createIbaProbeFromJson(ctx context.Context, bpId ObjectId, prob
 	if err == nil {
 		return response.Id, nil
 	}
-	ce := convertTtaeToAceWherePossible(err)
-	if !(reflect.TypeOf(ce) == reflect.TypeOf(ClientErr{}) && ce.(ClientErr).IsRetryable()) {
-		return "", err
+
+	err = convertTtaeToAceWherePossible(err)
+
+	var ace ClientErr
+	if !(errors.As(err, &ace) && ace.IsRetryable()) {
+		return "", err // fatal error
 	}
 
-	for i := 0; i < dcClientMaxRetries; i++ {
+	retryMax := o.GetTuningParam("createProbeMaxRetries")
+	retryInterval := time.Duration(o.GetTuningParam("createProbeRetryIntervalMs")) * time.Millisecond
+
+	for i := 0; i < retryMax; i++ {
 		// Make a random wait, in case multiple threads are running
-		if rand.Int()/2 == 0 {
-			time.Sleep(dcClientRetryBackoff)
+		if rand.Int()%2 == 0 {
+			time.Sleep(retryInterval)
 		}
-		time.Sleep(dcClientRetryBackoff * time.Duration(i))
+
+		time.Sleep(retryInterval * time.Duration(i))
+
 		e := o.talkToApstra(ctx, &talkToApstraIn{
 			method:      http.MethodPost,
 			urlStr:      fmt.Sprintf(apiUrlIbaProbes, bpId),
 			apiInput:    probeJson,
 			apiResponse: &response,
 		})
-		if err == nil {
-			return response.Id, nil
+		if e == nil {
+			return response.Id, nil // success!
 		}
-		ce := convertTtaeToAceWherePossible(err)
-		if !(reflect.TypeOf(ce) == reflect.TypeOf(ClientErr{}) && ce.(ClientErr).IsRetryable()) {
-			return "", err
+
+		e = convertTtaeToAceWherePossible(e)
+		if !(errors.As(err, &ace) && ace.IsRetryable()) {
+			return "", e // return the fatal error
 		}
-		err = errors.Join(err, e)
+
+		err = errors.Join(err, e) // the error is retryable; stack it with the rest
 	}
-	return "", err
+
+	return "", errors.Join(err, fmt.Errorf("reached retry limit %d", retryMax))
 }

--- a/apstra/client.go
+++ b/apstra/client.go
@@ -42,6 +42,7 @@ const (
 	clientPollingIntervalMs = 1000
 
 	defaultTimerPollingIntervalMs = 1000
+	defaultTimerRetryIntervalMs   = 100
 	defaultTimerTimeoutSec        = 10
 	defaultMaxRetries             = 5
 
@@ -159,6 +160,8 @@ func (o *Client) GetTuningParam(name string) int {
 	switch {
 	case strings.Contains(name, "TimeoutSec"):
 		return defaultTimerTimeoutSec
+	case strings.Contains(name, "RetryIntervalMs"):
+		return defaultTimerRetryIntervalMs
 	case strings.Contains(name, "PollingIntervalMs"):
 		return defaultTimerPollingIntervalMs
 	case strings.Contains(name, "MaxRetries"):

--- a/apstra/talk_to_apstra.go
+++ b/apstra/talk_to_apstra.go
@@ -105,7 +105,6 @@ func convertTtaeToAceWherePossible(err error) error {
 			case strings.Contains(ttae.Msg, "Error executing facade API GET /obj-policy-export") &&
 				strings.Contains(ttae.Msg, "'NoneType' object has no attribute 'id'"):
 				return ClientErr{errType: ErrNotfound, err: errors.New(ttae.Msg)}
-
 			case strings.Contains(ttae.Msg, "The current mount is conflicting with an existing mount"):
 				return ClientErr{errType: ErrIbaCurrentMountConflictsWithExistingMount, retryable: true, err: errors.New(ttae.Msg)}
 			}


### PR DESCRIPTION
- Use `errors.As()` instead of `reflect` package
- normalize `response` object (vs. pointer in some cases)
- use new `GetTuningParam()` for intervals/counters
- add `RetryIntervalMs` default value for tuning params (100ms)
- change dice roll from `rand.Int()/2 == 0` to `rand.Int()%2 == 0` (I think this is what was intended?)
- join a final "max retries" error to the error return if max retries reached