### PR TITLE
Convert Freeform Links test to use map of multi-step test cases

### DIFF
--- a/apstra/freeform_link_integration_test.go
+++ b/apstra/freeform_link_integration_test.go
@@ -5,6 +5,8 @@ package apstra
 
 import (
 	"context"
+	"math/rand"
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,25 +17,29 @@ func TestCRUDFFLink(t *testing.T) {
 	clients, err := getTestClients(ctx, t)
 	require.NoError(t, err)
 
-	compareEndPoint := func(t testing.TB, a, b *FreeformEndpoint) {
+	compareEndPoint := func(t testing.TB, req, resp *FreeformEndpoint) {
 		t.Helper()
 
-		require.Equal(t, a.SystemId, b.SystemId)
-		require.Equal(t, a.Interface.Data.IfName, b.Interface.Data.IfName)
-		require.Equal(t, a.Interface.Data.TransformationId, b.Interface.Data.TransformationId)
-		if a.Interface.Data.Ipv4Address != nil && b.Interface.Data.Ipv4Address != nil {
-			require.Equal(t, a.Interface.Data.Ipv4Address.String(), b.Interface.Data.Ipv4Address.String())
-		} else {
-			require.Nil(t, a.Interface.Data.Ipv4Address)
-			require.Nil(t, b.Interface.Data.Ipv4Address)
+		require.Equal(t, req.SystemId, resp.SystemId)
+		if req.Interface.Id != nil {
+			require.NotNil(t, resp.Interface)
+			require.Equal(t, *req.Interface.Id, *resp.Interface.Id)
 		}
-		if a.Interface.Data.Ipv6Address != nil && b.Interface.Data.Ipv6Address != nil {
-			require.Equal(t, a.Interface.Data.Ipv6Address.String(), b.Interface.Data.Ipv6Address.String())
+		require.Equal(t, req.Interface.Data.IfName, resp.Interface.Data.IfName)
+		require.Equal(t, req.Interface.Data.TransformationId, resp.Interface.Data.TransformationId)
+		if req.Interface.Data.Ipv4Address != nil && resp.Interface.Data.Ipv4Address != nil {
+			require.Equal(t, req.Interface.Data.Ipv4Address.String(), resp.Interface.Data.Ipv4Address.String())
 		} else {
-			require.Nil(t, a.Interface.Data.Ipv6Address)
-			require.Nil(t, b.Interface.Data.Ipv6Address)
+			require.Nil(t, req.Interface.Data.Ipv4Address)
+			require.Nil(t, resp.Interface.Data.Ipv4Address)
 		}
-		compareSlicesAsSets(t, a.Interface.Data.Tags, b.Interface.Data.Tags, "tag mismatch")
+		if req.Interface.Data.Ipv6Address != nil && resp.Interface.Data.Ipv6Address != nil {
+			require.Equal(t, req.Interface.Data.Ipv6Address.String(), resp.Interface.Data.Ipv6Address.String())
+		} else {
+			require.Nil(t, req.Interface.Data.Ipv6Address)
+			require.Nil(t, resp.Interface.Data.Ipv6Address)
+		}
+		compareSlicesAsSets(t, req.Interface.Data.Tags, resp.Interface.Data.Tags, "tag mismatch")
 	}
 
 	compare := func(t testing.TB, req *FreeformLinkRequest, resp *FreeformLinkData) {
@@ -52,84 +58,173 @@ func TestCRUDFFLink(t *testing.T) {
 		compareSlicesAsSets(t, req.Tags, resp.Tags, "tag mismatch")
 	}
 
+	type testCase struct {
+		steps []FreeformLinkRequest
+	}
+
 	for _, client := range clients {
 		ffc, sysIds := testFFBlueprintB(ctx, t, client.client, 2)
 
-		req := FreeformLinkRequest{
-			Label: randString(6, "hex"),
-			Tags:  []string{"a", "b"},
-			Endpoints: [2]FreeformEndpoint{
-				{
-					SystemId: sysIds[0],
-					Interface: FreeformInterface{
-						Id: nil,
-						Data: &FreeformInterfaceData{
-							IfName:           "ge-0/0/0",
-							TransformationId: 1,
-							Ipv4Address:      nil,
-							Ipv6Address:      nil,
-							Tags:             nil,
+		testCases := map[string]testCase{
+			"start_with_minimal_config": {
+				steps: []FreeformLinkRequest{
+					{
+						Label: randString(6, "hex"),
+						Endpoints: [2]FreeformEndpoint{
+							{SystemId: sysIds[0], Interface: FreeformInterface{Data: &FreeformInterfaceData{
+								IfName:           "ge-0/0/0",
+								TransformationId: 1,
+							}}},
+							{SystemId: sysIds[1], Interface: FreeformInterface{Data: &FreeformInterfaceData{
+								IfName:           "ge-0/0/0",
+								TransformationId: 1,
+							}}},
+						},
+					},
+					{
+						Label: randString(6, "hex"),
+						Tags:  randStrings(rand.Intn(3)+2, 6),
+						Endpoints: [2]FreeformEndpoint{
+							{SystemId: sysIds[0], Interface: FreeformInterface{Data: &FreeformInterfaceData{
+								IfName:           "ge-0/0/1",
+								TransformationId: 2,
+								Ipv4Address:      &net.IPNet{IP: net.ParseIP("10.0.0.3"), Mask: net.CIDRMask(24, 32)},
+								Ipv6Address:      &net.IPNet{IP: net.ParseIP("2001:db8::3"), Mask: net.CIDRMask(64, 128)},
+								Tags:             randStrings(rand.Intn(3)+2, 6),
+							}}},
+							{SystemId: sysIds[1], Interface: FreeformInterface{Data: &FreeformInterfaceData{
+								IfName:           "ge-0/0/1",
+								TransformationId: 2,
+								Ipv4Address:      &net.IPNet{IP: net.ParseIP("10.0.0.4"), Mask: net.CIDRMask(24, 32)},
+								Ipv6Address:      &net.IPNet{IP: net.ParseIP("2001:db8::4"), Mask: net.CIDRMask(64, 128)},
+								Tags:             randStrings(rand.Intn(3)+2, 6),
+							}}},
+						},
+					},
+					{
+						Label: randString(6, "hex"),
+						Endpoints: [2]FreeformEndpoint{
+							{SystemId: sysIds[0], Interface: FreeformInterface{Data: &FreeformInterfaceData{
+								IfName:           "ge-0/0/2",
+								TransformationId: 1,
+							}}},
+							{SystemId: sysIds[1], Interface: FreeformInterface{Data: &FreeformInterfaceData{
+								IfName:           "ge-0/0/2",
+								TransformationId: 1,
+							}}},
 						},
 					},
 				},
-				{
-					SystemId: sysIds[1],
-					Interface: FreeformInterface{
-						Id: nil,
-						Data: &FreeformInterfaceData{
-							IfName:           "ge-0/0/0",
-							TransformationId: 1,
-							Ipv4Address:      nil,
-							Ipv6Address:      nil,
-							Tags:             nil,
+			},
+			"start_with_maximal_config": {
+				steps: []FreeformLinkRequest{
+					{
+						Label: randString(6, "hex"),
+						Tags:  randStrings(rand.Intn(3)+2, 6),
+						Endpoints: [2]FreeformEndpoint{
+							{SystemId: sysIds[0], Interface: FreeformInterface{Data: &FreeformInterfaceData{
+								IfName:           "ge-0/0/3",
+								TransformationId: 2,
+								Ipv4Address:      &net.IPNet{IP: net.ParseIP("10.1.0.1"), Mask: net.CIDRMask(24, 32)},
+								Ipv6Address:      &net.IPNet{IP: net.ParseIP("2001:db8:1::1"), Mask: net.CIDRMask(64, 128)},
+								Tags:             randStrings(rand.Intn(3)+2, 6),
+							}}},
+							{SystemId: sysIds[1], Interface: FreeformInterface{Data: &FreeformInterfaceData{
+								IfName:           "ge-0/0/3",
+								TransformationId: 2,
+								Ipv4Address:      &net.IPNet{IP: net.ParseIP("10.1.0.2"), Mask: net.CIDRMask(24, 32)},
+								Ipv6Address:      &net.IPNet{IP: net.ParseIP("2001:db8:1::2"), Mask: net.CIDRMask(64, 128)},
+								Tags:             randStrings(rand.Intn(3)+2, 6),
+							}}},
+						},
+					},
+					{
+						Label: randString(6, "hex"),
+						Endpoints: [2]FreeformEndpoint{
+							{SystemId: sysIds[0], Interface: FreeformInterface{Data: &FreeformInterfaceData{
+								IfName:           "ge-0/0/4",
+								TransformationId: 1,
+							}}},
+							{SystemId: sysIds[1], Interface: FreeformInterface{Data: &FreeformInterfaceData{
+								IfName:           "ge-0/0/4",
+								TransformationId: 1,
+							}}},
+						},
+					},
+					{
+						Label: randString(6, "hex"),
+						Tags:  randStrings(rand.Intn(3)+2, 6),
+						Endpoints: [2]FreeformEndpoint{
+							{SystemId: sysIds[0], Interface: FreeformInterface{Data: &FreeformInterfaceData{
+								IfName:           "ge-0/0/5",
+								TransformationId: 2,
+								Ipv4Address:      &net.IPNet{IP: net.ParseIP("10.1.0.2"), Mask: net.CIDRMask(24, 32)},
+								Ipv6Address:      &net.IPNet{IP: net.ParseIP("2001:db8:1::2"), Mask: net.CIDRMask(64, 128)},
+								Tags:             randStrings(rand.Intn(3)+2, 6),
+							}}},
+							{SystemId: sysIds[1], Interface: FreeformInterface{Data: &FreeformInterfaceData{
+								IfName:           "ge-0/0/5",
+								TransformationId: 2,
+								Ipv4Address:      &net.IPNet{IP: net.ParseIP("10.1.0.3"), Mask: net.CIDRMask(24, 32)},
+								Ipv6Address:      &net.IPNet{IP: net.ParseIP("2001:db8:1::3"), Mask: net.CIDRMask(64, 128)},
+								Tags:             randStrings(rand.Intn(3)+2, 6),
+							}}},
 						},
 					},
 				},
 			},
 		}
 
-		// create the link
-		id, err := ffc.CreateLink(ctx, &req)
-		require.NoError(t, err)
+		for tName, tCase := range testCases {
+			tName, tCase := tName, tCase
 
-		// now lets read the link
-		readLink, err := ffc.GetLink(ctx, id)
-		require.NoError(t, err)
-		require.Equal(t, id, readLink.Id)
-		compare(t, &req, readLink.Data)
+			t.Run(tName, func(t *testing.T) {
+				t.Parallel()
 
-		// lets see if we can update the link
-		// first put the read link endpoint interface ID's into the req data structure.
-		req.Endpoints[0].Interface.Id = readLink.Data.Endpoints[0].Interface.Id
-		req.Endpoints[1].Interface.Id = readLink.Data.Endpoints[1].Interface.Id
-		// Now change the Label and the tags.
-		req.Label = randString(7, "hex")
-		req.Tags = []string{"a", "b", "c"}
-		// update the link.
-		err = ffc.UpdateLink(ctx, id, &req)
-		require.NoError(t, err)
-		// read the link back.
-		readLink, err = ffc.GetLink(ctx, id)
-		require.NoError(t, err)
-		require.Equal(t, id, readLink.Id)
-		compare(t, &req, readLink.Data)
+				// create the link
+				id, err := ffc.CreateLink(ctx, &tCase.steps[0])
+				require.NoError(t, err)
 
-		// delete the link
-		err = ffc.DeleteLink(ctx, id)
-		require.NoError(t, err)
+				// read the link
+				link, err := ffc.GetLink(ctx, id)
+				require.NoError(t, err)
+				require.Equal(t, id, link.Id)
+				compare(t, &tCase.steps[0], link.Data)
 
-		var ace ClientErr
+				// update the link once for each "step", including the first step (values used at creation)
+				for _, step := range tCase.steps {
+					// record the interface ID in the update request
+					step.Endpoints[0].Interface.Id = link.Data.Endpoints[0].Interface.Id
+					step.Endpoints[1].Interface.Id = link.Data.Endpoints[1].Interface.Id
 
-		// fetching a previously deleted link should fail
-		_, err = ffc.GetLink(ctx, id)
-		require.Error(t, err)
-		require.ErrorAs(t, err, &ace)
-		require.Equal(t, ErrNotfound, ace.Type())
+					// update the link
+					require.NoError(t, ffc.UpdateLink(ctx, id, &step))
 
-		// deleting a previously deleted link should fail
-		err = ffc.DeleteLink(ctx, id)
-		require.Error(t, err)
-		require.ErrorAs(t, err, &ace)
-		require.Equal(t, ErrNotfound, ace.Type())
+					// read the link
+					link, err = ffc.GetLink(ctx, id)
+					require.NoError(t, err)
+					require.Equal(t, id, link.Id)
+					compare(t, &step, link.Data)
+				}
+
+				// delete the link
+				err = ffc.DeleteLink(ctx, id)
+				require.NoError(t, err)
+
+				var ace ClientErr
+
+				// fetching a previously deleted link should fail
+				_, err = ffc.GetLink(ctx, id)
+				require.Error(t, err)
+				require.ErrorAs(t, err, &ace)
+				require.Equal(t, ErrNotfound, ace.Type())
+
+				// deleting a previously deleted link should fail
+				err = ffc.DeleteLink(ctx, id)
+				require.Error(t, err)
+				require.ErrorAs(t, err, &ace)
+				require.Equal(t, ErrNotfound, ace.Type())
+			})
+		}
 	}
 }

--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -42,6 +42,14 @@ func randString(n int, style string) string {
 	return string(b)
 }
 
+func randStrings(count, strLen int) []string {
+	result := make([]string, count)
+	for i := range result {
+		result[i] = randString(strLen, "hex")
+	}
+	return result
+}
+
 func randJwt() string {
 	return randString(36, "b64") + "." +
 		randString(178, "b64") + "." +


### PR DESCRIPTION
This PR introduces a little helper function for generating random tags, and pretty much replaces the `apstra/freeform_link_integration_test.go` file. Better to just read the file than try to parse the diff.