### PR TITLE
Disable IBA Dashboard functionality with Apstra >= 5.0.0

### DIFF
--- a/apstra/api_iba_dashboards_test.go
+++ b/apstra/api_iba_dashboards_test.go
@@ -5,127 +5,134 @@ package apstra
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"reflect"
 	"testing"
 )
 
 func TestCreateReadUpdateDeleteIbaDashboards(t *testing.T) {
-
-	clients, err := getTestClients(context.Background(), t)
+	ctx := context.Background()
+	clients, err := getTestClients(ctx, t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx := context.Background()
+
 	for clientName, client := range clients {
-		log.Printf("testing IBA Dashboard code against %s %s (%s)", client.clientType, clientName,
-			client.client.ApiVersion())
+		t.Run(fmt.Sprintf("%s_%s", clientName, client.client.apiVersion), func(*testing.T) {
+			if geApstra500.Check(client.client.apiVersion) {
+				t.Skipf("skipping test due to unsupported API changes in %s", client.client.apiVersion)
+			}
 
-		bpClient := testBlueprintA(ctx, t, client.client)
+			log.Printf("testing IBA Dashboard code against %s %s (%s)", client.clientType, clientName,
+				client.client.ApiVersion())
 
-		widgetAId, _, widgetBId, _ := testWidgetsAB(ctx, t, bpClient)
+			bpClient := testBlueprintA(ctx, t, client.client)
 
-		data := IbaDashboardData{
-			Description:   "Test Dashboard",
-			Default:       false,
-			Label:         "Test Dash",
-			IbaWidgetGrid: [][]ObjectId{{widgetAId, widgetBId}, {widgetAId, widgetBId}},
-		}
+			widgetAId, _, widgetBId, _ := testWidgetsAB(ctx, t, bpClient)
 
-		ds, err := bpClient.GetAllIbaDashboards(ctx)
-		l := len(ds)
-		if l != 0 {
-			t.Fatalf("Expected no dashboards. got %d", l)
-		}
+			data := IbaDashboardData{
+				Description:   "Test Dashboard",
+				Default:       false,
+				Label:         "Test Dash",
+				IbaWidgetGrid: [][]ObjectId{{widgetAId, widgetBId}, {widgetAId, widgetBId}},
+			}
 
-		t.Logf("Test Create Dashboard")
-		id, err := bpClient.CreateIbaDashboard(ctx, &data)
-		if err != nil {
-			t.Log(data)
-			t.Fatal(err)
-		}
+			ds, err := bpClient.GetAllIbaDashboards(ctx)
+			l := len(ds)
+			if l != 0 {
+				t.Fatalf("Expected no dashboards. got %d", l)
+			}
 
-		data2 := IbaDashboardData{
-			Description:   "Test Dashboard Backup",
-			Default:       false,
-			Label:         "Test Dash B",
-			IbaWidgetGrid: [][]ObjectId{{widgetAId, widgetBId}, {widgetAId, widgetBId}},
-		}
-
-		t.Logf("Test Create Second Dashboard")
-		_, err = bpClient.CreateIbaDashboard(ctx, &data2)
-		if err != nil {
-			t.Log(data)
-			t.Fatal(err)
-		}
-
-		ds, err = bpClient.GetAllIbaDashboards(ctx)
-		l = len(ds)
-		t.Logf("Found %d dashboards", l)
-		if l != 2 {
-			t.Fatalf("Expected 2 dashboards. got %d", l)
-		}
-
-		checkDashes := func() {
-			t.Log("Test GetIbaDashboard")
-			d1, err := bpClient.GetIbaDashboard(ctx, id)
+			t.Logf("Test Create Dashboard")
+			id, err := bpClient.CreateIbaDashboard(ctx, &data)
 			if err != nil {
-				t.Log(id)
+				t.Log(data)
 				t.Fatal(err)
 			}
-			t.Log("Test GetIbaDashboardByLabel")
-			d2, err := bpClient.GetIbaDashboardByLabel(ctx, data.Label)
+
+			data2 := IbaDashboardData{
+				Description:   "Test Dashboard Backup",
+				Default:       false,
+				Label:         "Test Dash B",
+				IbaWidgetGrid: [][]ObjectId{{widgetAId, widgetBId}, {widgetAId, widgetBId}},
+			}
+
+			t.Logf("Test Create Second Dashboard")
+			_, err = bpClient.CreateIbaDashboard(ctx, &data2)
 			if err != nil {
-				t.Log(data.Label)
+				t.Log(data)
 				t.Fatal(err)
 			}
-			t.Log("Dashboard Data")
-			t.Log(data)
-			t.Log("IBA Probe by Id")
-			t.Log(d1)
-			t.Log("IBA Dashboard by Name")
-			t.Log(d2)
 
-			if !reflect.DeepEqual(d1, d2) {
-				t.Fatal("GetIbaDashboardByLabel gets different object than GetIbaDashboard")
+			ds, err = bpClient.GetAllIbaDashboards(ctx)
+			l = len(ds)
+			t.Logf("Found %d dashboards", l)
+			if l != 2 {
+				t.Fatalf("Expected 2 dashboards. got %d", l)
 			}
-			t.Log("Ensure Data matches")
-			t.Log(d1.Data)
 
-			if d1.Data.Label != data.Label {
-				t.Fatal("IBA Dashboard Label mismatch")
-			}
-			if d1.Data.Default != data.Default {
-				t.Fatal("IBA Dasboard Default mismatch")
-			}
-			if d1.Data.Description != data.Description {
-				t.Fatal("IBA Dashboard Description mismatch")
-			}
-			if !reflect.DeepEqual(d1.Data.IbaWidgetGrid, data.IbaWidgetGrid) {
-				t.Fatal("Widget Grid mismatch")
-			}
-		}
-		checkDashes()
+			checkDashes := func() {
+				t.Log("Test GetIbaDashboard")
+				d1, err := bpClient.GetIbaDashboard(ctx, id)
+				if err != nil {
+					t.Log(id)
+					t.Fatal(err)
+				}
+				t.Log("Test GetIbaDashboardByLabel")
+				d2, err := bpClient.GetIbaDashboardByLabel(ctx, data.Label)
+				if err != nil {
+					t.Log(data.Label)
+					t.Fatal(err)
+				}
+				t.Log("Dashboard Data")
+				t.Log(data)
+				t.Log("IBA Probe by Id")
+				t.Log(d1)
+				t.Log("IBA Dashboard by Name")
+				t.Log(d2)
 
-		t.Log("Test Update Dashboard")
-		data.Label = "Test Dash 2"
-		data.IbaWidgetGrid = append(data.IbaWidgetGrid, []ObjectId{widgetAId, widgetBId})
-		data.Description = "Test Dashboard 2"
-		err = bpClient.UpdateIbaDashboard(ctx, id, &data)
-		if err != nil {
-			t.Log(data)
-			t.Fatal(err)
-		}
-		checkDashes()
+				if !reflect.DeepEqual(d1, d2) {
+					t.Fatal("GetIbaDashboardByLabel gets different object than GetIbaDashboard")
+				}
+				t.Log("Ensure Data matches")
+				t.Log(d1.Data)
 
-		t.Log("Test Delete Dashboard")
-		err = bpClient.DeleteIbaDashboard(ctx, id)
-		if err != nil {
-			t.Fatal(err)
-		}
-		_, err = bpClient.GetIbaDashboard(ctx, id)
-		if err == nil {
-			t.Fatalf("Deleted but id %s is still available", id)
-		}
+				if d1.Data.Label != data.Label {
+					t.Fatal("IBA Dashboard Label mismatch")
+				}
+				if d1.Data.Default != data.Default {
+					t.Fatal("IBA Dasboard Default mismatch")
+				}
+				if d1.Data.Description != data.Description {
+					t.Fatal("IBA Dashboard Description mismatch")
+				}
+				if !reflect.DeepEqual(d1.Data.IbaWidgetGrid, data.IbaWidgetGrid) {
+					t.Fatal("Widget Grid mismatch")
+				}
+			}
+			checkDashes()
+
+			t.Log("Test Update Dashboard")
+			data.Label = "Test Dash 2"
+			data.IbaWidgetGrid = append(data.IbaWidgetGrid, []ObjectId{widgetAId, widgetBId})
+			data.Description = "Test Dashboard 2"
+			err = bpClient.UpdateIbaDashboard(ctx, id, &data)
+			if err != nil {
+				t.Log(data)
+				t.Fatal(err)
+			}
+			checkDashes()
+
+			t.Log("Test Delete Dashboard")
+			err = bpClient.DeleteIbaDashboard(ctx, id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = bpClient.GetIbaDashboard(ctx, id)
+			if err == nil {
+				t.Fatalf("Deleted but id %s is still available", id)
+			}
+		})
 	}
 }

--- a/apstra/compatibility.go
+++ b/apstra/compatibility.go
@@ -14,6 +14,7 @@ const (
 	apstra421  = "4.2.1"
 	apstra4211 = "4.2.1.1"
 	apstra422  = "4.2.2"
+	apstra500  = "5.0.0"
 
 	apstraSupportedApiVersions = "4.2.0, 4.2.1, 4.2.1.1, 4.2.2"
 	apstraSupportedVersionSep  = ","
@@ -36,6 +37,7 @@ var (
 	geApstra411 = version.MustConstraints(version.NewConstraint(">=" + apstra411))
 	geApstra420 = version.MustConstraints(version.NewConstraint(">=" + apstra420))
 	geApstra421 = version.MustConstraints(version.NewConstraint(">=" + apstra421))
+	geApstra500 = version.MustConstraints(version.NewConstraint(">=" + apstra500))
 	leApstra412 = version.MustConstraints(version.NewConstraint("<=" + apstra412))
 	leApstra420 = version.MustConstraints(version.NewConstraint("<=" + apstra420))
 

--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -671,9 +671,7 @@ func testWidgetsAB(ctx context.Context, t *testing.T, bpClient *TwoStageL3ClosCl
 			"Threshold": 40
 		}`),
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	probeBId, err := bpClient.InstantiateIbaPredefinedProbe(ctx, &IbaPredefinedProbeRequest{
 		Name: "drain_node_traffic_anomaly",
@@ -682,9 +680,7 @@ func testWidgetsAB(ctx context.Context, t *testing.T, bpClient *TwoStageL3ClosCl
 			"Threshold": 100000
 		}`),
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	widgetA := IbaWidgetData{
 		Type:      enum.IbaWidgetTypeStage,
@@ -693,9 +689,7 @@ func testWidgetsAB(ctx context.Context, t *testing.T, bpClient *TwoStageL3ClosCl
 		StageName: "BGP Session",
 	}
 	widgetAId, err := bpClient.CreateIbaWidget(ctx, &widgetA)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	widgetB := IbaWidgetData{
 		Type:      enum.IbaWidgetTypeStage,
@@ -704,9 +698,7 @@ func testWidgetsAB(ctx context.Context, t *testing.T, bpClient *TwoStageL3ClosCl
 		StageName: "excess_range",
 	}
 	widgetBId, err := bpClient.CreateIbaWidget(ctx, &widgetB)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	return widgetAId, widgetA, widgetBId, widgetB
 }

--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -662,6 +662,7 @@ func testBlueprintG(ctx context.Context, t *testing.T, client *Client) *TwoStage
 // testWidgetsAB instantiates two predefined probes and creates widgets from them,
 // returning the widget Object Id and the IbaWidgetData object used for creation
 func testWidgetsAB(ctx context.Context, t *testing.T, bpClient *TwoStageL3ClosClient) (ObjectId, IbaWidgetData, ObjectId, IbaWidgetData) {
+	t.Helper()
 	probeAId, err := bpClient.InstantiateIbaPredefinedProbe(ctx, &IbaPredefinedProbeRequest{
 		Name: "bgp_session",
 		Data: []byte(`{

--- a/apstra/two_stage_l3_clos_client.go
+++ b/apstra/two_stage_l3_clos_client.go
@@ -823,6 +823,10 @@ func (o *TwoStageL3ClosClient) CreateIbaProbeFromJson(ctx context.Context, probe
 
 // GetAllIbaDashboards returns a list of IBA Dashboards in the blueprint
 func (o *TwoStageL3ClosClient) GetAllIbaDashboards(ctx context.Context) ([]IbaDashboard, error) {
+	if geApstra500.Check(o.client.apiVersion) {
+		return nil, fmt.Errorf("IBA Dashboard not supported with Asptra %s", o.client.apiVersion)
+	}
+
 	rawDashes, err := o.client.getAllIbaDashboards(ctx, o.blueprintId)
 	if err != nil {
 		return nil, err
@@ -842,6 +846,10 @@ func (o *TwoStageL3ClosClient) GetAllIbaDashboards(ctx context.Context) ([]IbaDa
 
 // GetIbaDashboard returns the IBA Dashboard that matches the ID
 func (o *TwoStageL3ClosClient) GetIbaDashboard(ctx context.Context, id ObjectId) (*IbaDashboard, error) {
+	if geApstra500.Check(o.client.apiVersion) {
+		return nil, fmt.Errorf("IBA Dashboard not supported with Asptra %s", o.client.apiVersion)
+	}
+
 	rawIbaDb, err := o.client.getIbaDashboard(ctx, o.blueprintId, id)
 	if err != nil {
 		return nil, err
@@ -853,6 +861,10 @@ func (o *TwoStageL3ClosClient) GetIbaDashboard(ctx context.Context, id ObjectId)
 // GetIbaDashboardByLabel returns the IBA Dashboard that matches the label.
 // It will return an error if more than one IBA dashboard matches the label.
 func (o *TwoStageL3ClosClient) GetIbaDashboardByLabel(ctx context.Context, label string) (*IbaDashboard, error) {
+	if geApstra500.Check(o.client.apiVersion) {
+		return nil, fmt.Errorf("IBA Dashboard not supported with Asptra %s", o.client.apiVersion)
+	}
+
 	rawIbaDb, err := o.client.getIbaDashboardByLabel(ctx, o.blueprintId, label)
 	if err != nil {
 		return nil, err
@@ -864,6 +876,10 @@ func (o *TwoStageL3ClosClient) GetIbaDashboardByLabel(ctx context.Context, label
 // CreateIbaDashboard creates an IBA Dashboard and returns the id of the created dashboard on success,
 // or a blank and error on failure
 func (o *TwoStageL3ClosClient) CreateIbaDashboard(ctx context.Context, data *IbaDashboardData) (ObjectId, error) {
+	if geApstra500.Check(o.client.apiVersion) {
+		return "", fmt.Errorf("IBA Dashboard not supported with Asptra %s", o.client.apiVersion)
+	}
+
 	id, err := o.client.createIbaDashboard(ctx, o.blueprintId, data.raw())
 	if err != nil {
 		return "", err
@@ -874,11 +890,19 @@ func (o *TwoStageL3ClosClient) CreateIbaDashboard(ctx context.Context, data *Iba
 
 // UpdateIbaDashboard updates an IBA Dashboard and returns an error on failure
 func (o *TwoStageL3ClosClient) UpdateIbaDashboard(ctx context.Context, id ObjectId, data *IbaDashboardData) error {
+	if geApstra500.Check(o.client.apiVersion) {
+		return fmt.Errorf("IBA Dashboard not supported with Asptra %s", o.client.apiVersion)
+	}
+
 	return o.client.updateIbaDashboard(ctx, o.blueprintId, id, data.raw())
 }
 
 // DeleteIbaDashboard deletes an IBA Dashboard and returns an error on failure
 func (o *TwoStageL3ClosClient) DeleteIbaDashboard(ctx context.Context, id ObjectId) error {
+	if geApstra500.Check(o.client.apiVersion) {
+		return fmt.Errorf("IBA Dashboard not supported with Asptra %s", o.client.apiVersion)
+	}
+
 	return o.client.deleteIbaDashboard(ctx, o.blueprintId, id)
 }
 


### PR DESCRIPTION
A bunch of analytics stuff is failing with Apstra 5.0.0.

We're starting by disabling stuff so that tests pass and it's clear to callers that catch-up work is required.

Tests skip 5.0.0.

TwoStageL3ClosClient methods refuse to run against 5.0.0