### PR TITLE
#323 Ensure that VN Multiple primitives always send a list of tagged VN IDs

### DIFF
--- a/.ci/scripts/gofumpt_check.sh
+++ b/.ci/scripts/gofumpt_check.sh
@@ -26,7 +26,7 @@ then
 
   for f in "${needs_update[@]}"
   do
-     echo "  go run mvdan.cc/gofumpt -w '$file'"
+     echo "  go run mvdan.cc/gofumpt -w '$f'"
   done
 
   echo ""

--- a/apstra/freeform_link.go
+++ b/apstra/freeform_link.go
@@ -174,8 +174,10 @@ func (o FreeformInterfaceData) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&raw)
 }
 
-var _ json.Unmarshaler = new(FreeformInterface)
-var _ json.Marshaler = new(FreeformInterface)
+var (
+	_ json.Unmarshaler = new(FreeformInterface)
+	_ json.Marshaler   = new(FreeformInterface)
+)
 
 type FreeformInterface struct {
 	Id   *ObjectId

--- a/apstra/two_stage_l3_clos_connectivity_template_primitive_attributes.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_primitive_attributes.go
@@ -93,6 +93,11 @@ func (o *ConnectivityTemplatePrimitiveAttributesAttachMultipleVlan) raw() (json.
 		TaggedVnNodeIds:  o.TaggedVnNodeIds,
 	}
 
+	// don't send `null` to the API. Send an empty array instead.
+	if raw.TaggedVnNodeIds == nil {
+		raw.TaggedVnNodeIds = []ObjectId{}
+	}
+
 	return json.Marshal(&raw)
 }
 


### PR DESCRIPTION
The API for VN Multiple primitives don't like when we omit the slice of VN IDs, nor when we send `null`.

This change ensures we send an empty list even when the caller supplies a `nil` slice.

Also snuck in here:
- a bug fix in the new format checking script: loop used wrong variable `file` rather than `f`
- formatting to an offending file which tripped up the format checking script

Closes #323