### PR TITLE
Feat/277 subinterface ip address control

### DIFF
--- a/apstra/enum.go
+++ b/apstra/enum.go
@@ -106,6 +106,44 @@ var (
 	TcpStateQualifiers                = oenum.New(
 		TcpStateQualifierEstablished,
 	)
+
+	_                      enum = new(FFResourceType)
+	FFResourceTypeAsn           = FFResourceType{Value: "asn"}
+	FFResourceTypeHostIpv4      = FFResourceType{Value: "host_ip"}
+	FFResourceTypeHostIpv6      = FFResourceType{Value: "host_ipv6"}
+	FFResourceTypeInt           = FFResourceType{Value: "integer"}
+	FFResourceTypeIpv4          = FFResourceType{Value: "ip"}
+	FFResourceTypeIpv6          = FFResourceType{Value: "ipv6"}
+	FFResourceTypeVlan          = FFResourceType{Value: "vlan"}
+	FFResourceTypeVni           = FFResourceType{Value: "vni"}
+	FFResourceTypes             = oenum.New(
+		FFResourceTypeAsn,
+		FFResourceTypeHostIpv4,
+		FFResourceTypeHostIpv6,
+		FFResourceTypeInt,
+		FFResourceTypeIpv4,
+		FFResourceTypeIpv6,
+		FFResourceTypeVlan,
+		FFResourceTypeVni,
+	)
+
+	_                                  enum = new(InterfaceNumberingIpv4Type)
+	InterfaceNumberingIpv4TypeNone          = InterfaceNumberingIpv4Type{Value: ""}
+	InterfaceNumberingIpv4TypeNumbered      = InterfaceNumberingIpv4Type{Value: "numbered"}
+	InterfaceNumberingIpv4Types             = oenum.New(
+		InterfaceNumberingIpv4TypeNone,
+		InterfaceNumberingIpv4TypeNumbered,
+	)
+
+	_                                   enum = new(InterfaceNumberingIpv6Type)
+	InterfaceNumberingIpv6TypeNone           = InterfaceNumberingIpv6Type{Value: ""}
+	InterfaceNumberingIpv6TypeNumbered       = InterfaceNumberingIpv6Type{Value: "numbered"}
+	InterfaceNumberingIpv6TypeLinkLocal      = InterfaceNumberingIpv6Type{Value: "link_local"}
+	InterfaceNumberingIpv6Types              = oenum.New(
+		InterfaceNumberingIpv6TypeNone,
+		InterfaceNumberingIpv6TypeNumbered,
+		InterfaceNumberingIpv6TypeLinkLocal,
+	)
 )
 
 type DeployMode oenum.Member[string]
@@ -253,6 +291,51 @@ func (o *TcpStateQualifier) FromString(s string) error {
 	t := TcpStateQualifiers.Parse(s)
 	if t == nil {
 		return fmt.Errorf("failed to parse TcpStateQualifier %q", s)
+	}
+	o.Value = t.Value
+	return nil
+}
+
+type FFResourceType oenum.Member[string]
+
+func (o FFResourceType) String() string {
+	return o.Value
+}
+
+func (o *FFResourceType) FromString(s string) error {
+	t := FFResourceTypes.Parse(s)
+	if t == nil {
+		return fmt.Errorf("failed to parse FFResourceType %q", s)
+	}
+	o.Value = t.Value
+	return nil
+}
+
+type InterfaceNumberingIpv4Type oenum.Member[string]
+
+func (o InterfaceNumberingIpv4Type) String() string {
+	return o.Value
+}
+
+func (o *InterfaceNumberingIpv4Type) FromString(s string) error {
+	t := InterfaceNumberingIpv4Types.Parse(s)
+	if t == nil {
+		return fmt.Errorf("failed to parse InterfaceNumberingIpv4Type %q", s)
+	}
+	o.Value = t.Value
+	return nil
+}
+
+type InterfaceNumberingIpv6Type oenum.Member[string]
+
+func (o InterfaceNumberingIpv6Type) String() string {
+	return o.Value
+}
+
+func (o *InterfaceNumberingIpv6Type) FromString(s string) error {
+	t := InterfaceNumberingIpv6Types.Parse(s)
+	if t == nil {
+		return fmt.Errorf("failed to parse InterfaceNumberingIpv6Type %q", s)
 	}
 	o.Value = t.Value
 	return nil

--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -183,26 +183,21 @@ func testBlueprintB(ctx context.Context, t *testing.T, client *Client) *TwoStage
 	return bpClient
 }
 
-func testBlueprintC(ctx context.Context, t *testing.T, client *Client) (*TwoStageL3ClosClient, func(context.Context) error) {
+func testBlueprintC(ctx context.Context, t *testing.T, client *Client) *TwoStageL3ClosClient {
+	t.Helper()
+
 	bpId, err := client.CreateBlueprintFromTemplate(ctx, &CreateBlueprintFromTemplateRequest{
 		RefDesign:  RefDesignTwoStageL3Clos,
 		Label:      randString(5, "hex"),
 		TemplateId: "L2_Virtual_EVPN",
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.DeleteBlueprint(ctx, bpId)) })
 
 	bpClient, err := client.NewTwoStageL3ClosClient(ctx, bpId)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	bpDeleteFunc := func(ctx context.Context) error {
-		return client.DeleteBlueprint(ctx, bpId)
-	}
-
-	return bpClient, bpDeleteFunc
+	return bpClient
 }
 
 func testBlueprintD(ctx context.Context, t *testing.T, client *Client) (*TwoStageL3ClosClient, func(context.Context) error) {

--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -183,7 +183,7 @@ func testBlueprintB(ctx context.Context, t *testing.T, client *Client) *TwoStage
 	return bpClient
 }
 
-func testBlueprintC(ctx context.Context, t *testing.T, client *Client) *TwoStageL3ClosClient {
+func testBlueprintC(ctx context.Context, t testing.TB, client *Client) *TwoStageL3ClosClient {
 	t.Helper()
 
 	bpId, err := client.CreateBlueprintFromTemplate(ctx, &CreateBlueprintFromTemplateRequest{

--- a/apstra/two_stage_l3_clos_connectivity_template_assignment_integration_test.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_assignment_integration_test.go
@@ -56,16 +56,7 @@ func TestAssignClearCtToInterface(t *testing.T) {
 	vnCount := 2
 
 	for clientName, client := range clients {
-		bpClient, bpDel := testBlueprintC(ctx, t, client.client)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer func() {
-			err := bpDel(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient := testBlueprintC(ctx, t, client.client)
 
 		leafIds, err := getSystemIdsByRole(ctx, bpClient, "leaf")
 		if err != nil {

--- a/apstra/two_stage_l3_clos_fabric_settings_integration_test.go
+++ b/apstra/two_stage_l3_clos_fabric_settings_integration_test.go
@@ -246,13 +246,7 @@ func TestSetGetFabricSettings(t *testing.T) {
 
 	for clientName, client := range clients {
 		client := client
-		bpClient, bpDel := testBlueprintC(ctx, t, client.client)
-		defer func() {
-			err = bpDel(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient := testBlueprintC(ctx, t, client.client)
 
 		for tName, tCase := range testCases {
 			tName, tCase := tName, tCase
@@ -324,13 +318,7 @@ func TestFabricSettingsRoutesMaxDefaultVsZero(t *testing.T) {
 
 	for clientName, client := range clients {
 		client := client
-		bpClient, bpDel := testBlueprintC(ctx, t, client.client)
-		defer func() {
-			err = bpDel(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient := testBlueprintC(ctx, t, client.client)
 
 		for _, tCase := range testCases {
 			tCase := tCase
@@ -367,13 +355,7 @@ func TestSetGetFabricSettingsV6(t *testing.T) {
 	for clientName, client := range clients {
 		client := client
 
-		bpClient, bpDel := testBlueprintC(ctx, t, client.client)
-		defer func() {
-			err = bpDel(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient := testBlueprintC(ctx, t, client.client)
 
 		t.Run("enable_and_check_ipv6", func(t *testing.T) {
 			fsSet := &FabricSettings{

--- a/apstra/two_stage_l3_clos_property_sets_test.go
+++ b/apstra/two_stage_l3_clos_property_sets_test.go
@@ -21,13 +21,8 @@ func TestImportGetUpdateGetDeletePropertySet(t *testing.T) {
 	for clientName, client := range clients {
 
 		// Create Blueprint
-		bpClient, bpDel := testBlueprintC(ctx, t, client.client)
-		defer func() {
-			err := bpDel(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient := testBlueprintC(ctx, t, client.client)
+
 		// Create Property Set
 		samples := rand.Intn(10) + 4
 		ps := &PropertySetData{

--- a/apstra/two_stage_l3_clos_racks_integration_test.go
+++ b/apstra/two_stage_l3_clos_racks_integration_test.go
@@ -39,13 +39,7 @@ func TestCreateDeleteRack(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		bp, bpDel := testBlueprintC(ctx, t, client.client)
-		defer func() {
-			err = bpDel(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bp := testBlueprintC(ctx, t, client.client)
 
 		for _, tCase := range testCases {
 			log.Printf("testing CreateRack() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())

--- a/apstra/two_stage_l3_clos_subinterface.go
+++ b/apstra/two_stage_l3_clos_subinterface.go
@@ -1,0 +1,134 @@
+package apstra
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+)
+
+const (
+	apiUrlSubinterfaces = apiUrlBlueprintByIdPrefix + "subinterfaces"
+)
+
+var _ json.Marshaler = (*TwoStageL3ClosSubinterface)(nil)
+var _ json.Unmarshaler = (*TwoStageL3ClosSubinterface)(nil)
+
+type TwoStageL3ClosSubinterface struct {
+	Id           ObjectId
+	Ipv4AddrType *InterfaceNumberingIpv4Type
+	Ipv6AddrType *InterfaceNumberingIpv6Type
+	Ipv4Addr     *net.IPNet
+	Ipv6Addr     *net.IPNet
+}
+
+func (o TwoStageL3ClosSubinterface) MarshalJSON() ([]byte, error) {
+	var raw struct {
+		Id           ObjectId `json:"id"`
+		Ipv4AddrType string   `json:"ipv4_addr_type,omitempty"`
+		Ipv6AddrType string   `json:"ipv6_addr_type,omitempty"`
+		Ipv4Addr     *string  `json:"ipv4_addr,omitempty"`
+		Ipv6Addr     *string  `json:"ipv6_addr,omitempty"`
+	}
+
+	raw.Id = o.Id
+
+	if o.Ipv4AddrType != nil {
+		raw.Ipv4AddrType = o.Ipv4AddrType.String()
+	}
+
+	if o.Ipv6AddrType != nil {
+		raw.Ipv6AddrType = o.Ipv6AddrType.String()
+	}
+
+	if o.Ipv4Addr != nil {
+		if len(o.Ipv4Addr.IP) > 0 && len(o.Ipv4Addr.Mask) > 0 {
+			raw.Ipv4Addr = toPtr(o.Ipv4Addr.String()) // send the string representation
+		} else {
+			raw.Ipv4Addr = toPtr("") // send an empty string to clear the value on the server
+		}
+	}
+
+	if o.Ipv6Addr != nil {
+		if len(o.Ipv6Addr.IP) > 0 && len(o.Ipv6Addr.Mask) > 0 {
+			raw.Ipv6Addr = toPtr(o.Ipv6Addr.String()) // send the string representation
+		} else {
+			raw.Ipv6Addr = toPtr("") // send an empty string to clear the value on the server
+		}
+	}
+
+	return json.Marshal(raw)
+}
+
+func (o *TwoStageL3ClosSubinterface) UnmarshalJSON(bytes []byte) error {
+	var raw struct {
+		Id           ObjectId `json:"id"`
+		Ipv4AddrType string   `json:"ipv4_addr_type,omitempty"`
+		Ipv6AddrType string   `json:"ipv6_addr_type,omitempty"`
+		Ipv4Addr     *string  `json:"ipv4_addr,omitempty"`
+		Ipv6Addr     *string  `json:"ipv6_addr,omitempty"`
+	}
+
+	err := json.Unmarshal(bytes, &raw)
+	if err != nil {
+		return err
+	}
+
+	o.Id = raw.Id
+
+	o.Ipv4AddrType = new(InterfaceNumberingIpv4Type)
+	err = o.Ipv4AddrType.FromString(raw.Ipv4AddrType)
+	if err != nil {
+		return fmt.Errorf("failed parsing ipv4_addr_type %q while unmarshaling TwoStageL3ClosSubinterface", raw.Ipv4AddrType)
+	}
+
+	o.Ipv6AddrType = new(InterfaceNumberingIpv6Type)
+	err = o.Ipv6AddrType.FromString(raw.Ipv6AddrType)
+	if err != nil {
+		return fmt.Errorf("failed parsing ipv6_addr_type %q while unmarshaling TwoStageL3ClosSubinterface", raw.Ipv6AddrType)
+	}
+
+	if raw.Ipv4Addr != nil {
+		ip, net, err := net.ParseCIDR(*raw.Ipv4Addr)
+		if err != nil {
+			return fmt.Errorf("failed parsing ipv4_addr while unmarshaling subinterface - %w", err)
+		}
+		net.IP = ip
+		o.Ipv4Addr = net
+	}
+
+	if raw.Ipv6Addr != nil {
+		ip, net, err := net.ParseCIDR(*raw.Ipv6Addr)
+		if err != nil {
+			return fmt.Errorf("failed parsing ipv6_addr while unmarshaling subinterface - %w", err)
+		}
+		net.IP = ip
+		o.Ipv6Addr = net
+	}
+
+	return nil
+}
+
+func (o *TwoStageL3ClosClient) UpdateSubinterfaces(ctx context.Context, in []TwoStageL3ClosSubinterface) error {
+	var input struct {
+		Subinterfaces map[ObjectId]TwoStageL3ClosSubinterface `json:"subinterfaces"`
+	}
+
+	input.Subinterfaces = make(map[ObjectId]TwoStageL3ClosSubinterface, len(in))
+	for _, si := range in {
+		input.Subinterfaces[si.Id] = si
+	}
+
+	err := o.client.talkToApstra(ctx, &talkToApstraIn{
+		method:   http.MethodPatch,
+		urlStr:   fmt.Sprintf(apiUrlSubinterfaces, o.Id()),
+		apiInput: &input,
+	})
+
+	if err != nil {
+		return convertTtaeToAceWherePossible(err)
+	}
+
+	return nil
+}

--- a/apstra/two_stage_l3_clos_subinterface.go
+++ b/apstra/two_stage_l3_clos_subinterface.go
@@ -12,8 +12,10 @@ const (
 	apiUrlSubinterfaces = apiUrlBlueprintByIdPrefix + "subinterfaces"
 )
 
-var _ json.Marshaler = (*TwoStageL3ClosSubinterface)(nil)
-var _ json.Unmarshaler = (*TwoStageL3ClosSubinterface)(nil)
+var (
+	_ json.Marshaler   = (*TwoStageL3ClosSubinterface)(nil)
+	_ json.Unmarshaler = (*TwoStageL3ClosSubinterface)(nil)
+)
 
 type TwoStageL3ClosSubinterface struct {
 	Ipv4AddrType InterfaceNumberingIpv4Type
@@ -166,7 +168,6 @@ func (o *TwoStageL3ClosClient) UpdateSubinterfaces(ctx context.Context, in map[O
 			Subinterfaces: in,
 		},
 	})
-
 	if err != nil {
 		return convertTtaeToAceWherePossible(err)
 	}

--- a/apstra/two_stage_l3_clos_subinterface.go
+++ b/apstra/two_stage_l3_clos_subinterface.go
@@ -24,18 +24,18 @@ type TwoStageL3ClosSubinterface struct {
 
 func (o TwoStageL3ClosSubinterface) MarshalJSON() ([]byte, error) {
 	var raw struct {
-		Ipv4AddrType string  `json:"ipv4_addr_type,omitempty"`
-		Ipv6AddrType string  `json:"ipv6_addr_type,omitempty"`
+		Ipv4AddrType *string `json:"ipv4_addr_type,omitempty"`
+		Ipv6AddrType *string `json:"ipv6_addr_type,omitempty"`
 		Ipv4Addr     *string `json:"ipv4_addr,omitempty"`
 		Ipv6Addr     *string `json:"ipv6_addr,omitempty"`
 	}
 
 	if o.Ipv4AddrType != nil {
-		raw.Ipv4AddrType = o.Ipv4AddrType.String()
+		raw.Ipv4AddrType = toPtr(o.Ipv4AddrType.String())
 	}
 
 	if o.Ipv6AddrType != nil {
-		raw.Ipv6AddrType = o.Ipv6AddrType.String()
+		raw.Ipv6AddrType = toPtr(o.Ipv6AddrType.String())
 	}
 
 	if o.Ipv4Addr != nil {

--- a/apstra/two_stage_l3_clos_subinterface.go
+++ b/apstra/two_stage_l3_clos_subinterface.go
@@ -16,7 +16,6 @@ var _ json.Marshaler = (*TwoStageL3ClosSubinterface)(nil)
 var _ json.Unmarshaler = (*TwoStageL3ClosSubinterface)(nil)
 
 type TwoStageL3ClosSubinterface struct {
-	Id           ObjectId
 	Ipv4AddrType *InterfaceNumberingIpv4Type
 	Ipv6AddrType *InterfaceNumberingIpv6Type
 	Ipv4Addr     *net.IPNet
@@ -25,14 +24,11 @@ type TwoStageL3ClosSubinterface struct {
 
 func (o TwoStageL3ClosSubinterface) MarshalJSON() ([]byte, error) {
 	var raw struct {
-		Id           ObjectId `json:"id"`
-		Ipv4AddrType string   `json:"ipv4_addr_type,omitempty"`
-		Ipv6AddrType string   `json:"ipv6_addr_type,omitempty"`
-		Ipv4Addr     *string  `json:"ipv4_addr,omitempty"`
-		Ipv6Addr     *string  `json:"ipv6_addr,omitempty"`
+		Ipv4AddrType string  `json:"ipv4_addr_type,omitempty"`
+		Ipv6AddrType string  `json:"ipv6_addr_type,omitempty"`
+		Ipv4Addr     *string `json:"ipv4_addr,omitempty"`
+		Ipv6Addr     *string `json:"ipv6_addr,omitempty"`
 	}
-
-	raw.Id = o.Id
 
 	if o.Ipv4AddrType != nil {
 		raw.Ipv4AddrType = o.Ipv4AddrType.String()
@@ -63,19 +59,16 @@ func (o TwoStageL3ClosSubinterface) MarshalJSON() ([]byte, error) {
 
 func (o *TwoStageL3ClosSubinterface) UnmarshalJSON(bytes []byte) error {
 	var raw struct {
-		Id           ObjectId `json:"id"`
-		Ipv4AddrType string   `json:"ipv4_addr_type,omitempty"`
-		Ipv6AddrType string   `json:"ipv6_addr_type,omitempty"`
-		Ipv4Addr     *string  `json:"ipv4_addr,omitempty"`
-		Ipv6Addr     *string  `json:"ipv6_addr,omitempty"`
+		Ipv4AddrType string  `json:"ipv4_addr_type,omitempty"`
+		Ipv6AddrType string  `json:"ipv6_addr_type,omitempty"`
+		Ipv4Addr     *string `json:"ipv4_addr,omitempty"`
+		Ipv6Addr     *string `json:"ipv6_addr,omitempty"`
 	}
 
 	err := json.Unmarshal(bytes, &raw)
 	if err != nil {
 		return err
 	}
-
-	o.Id = raw.Id
 
 	o.Ipv4AddrType = new(InterfaceNumberingIpv4Type)
 	err = o.Ipv4AddrType.FromString(raw.Ipv4AddrType)
@@ -110,20 +103,15 @@ func (o *TwoStageL3ClosSubinterface) UnmarshalJSON(bytes []byte) error {
 	return nil
 }
 
-func (o *TwoStageL3ClosClient) UpdateSubinterfaces(ctx context.Context, in []TwoStageL3ClosSubinterface) error {
-	var input struct {
-		Subinterfaces map[ObjectId]TwoStageL3ClosSubinterface `json:"subinterfaces"`
-	}
-
-	input.Subinterfaces = make(map[ObjectId]TwoStageL3ClosSubinterface, len(in))
-	for _, si := range in {
-		input.Subinterfaces[si.Id] = si
-	}
-
+func (o *TwoStageL3ClosClient) UpdateSubinterfaces(ctx context.Context, in map[ObjectId]TwoStageL3ClosSubinterface) error {
 	err := o.client.talkToApstra(ctx, &talkToApstraIn{
-		method:   http.MethodPatch,
-		urlStr:   fmt.Sprintf(apiUrlSubinterfaces, o.Id()),
-		apiInput: &input,
+		method: http.MethodPatch,
+		urlStr: fmt.Sprintf(apiUrlSubinterfaces, o.Id()),
+		apiInput: &struct {
+			Subinterfaces map[ObjectId]TwoStageL3ClosSubinterface `json:"subinterfaces"`
+		}{
+			Subinterfaces: in,
+		},
 	})
 
 	if err != nil {

--- a/apstra/two_stage_l3_clos_subinterface.go
+++ b/apstra/two_stage_l3_clos_subinterface.go
@@ -16,42 +16,34 @@ var _ json.Marshaler = (*TwoStageL3ClosSubinterface)(nil)
 var _ json.Unmarshaler = (*TwoStageL3ClosSubinterface)(nil)
 
 type TwoStageL3ClosSubinterface struct {
-	Ipv4AddrType *InterfaceNumberingIpv4Type
-	Ipv6AddrType *InterfaceNumberingIpv6Type
+	Ipv4AddrType InterfaceNumberingIpv4Type
+	Ipv6AddrType InterfaceNumberingIpv6Type
 	Ipv4Addr     *net.IPNet
 	Ipv6Addr     *net.IPNet
 }
 
 func (o TwoStageL3ClosSubinterface) MarshalJSON() ([]byte, error) {
 	var raw struct {
-		Ipv4AddrType *string `json:"ipv4_addr_type,omitempty"`
-		Ipv6AddrType *string `json:"ipv6_addr_type,omitempty"`
-		Ipv4Addr     *string `json:"ipv4_addr,omitempty"`
-		Ipv6Addr     *string `json:"ipv6_addr,omitempty"`
+		Ipv4AddrType *string `json:"ipv4_addr_type"`
+		Ipv6AddrType *string `json:"ipv6_addr_type"`
+		Ipv4Addr     *string `json:"ipv4_addr"`
+		Ipv6Addr     *string `json:"ipv6_addr"`
 	}
 
-	if o.Ipv4AddrType != nil {
+	if o.Ipv4AddrType != InterfaceNumberingIpv4TypeNone {
 		raw.Ipv4AddrType = toPtr(o.Ipv4AddrType.String())
 	}
 
-	if o.Ipv6AddrType != nil {
+	if o.Ipv6AddrType != InterfaceNumberingIpv6TypeNone {
 		raw.Ipv6AddrType = toPtr(o.Ipv6AddrType.String())
 	}
 
 	if o.Ipv4Addr != nil {
-		if len(o.Ipv4Addr.IP) > 0 && len(o.Ipv4Addr.Mask) > 0 {
-			raw.Ipv4Addr = toPtr(o.Ipv4Addr.String()) // send the string representation
-		} else {
-			raw.Ipv4Addr = toPtr("") // send an empty string to clear the value on the server
-		}
+		raw.Ipv4Addr = toPtr(o.Ipv4Addr.String()) // send the string representation
 	}
 
 	if o.Ipv6Addr != nil {
-		if len(o.Ipv6Addr.IP) > 0 && len(o.Ipv6Addr.Mask) > 0 {
-			raw.Ipv6Addr = toPtr(o.Ipv6Addr.String()) // send the string representation
-		} else {
-			raw.Ipv6Addr = toPtr("") // send an empty string to clear the value on the server
-		}
+		raw.Ipv6Addr = toPtr(o.Ipv6Addr.String()) // send the string representation
 	}
 
 	return json.Marshal(raw)
@@ -70,13 +62,11 @@ func (o *TwoStageL3ClosSubinterface) UnmarshalJSON(bytes []byte) error {
 		return err
 	}
 
-	o.Ipv4AddrType = new(InterfaceNumberingIpv4Type)
 	err = o.Ipv4AddrType.FromString(raw.Ipv4AddrType)
 	if err != nil {
 		return fmt.Errorf("failed parsing ipv4_addr_type %q while unmarshaling TwoStageL3ClosSubinterface", raw.Ipv4AddrType)
 	}
 
-	o.Ipv6AddrType = new(InterfaceNumberingIpv6Type)
 	err = o.Ipv6AddrType.FromString(raw.Ipv6AddrType)
 	if err != nil {
 		return fmt.Errorf("failed parsing ipv6_addr_type %q while unmarshaling TwoStageL3ClosSubinterface", raw.Ipv6AddrType)
@@ -101,6 +91,69 @@ func (o *TwoStageL3ClosSubinterface) UnmarshalJSON(bytes []byte) error {
 	}
 
 	return nil
+}
+
+func (o *TwoStageL3ClosClient) GetSubinterface(ctx context.Context, id ObjectId) (*TwoStageL3ClosSubinterface, error) {
+	var node struct {
+		Type     nodeType `json:"type"`
+		IfType   string   `json:"if_type"`
+		Ipv4Addr *string  `json:"ipv4_addr"`
+		Ipv4Type *string  `json:"ipv4_addr_type"`
+		Ipv6Addr *string  `json:"ipv6_addr"`
+		Ipv6Type *string  `json:"ipv6_addr_type"`
+	}
+
+	err := o.Client().GetNode(ctx, o.Id(), id, &node)
+	if err != nil {
+		return nil, err
+	}
+
+	if node.Type != nodeTypeInterface {
+		return nil, fmt.Errorf("node %q exists but has type %q - expected %q", id, nodeTypeInterface, node.Type)
+	}
+
+	if node.IfType != "subinterface" {
+		return nil, fmt.Errorf("interface node %q has enexpected if_type %q", id, node.IfType)
+	}
+
+	result := TwoStageL3ClosSubinterface{
+		Ipv4AddrType: InterfaceNumberingIpv4TypeNone,
+		Ipv6AddrType: InterfaceNumberingIpv6TypeNone,
+	}
+
+	if node.Ipv4Type != nil {
+		err = result.Ipv4AddrType.FromString(*node.Ipv4Type)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse node %q ipv4_addr_type value %q - %w", id, *node.Ipv4Type, err)
+		}
+	}
+
+	if node.Ipv6Type != nil {
+		err = result.Ipv6AddrType.FromString(*node.Ipv6Type)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse node %q ipv6_addr_type value %q - %w", id, *node.Ipv6Type, err)
+		}
+	}
+
+	if node.Ipv4Addr != nil {
+		var ip net.IP
+		ip, result.Ipv4Addr, err = net.ParseCIDR(*node.Ipv4Addr)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse node %q ipv4_addr value %q - %w", id, *node.Ipv4Addr, err)
+		}
+		result.Ipv4Addr.IP = ip
+	}
+
+	if node.Ipv6Addr != nil {
+		var ip net.IP
+		ip, result.Ipv6Addr, err = net.ParseCIDR(*node.Ipv6Addr)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse node %q ipv6_addr value %q - %w", id, *node.Ipv6Addr, err)
+		}
+		result.Ipv6Addr.IP = ip
+	}
+
+	return &result, nil
 }
 
 func (o *TwoStageL3ClosClient) UpdateSubinterfaces(ctx context.Context, in map[ObjectId]TwoStageL3ClosSubinterface) error {

--- a/apstra/two_stage_l3_clos_subinterface.go
+++ b/apstra/two_stage_l3_clos_subinterface.go
@@ -111,11 +111,11 @@ func (o *TwoStageL3ClosClient) GetSubinterface(ctx context.Context, id ObjectId)
 	}
 
 	if node.Type != nodeTypeInterface {
-		return nil, fmt.Errorf("node %q exists but has type %q - expected %q", id, nodeTypeInterface, node.Type)
+		return nil, fmt.Errorf("node %q exists but has type %q - expected %q", id, node.Type, nodeTypeInterface)
 	}
 
 	if node.IfType != "subinterface" {
-		return nil, fmt.Errorf("interface node %q has enexpected if_type %q", id, node.IfType)
+		return nil, fmt.Errorf("interface node %q has if_type %q - expected \"subinterface\"", id, node.IfType)
 	}
 
 	result := TwoStageL3ClosSubinterface{

--- a/apstra/two_stage_l3_clos_subinterface_integration_test.go
+++ b/apstra/two_stage_l3_clos_subinterface_integration_test.go
@@ -1,0 +1,181 @@
+//go:build integration
+// +build integration
+
+package apstra
+
+import (
+	"context"
+	"github.com/stretchr/testify/require"
+	"math/rand"
+	"net"
+	"testing"
+)
+
+func TestUpdateTwoStageL3ClosSubinterface(t *testing.T) {
+	ctx := context.Background()
+
+	clients, err := getTestClients(ctx, t)
+	require.NoError(t, err)
+
+	for _, client := range clients {
+		// create a blueprint and enable IPv6
+		bp := testBlueprintC(ctx, t, client.client)
+		settings, err := bp.GetFabricSettings(ctx)
+		require.NoError(t, err)
+		settings.Ipv6Enabled = toPtr(true)
+		require.NoError(t, bp.SetFabricSettings(ctx, settings))
+
+		// create a security zone within the blueprint
+		szName := randString(6, "hex")
+		szId, err := bp.CreateSecurityZone(ctx, &SecurityZoneData{
+			Label:   szName,
+			SzType:  SecurityZoneTypeEVPN,
+			VrfName: szName,
+			VniId:   toPtr(rand.Intn(1000) + 10000),
+		})
+		require.NoError(t, err)
+
+		// create a simple "ip link" connectivity template which uses the security zone
+		ct := ConnectivityTemplate{
+			Label: randString(6, "hex"),
+			Subpolicies: []*ConnectivityTemplatePrimitive{{
+				Label: "IP Link",
+				Attributes: &ConnectivityTemplatePrimitiveAttributesAttachLogicalLink{
+					Label:              "",
+					SecurityZone:       &szId,
+					IPv4AddressingType: CtPrimitiveIPv4AddressingTypeNone,
+					IPv6AddressingType: CtPrimitiveIPv6AddressingTypeLinkLocal,
+				},
+			}},
+		}
+		require.NoError(t, ct.SetIds())
+		require.NoError(t, ct.SetUserData())
+		require.NoError(t, bp.CreateConnectivityTemplate(ctx, &ct))
+
+		// prep a graph query which finds all server-facing switch interfaces
+		query := new(PathQuery).SetClient(client.client).SetBlueprintId(bp.Id()).
+			Node([]QEEAttribute{
+				NodeTypeSystem.QEEAttribute(),
+				{Key: "system_type", Value: QEStringVal(SystemTypeServer.String())},
+			}).
+			Out([]QEEAttribute{RelationshipTypeHostedInterfaces.QEEAttribute()}).
+			Node([]QEEAttribute{NodeTypeInterface.QEEAttribute()}).
+			Out([]QEEAttribute{RelationshipTypeLink.QEEAttribute()}).
+			Node([]QEEAttribute{
+				NodeTypeLink.QEEAttribute(),
+				{Key: "link_type", Value: QEStringVal("ethernet")},
+			}).
+			In([]QEEAttribute{RelationshipTypeLink.QEEAttribute()}).
+			Node([]QEEAttribute{
+				NodeTypeInterface.QEEAttribute(),
+				{Key: "name", Value: QEStringVal("n_interface")},
+			}).
+			In([]QEEAttribute{RelationshipTypeHostedInterfaces.QEEAttribute()}).
+			Node([]QEEAttribute{
+				NodeTypeSystem.QEEAttribute(),
+				{Key: "system_type", Value: QEStringVal(SystemTypeSwitch.String())},
+			})
+
+		// prep the response object and run the query
+		var response struct {
+			Items []struct {
+				Interface struct {
+					Id ObjectId `json:"id"`
+				} `json:"n_interface"`
+			} `json:"items"`
+		}
+		require.NoError(t, query.Do(ctx, &response))
+
+		// extract interface IDs from the query response
+		intfIds := make([]ObjectId, len(response.Items))
+		for i, item := range response.Items {
+			intfIds[i] = item.Interface.Id
+		}
+
+		// collect a CT application map for our switch port interfaces
+		apMap, err := bp.GetConnectivityTemplatesByApplicationPoints(ctx, intfIds)
+		require.NoError(t, err)
+		require.EqualValuesf(t, len(response.Items), len(apMap),
+			"found %d server-facing ports, but %d application points - these should match",
+			len(response.Items), len(apMap))
+
+		// "check the box" so that our CT will be assigned to all eligible application points
+		for k, v := range apMap {
+			if _, ok := v[*ct.Id]; !ok {
+				t.Fatalf("required CT ID %q not found in CT map for interface %q", *ct.Id, k)
+			}
+			apMap[k][*ct.Id] = true // indicates the CT should be attached to this port
+		}
+
+		// assign the CT to the application points
+		err = bp.SetApplicationPointsConnectivityTemplates(ctx, apMap)
+		require.NoError(t, err)
+
+		// fetch the links created by assigning CTs
+		links, err := bp.GetAllSubinterfaceLinks(ctx)
+		require.NoError(t, err)
+
+		// prep new addresses for those links (two endpoints per link)
+		var subinterfaceApiPayload []TwoStageL3ClosSubinterface                              // slice for use as Update() payload -- do not attempt to size!
+		expectedSubinterfaces := make(map[ObjectId]TwoStageL3ClosSubinterface, len(links)*2) // map for easy lookup later
+		for _, link := range links {
+			require.EqualValuesf(t, len(link.Endpoints), 2, "link should have two endpoints, got %d", len(link.Endpoints))
+
+			// pair of /31s for each link
+			v4prefixes := make([]net.IPNet, 2)
+			v4prefixes[0] = randomSlash31(t)
+			v4prefixes[1] = randomSlash31(t)
+			copy(v4prefixes[1].IP, v4prefixes[0].IP)
+			copy(v4prefixes[1].Mask, v4prefixes[0].Mask)
+			v4prefixes[1].IP[3]++
+
+			// pair of /127s for each link
+			v6prefixes := make([]net.IPNet, 2)
+			v6prefixes[0] = randomSlash127(t)
+			v6prefixes[1] = randomSlash127(t)
+			copy(v6prefixes[1].IP, v6prefixes[0].IP)
+			copy(v6prefixes[1].Mask, v6prefixes[0].Mask)
+			v6prefixes[1].IP[15]++
+
+			// prep an API payload for each end of the link
+			for i, endpoint := range link.Endpoints {
+				expectedSubinterfaces[endpoint.Subinterface.Id] = TwoStageL3ClosSubinterface{
+					Id:           endpoint.Subinterface.Id,
+					Ipv4AddrType: toPtr(InterfaceNumberingIpv4TypeNumbered),
+					Ipv6AddrType: toPtr(InterfaceNumberingIpv6TypeNumbered),
+					Ipv4Addr:     &v4prefixes[i],
+					Ipv6Addr:     &v6prefixes[i],
+				}
+				subinterfaceApiPayload = append(subinterfaceApiPayload, expectedSubinterfaces[endpoint.Subinterface.Id])
+			}
+		}
+
+		// update the link endpoints
+		require.NoError(t, bp.UpdateSubinterfaces(ctx, subinterfaceApiPayload))
+
+		// fetch the result
+		links, err = bp.GetAllSubinterfaceLinks(ctx)
+		require.NoError(t, err)
+
+		// validate tha the fetched result matches the values we sent
+		var totalEndpoints int
+		for _, link := range links {
+			for _, ep := range link.Endpoints {
+				totalEndpoints++
+
+				expectedSubinterface, ok := expectedSubinterfaces[ep.Subinterface.Id]
+				if !ok {
+					t.Fatalf("endpoint with subinterface ID %q was not expected", ep.Subinterface.Id)
+				}
+
+				require.EqualValues(t, *expectedSubinterface.Ipv4AddrType, *ep.Subinterface.Ipv4AddrType)
+				require.EqualValues(t, *expectedSubinterface.Ipv6AddrType, *ep.Subinterface.Ipv6AddrType)
+				require.EqualValues(t, expectedSubinterface.Ipv4Addr.String(), ep.Subinterface.Ipv4Addr.String())
+				require.EqualValues(t, expectedSubinterface.Ipv6Addr.String(), ep.Subinterface.Ipv6Addr.String())
+			}
+		}
+
+		// make sure we didn't miss anything or get any extras
+		require.EqualValues(t, len(subinterfaceApiPayload), totalEndpoints)
+	}
+}

--- a/apstra/two_stage_l3_clos_subinterface_integration_test.go
+++ b/apstra/two_stage_l3_clos_subinterface_integration_test.go
@@ -5,10 +5,11 @@ package apstra
 
 import (
 	"context"
-	"github.com/stretchr/testify/require"
 	"math/rand"
 	"net"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestUpdateTwoStageL3ClosSubinterface(t *testing.T) {

--- a/apstra/two_stage_l3_clos_subinterface_link.go
+++ b/apstra/two_stage_l3_clos_subinterface_link.go
@@ -78,7 +78,7 @@ func (o *TwoStageL3ClosSubinterfaceLink) UnmarshalJSON(bytes []byte) error {
 			return err
 		}
 
-		//o.Endpoints[i].Subinterface.Ipv4AddrType = new(I)
+		// o.Endpoints[i].Subinterface.Ipv4AddrType = new(I)
 		sysRole, err := rep.System.Role.parse()
 		if err != nil {
 			return fmt.Errorf("failed to parse system role %q while unmarshaling TwoStageL3ClosSubinterfaceLink - %w", rep.System.Role, err)

--- a/apstra/two_stage_l3_clos_subinterface_link.go
+++ b/apstra/two_stage_l3_clos_subinterface_link.go
@@ -1,0 +1,103 @@
+package apstra
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+const (
+	apiUrlWebExpSubinterfaces = apiUrlBlueprintByIdPrefix + "experience/web/subinterfaces"
+)
+
+var _ json.Unmarshaler = (*TwoStageL3ClosSubinterfaceLink)(nil)
+
+type TwoStageL3ClosSubinterfaceLinkEndpoint struct {
+	System struct {
+		Id    ObjectId
+		Label string
+		Role  SystemRole
+	}
+	InterfaceId  ObjectId
+	Subinterface TwoStageL3ClosSubinterface
+}
+
+type TwoStageL3ClosSubinterfaceLink struct {
+	Id        ObjectId // logical link ID
+	VlanId    *Vlan
+	Endpoints []TwoStageL3ClosSubinterfaceLinkEndpoint
+	SzId      ObjectId
+	SzLabel   string
+}
+
+func (o *TwoStageL3ClosSubinterfaceLink) UnmarshalJSON(bytes []byte) error {
+	var raw struct {
+		LinkId    ObjectId `json:"link_id"`
+		VlanId    *Vlan    `json:"vlan_id"`
+		Endpoints []struct {
+			System struct {
+				Id    ObjectId   `json:"id"`
+				Label string     `json:"label"`
+				Role  systemRole `json:"role"`
+			} `json:"system"`
+			Interface struct {
+				Id ObjectId `json:"id"`
+			} `json:"interface"`
+			Subinterface TwoStageL3ClosSubinterface `json:"subinterface"`
+		} `json:"endpoints"`
+		SzId    ObjectId `json:"sz_id"`
+		SzLabel string   `json:"sz_label"`
+	}
+
+	err := json.Unmarshal(bytes, &raw)
+	if err != nil {
+		return err
+	}
+
+	o.Id = raw.LinkId
+	o.VlanId = raw.VlanId
+	o.SzId = raw.SzId
+	o.SzLabel = raw.SzLabel
+	o.Endpoints = make([]TwoStageL3ClosSubinterfaceLinkEndpoint, len(raw.Endpoints))
+	for i, rep := range raw.Endpoints {
+		//o.Endpoints[i].Subinterface.Ipv4AddrType = new(I)
+		sysRole, err := rep.System.Role.parse()
+		if err != nil {
+			return fmt.Errorf("failed to parse system role %q while unmarshaling TwoStageL3ClosSubinterfaceLink - %w", rep.System.Role, err)
+		}
+
+		o.Endpoints[i] = TwoStageL3ClosSubinterfaceLinkEndpoint{
+			System: struct {
+				Id    ObjectId
+				Label string
+				Role  SystemRole
+			}{
+				Id:    rep.System.Id,
+				Label: rep.System.Label,
+				Role:  SystemRole(sysRole),
+			},
+			InterfaceId:  rep.Interface.Id,
+			Subinterface: rep.Subinterface,
+		}
+	}
+
+	return nil
+}
+
+func (o *TwoStageL3ClosClient) GetAllSubinterfaceLinks(ctx context.Context) ([]TwoStageL3ClosSubinterfaceLink, error) {
+	var response struct {
+		Links []TwoStageL3ClosSubinterfaceLink `json:"subinterfaces"`
+	}
+
+	err := o.client.talkToApstra(ctx, &talkToApstraIn{
+		method:      http.MethodGet,
+		urlStr:      fmt.Sprintf(apiUrlWebExpSubinterfaces, o.Id()),
+		apiResponse: &response,
+	})
+	if err != nil {
+		return nil, convertTtaeToAceWherePossible(err)
+	}
+
+	return response.Links, nil
+}

--- a/apstra/two_stage_l3_clos_subinterface_link.go
+++ b/apstra/two_stage_l3_clos_subinterface_link.go
@@ -103,6 +103,24 @@ func (o *TwoStageL3ClosSubinterfaceLink) UnmarshalJSON(bytes []byte) error {
 	return nil
 }
 
+func (o *TwoStageL3ClosClient) GetSubinterfaceLink(ctx context.Context, id ObjectId) (*TwoStageL3ClosSubinterfaceLink, error) {
+	all, err := o.GetAllSubinterfaceLinks(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, link := range all {
+		if link.Id == id {
+			return &link, nil
+		}
+	}
+
+	return nil, ClientErr{
+		errType: ErrNotfound,
+		err:     fmt.Errorf("link %q not found", id),
+	}
+}
+
 func (o *TwoStageL3ClosClient) GetAllSubinterfaceLinks(ctx context.Context) ([]TwoStageL3ClosSubinterfaceLink, error) {
 	var response struct {
 		Links []TwoStageL3ClosSubinterfaceLink `json:"subinterfaces"`

--- a/apstra/two_stage_l3_clos_switch_system_links_integration_test.go
+++ b/apstra/two_stage_l3_clos_switch_system_links_integration_test.go
@@ -313,8 +313,7 @@ func TestDeleteSwitchSystemLinks_WithCtAssigned(t *testing.T) {
 	for clientName, client := range clients {
 		// create a blueprint
 		log.Printf("creating test blueprint against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		bp, bpDelete := testBlueprintC(ctx, t, client.client)
-		t.Cleanup(func() { require.NoError(t, bpDelete(ctx)) })
+		bp := testBlueprintC(ctx, t, client.client)
 
 		// collect leaf switch IDs
 		log.Printf("determining leaf switch IDs in blueprint %q %s %s (%s)", bp.Id(), client.clientType, clientName, client.client.ApiVersion())

--- a/apstra/two_stage_l3_clos_system_node_info_integration_test.go
+++ b/apstra/two_stage_l3_clos_system_node_info_integration_test.go
@@ -157,6 +157,24 @@ func randomIpv6() net.IP {
 	}
 }
 
+func randomSlash31(t testing.TB) net.IPNet {
+	t.Helper()
+
+	ip := randomIpv4()
+	_, ipNet, err := net.ParseCIDR(ip.String() + "/31")
+	require.NoError(t, err)
+	return *ipNet
+}
+
+func randomSlash127(t testing.TB) net.IPNet {
+	t.Helper()
+
+	ip := randomIpv6()
+	_, ipNet, err := net.ParseCIDR(ip.String() + "/127")
+	require.NoError(t, err)
+	return *ipNet
+}
+
 func TestSetSystemLoopbackIpv4v6(t *testing.T) {
 	ctx := context.Background()
 	clients, err := getTestClients(ctx, t)

--- a/apstra/two_stage_l3_clos_virtual_networks_integration_test.go
+++ b/apstra/two_stage_l3_clos_virtual_networks_integration_test.go
@@ -192,13 +192,8 @@ func TestCreateUpdateDeleteVirtualNetwork(t *testing.T) {
 	vrfName := "test-" + randStr
 
 	for clientName, client := range clients {
-		bpClient, bpDel := testBlueprintC(ctx, t, client.client)
-		defer func() {
-			err := bpDel(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient := testBlueprintC(ctx, t, client.client)
+
 		bpClient.SetType(BlueprintTypeStaging)
 
 		log.Printf("testing CreateSecurityZone() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())


### PR DESCRIPTION
- update `testBlueprintC()` so that errors are surfaced via `t testing.TB` rather than `error`
- introduce new graph node relationship types related to ep policy nodes
- introduce new enums for numbered/link_local/none interface numbering types
- introduce structs and methods related to IP_Link logical links and subinterfaces