### PR TITLE
Add special version handling for AI prereleases

### DIFF
--- a/apstra/api_version.go
+++ b/apstra/api_version.go
@@ -23,6 +23,7 @@ func (o *Client) getVersion(ctx context.Context) (*VersionResponse, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error parsing url '%s' - %w", apiUrlVersion, err)
 	}
+
 	response := &VersionResponse{}
 	return response, o.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodGet,

--- a/apstra/api_versions_test.go
+++ b/apstra/api_versions_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func TestGetVersionsServer(t *testing.T) {
+func TestGetVersionsAll(t *testing.T) {
 	clients, err := getTestClients(context.Background(), t)
 	if err != nil {
 		t.Fatal(err)

--- a/apstra/compatibility.go
+++ b/apstra/compatibility.go
@@ -14,6 +14,8 @@ const (
 	apstra421  = "4.2.1"
 	apstra4211 = "4.2.1.1"
 	apstra422  = "4.2.2"
+	apstra500  = "5.0.0"
+	apstra510  = "5.1.0"
 
 	apstraSupportedApiVersions = "4.2.0, 4.2.1, 4.2.1.1, 4.2.2"
 	apstraSupportedVersionSep  = ","


### PR DESCRIPTION
AI-enabled prereleases like `5.0.0a-6` claim to have API version `5.1.0`.

This PR introduces code which is suspicious of claims to be `5.1.0` and tries to detect AI-enabled prerelease versions of Apstra.

Closes #350