### PR TITLE
Replace old version constraint mechanism with new to facilitate apstra 5.0.0

### DIFF
--- a/apstra/api_blueprints_integration_test.go
+++ b/apstra/api_blueprints_integration_test.go
@@ -62,8 +62,8 @@ func TestCreateDeleteBlueprint(t *testing.T) {
 
 	for clientName, client := range clients {
 		var fabricSettings *FabricSettings
-		if rackBasedTemplateFabricAddressingPolicyForbidden().Includes(client.client.apiVersion.String()) {
-			// forbidden in the template means we can use this feature in the blueprint
+		if templateHasAddressingPolicy.Check(client.client.apiVersion) {
+			// not in the template means we can use this feature in the blueprint
 			fabricSettings = &FabricSettings{}
 
 			if !fabricL3MtuForbidden.Check(client.client.apiVersion) {

--- a/apstra/api_blueprints_integration_test.go
+++ b/apstra/api_blueprints_integration_test.go
@@ -726,7 +726,7 @@ func TestCreateDeleteBlueprintWithRoutingLimits(t *testing.T) {
 
 	type testCase struct {
 		name string
-		//versionConstraints   version.Constraints
+		// versionConstraints   version.Constraints
 		fabricSettings FabricSettings
 	}
 
@@ -766,7 +766,6 @@ func TestCreateDeleteBlueprintWithRoutingLimits(t *testing.T) {
 				tCase := tCase
 
 				t.Run(tCase.name, func(t *testing.T) {
-
 					bpr := blueprintRequest
 					bpr.FabricSettings = &tCase.fabricSettings
 					t.Logf("testing CreateBlueprintFromTemplate() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())

--- a/apstra/api_blueprints_integration_test.go
+++ b/apstra/api_blueprints_integration_test.go
@@ -62,8 +62,8 @@ func TestCreateDeleteBlueprint(t *testing.T) {
 
 	for clientName, client := range clients {
 		var fabricSettings *FabricSettings
-		if templateHasAddressingPolicy.Check(client.client.apiVersion) {
-			// not in the template means we can use this feature in the blueprint
+		if !legacyTemplateWithAddressingPolicy.Check(client.client.apiVersion) {
+			// current apstra releases put this feature in the blueprint, rather than the template
 			fabricSettings = &FabricSettings{}
 
 			if !fabricL3MtuForbidden.Check(client.client.apiVersion) {

--- a/apstra/api_design_templates.go
+++ b/apstra/api_design_templates.go
@@ -1432,7 +1432,7 @@ func (o *CreateRackBasedTemplateRequest) raw(ctx context.Context, client *Client
 	asnAllocationPolicy := o.AsnAllocationPolicy.raw()
 
 	var fabricAddressingPolicy *rawTemplateFabricAddressingPolicy410Only
-	if o.FabricAddressingPolicy != nil && templateHasAddressingPolicy.Check(client.apiVersion) {
+	if o.FabricAddressingPolicy != nil && legacyTemplateWithAddressingPolicy.Check(client.apiVersion) {
 		fabricAddressingPolicy = o.FabricAddressingPolicy.raw()
 	}
 
@@ -1552,7 +1552,7 @@ func (o *CreatePodBasedTemplateRequest) raw(ctx context.Context, client *Client)
 	}
 
 	var fabricAddressingPolicy *rawTemplateFabricAddressingPolicy410Only
-	if o.FabricAddressingPolicy != nil && templateHasAddressingPolicy.Check(client.apiVersion) {
+	if o.FabricAddressingPolicy != nil && legacyTemplateWithAddressingPolicy.Check(client.apiVersion) {
 		fabricAddressingPolicy = o.FabricAddressingPolicy.raw()
 	}
 

--- a/apstra/api_design_templates.go
+++ b/apstra/api_design_templates.go
@@ -1432,7 +1432,7 @@ func (o *CreateRackBasedTemplateRequest) raw(ctx context.Context, client *Client
 	asnAllocationPolicy := o.AsnAllocationPolicy.raw()
 
 	var fabricAddressingPolicy *rawTemplateFabricAddressingPolicy410Only
-	if o.FabricAddressingPolicy != nil && !rackBasedTemplateFabricAddressingPolicyForbidden().Includes(client.apiVersion.String()) {
+	if o.FabricAddressingPolicy != nil && templateHasAddressingPolicy.Check(client.apiVersion) {
 		fabricAddressingPolicy = o.FabricAddressingPolicy.raw()
 	}
 
@@ -1552,7 +1552,7 @@ func (o *CreatePodBasedTemplateRequest) raw(ctx context.Context, client *Client)
 	}
 
 	var fabricAddressingPolicy *rawTemplateFabricAddressingPolicy410Only
-	if o.FabricAddressingPolicy != nil && !podBasedTemplateFabricAddressingPolicyForbidden().Includes(client.apiVersion.String()) {
+	if o.FabricAddressingPolicy != nil && templateHasAddressingPolicy.Check(client.apiVersion) {
 		fabricAddressingPolicy = o.FabricAddressingPolicy.raw()
 	}
 

--- a/apstra/api_design_templates_test.go
+++ b/apstra/api_design_templates_test.go
@@ -1109,7 +1109,7 @@ func TestRackBasedTemplateMethods(t *testing.T) {
 			return fmt.Errorf("asn allocation policy spine asn scheme mismatch expected %q got %q", req.AsnAllocationPolicy.SpineAsnScheme, rbt.AsnAllocationPolicy.SpineAsnScheme)
 		}
 
-		if templateHasAddressingPolicy.Check(version.Must(version.NewVersion(apiVersionString))) {
+		if legacyTemplateWithAddressingPolicy.Check(version.Must(version.NewVersion(apiVersionString))) {
 			err = compareFabricAddressingPolicy(*req.FabricAddressingPolicy, *rbt.FabricAddressingPolicy)
 			if err != nil {
 				return err

--- a/apstra/api_design_templates_test.go
+++ b/apstra/api_design_templates_test.go
@@ -1109,7 +1109,7 @@ func TestRackBasedTemplateMethods(t *testing.T) {
 			return fmt.Errorf("asn allocation policy spine asn scheme mismatch expected %q got %q", req.AsnAllocationPolicy.SpineAsnScheme, rbt.AsnAllocationPolicy.SpineAsnScheme)
 		}
 
-		if !rackBasedTemplateFabricAddressingPolicyForbidden().Includes(apiVersionString) {
+		if templateHasAddressingPolicy.Check(version.Must(version.NewVersion(apiVersionString))) {
 			err = compareFabricAddressingPolicy(*req.FabricAddressingPolicy, *rbt.FabricAddressingPolicy)
 			if err != nil {
 				return err

--- a/apstra/compatibility.go
+++ b/apstra/compatibility.go
@@ -42,7 +42,7 @@ var (
 	fabricSettingsApiOk  = geApstra421
 	fabricL3MtuForbidden = leApstra412
 
-	templateHasAddressingPolicy = version.MustConstraints(version.NewConstraint("<" + apstra411))
+	legacyTemplateWithAddressingPolicy = version.MustConstraints(version.NewConstraint("<" + apstra411))
 )
 
 // SupportedApiVersions returns []string with each element representing an Apstra version number like "4.2.0"

--- a/apstra/compatibility.go
+++ b/apstra/compatibility.go
@@ -18,10 +18,6 @@ const (
 	apstraSupportedApiVersions = "4.2.0, 4.2.1, 4.2.1.1, 4.2.2"
 	apstraSupportedVersionSep  = ","
 
-	podBasedTemplateFabricAddressingPolicyForbiddenVersions = "4.1.1, 4.1.2, 4.2.0, 4.2.1, 4.2.1.1, 4.2.2"
-
-	rackBasedTemplateFabricAddressingPolicyForbiddenVersions = "4.1.1, 4.1.2, 4.2.0, 4.2.1, 4.2.1.1, 4.2.2"
-
 	fabricL3MtuForbiddenError = "fabric_l3_mtu permitted only with Apstra 4.2.0 and later"
 
 	integerPoolForbiddenVersions = "4.1.0, 4.1.1"
@@ -45,6 +41,8 @@ var (
 
 	fabricSettingsApiOk  = geApstra421
 	fabricL3MtuForbidden = leApstra412
+
+	templateHasAddressingPolicy = version.MustConstraints(version.NewConstraint("<" + apstra411))
 )
 
 // SupportedApiVersions returns []string with each element representing an Apstra version number like "4.2.0"
@@ -90,14 +88,6 @@ func (o StringSliceWithIncludes) Includes(s string) bool {
 
 func apstraSupportedApi() StringSliceWithIncludes {
 	return parseVersionList(apstraSupportedApiVersions)
-}
-
-func rackBasedTemplateFabricAddressingPolicyForbidden() StringSliceWithIncludes {
-	return parseVersionList(rackBasedTemplateFabricAddressingPolicyForbiddenVersions)
-}
-
-func podBasedTemplateFabricAddressingPolicyForbidden() StringSliceWithIncludes {
-	return parseVersionList(podBasedTemplateFabricAddressingPolicyForbiddenVersions)
 }
 
 func integerPoolForbidden() StringSliceWithIncludes {

--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -437,7 +437,7 @@ func testBlueprintH(ctx context.Context, t *testing.T, client *Client) (*TwoStag
 		TemplateId: "L2_Virtual_EVPN",
 	}
 
-	if !templateHasAddressingPolicy.Check(client.apiVersion) {
+	if !legacyTemplateWithAddressingPolicy.Check(client.apiVersion) {
 		bpRequest.FabricSettings = &FabricSettings{
 			SpineSuperspineLinks: toPtr(AddressingSchemeIp46),
 			SpineLeafLinks:       toPtr(AddressingSchemeIp46),
@@ -459,7 +459,7 @@ func testBlueprintH(ctx context.Context, t *testing.T, client *Client) (*TwoStag
 	}
 
 	// set fabric addressing to enable IPv6
-	if !templateHasAddressingPolicy.Check(client.apiVersion) {
+	if !legacyTemplateWithAddressingPolicy.Check(client.apiVersion) {
 		if client.apiVersion.String() == "4.2.1" {
 			// todo - this is temporary
 			err = client.talkToApstra(ctx, &talkToApstraIn{

--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -437,7 +437,7 @@ func testBlueprintH(ctx context.Context, t *testing.T, client *Client) (*TwoStag
 		TemplateId: "L2_Virtual_EVPN",
 	}
 
-	if rackBasedTemplateFabricAddressingPolicyForbidden().Includes(client.apiVersion.String()) {
+	if !templateHasAddressingPolicy.Check(client.apiVersion) {
 		bpRequest.FabricSettings = &FabricSettings{
 			SpineSuperspineLinks: toPtr(AddressingSchemeIp46),
 			SpineLeafLinks:       toPtr(AddressingSchemeIp46),
@@ -459,7 +459,7 @@ func testBlueprintH(ctx context.Context, t *testing.T, client *Client) (*TwoStag
 	}
 
 	// set fabric addressing to enable IPv6
-	if rackBasedTemplateFabricAddressingPolicyForbidden().Includes(client.apiVersion.String()) {
+	if !templateHasAddressingPolicy.Check(client.apiVersion) {
 		if client.apiVersion.String() == "4.2.1" {
 			// todo - this is temporary
 			err = client.talkToApstra(ctx, &talkToApstraIn{


### PR DESCRIPTION
The nil pointer dereference issue stemmed from the way version compatibility for the "addressing policy" feature of apstra templates was previously handled: We used to maintain a list of versions with a known behavior, requiring update with each new release. Now we use a version constraint: `<4.1.1` which should make forward compatibility easier in the future.

Eliminate:
- `podBasedTemplateFabricAddressingPolicyForbiddenVersions`
- `rackBasedTemplateFabricAddressingPolicyForbiddenVersions`

introduce: `templateHasAddressingPolicy`