### PR TITLE
Use `Core()` to drop pre-release label when comparing version

### DIFF
--- a/apstra/api_blueprints_integration_test.go
+++ b/apstra/api_blueprints_integration_test.go
@@ -171,7 +171,7 @@ func TestGetPatchGetPatchNode(t *testing.T) {
 				req := metadataNode{Label: newName}
 				resp := &metadataNode{}
 				log.Printf("testing patchNode(%s) against %s %s (%s)", bpClient.Id(), client.clientType, clientName, client.client.ApiVersion())
-				if patchNodeSupportsUnsafeArg.Check(client.client.apiVersion) {
+				if patchNodeSupportsUnsafeArg.Check(client.client.apiVersion.Core()) {
 					var ace ClientErr
 					err = bpClient.PatchNode(ctx, nodeA.Id, req, resp)
 					require.Error(t, err)

--- a/apstra/compatibility.go
+++ b/apstra/compatibility.go
@@ -47,7 +47,7 @@ var (
 
 	legacyTemplateWithAddressingPolicy = version.MustConstraints(version.NewConstraint("<" + apstra411))
 
-	patchNodeSupportsUnsafeArg = version.MustConstraints(version.NewConstraint(">=" + apstra500))
+	patchNodeSupportsUnsafeArg = geApstra500
 )
 
 // SupportedApiVersions returns []string with each element representing an Apstra version number like "4.2.0"


### PR DESCRIPTION
Closes #356