### PR TITLE
Remove support for Apstra 4.1.x

### DIFF
--- a/apstra/api_design_templates.go
+++ b/apstra/api_design_templates.go
@@ -499,40 +499,6 @@ func (o *rawAsnAllocationPolicy) polish() (*AsnAllocationPolicy, error) {
 	return &AsnAllocationPolicy{SpineAsnScheme: AsnAllocationScheme(sas)}, err
 }
 
-type TemplateFabricAddressingPolicy410Only struct {
-	SpineSuperspineLinks AddressingScheme
-	SpineLeafLinks       AddressingScheme
-}
-
-func (o *TemplateFabricAddressingPolicy410Only) raw() *rawTemplateFabricAddressingPolicy410Only {
-	return &rawTemplateFabricAddressingPolicy410Only{
-		SpineSuperspineLinks: o.SpineSuperspineLinks.raw(),
-		SpineLeafLinks:       o.SpineLeafLinks.raw(),
-	}
-}
-
-type rawTemplateFabricAddressingPolicy410Only struct {
-	SpineSuperspineLinks addressingScheme `json:"spine_superspine_links"`
-	SpineLeafLinks       addressingScheme `json:"spine_leaf_links"`
-}
-
-func (o *rawTemplateFabricAddressingPolicy410Only) polish() (*TemplateFabricAddressingPolicy410Only, error) {
-	ssl, err := o.SpineSuperspineLinks.parse()
-	if err != nil {
-		return nil, err
-	}
-
-	sll, err := o.SpineLeafLinks.parse()
-	if err != nil {
-		return nil, err
-	}
-
-	return &TemplateFabricAddressingPolicy410Only{
-		SpineSuperspineLinks: AddressingScheme(ssl),
-		SpineLeafLinks:       AddressingScheme(sll),
-	}, nil
-}
-
 type RackTypeCount struct {
 	RackTypeId ObjectId `json:"rack_type_id"`
 	Count      int      `json:"count"`
@@ -752,15 +718,14 @@ func (o *TemplateRackBased) OverlayControlProtocol() OverlayControlProtocol {
 }
 
 type TemplateRackBasedData struct {
-	DisplayName            string
-	AntiAffinityPolicy     *AntiAffinityPolicy
-	VirtualNetworkPolicy   VirtualNetworkPolicy
-	AsnAllocationPolicy    AsnAllocationPolicy
-	FabricAddressingPolicy *TemplateFabricAddressingPolicy410Only // Apstra 4.1.0 only
-	Capability             TemplateCapability
-	Spine                  Spine
-	RackInfo               map[ObjectId]TemplateRackBasedRackInfo
-	DhcpServiceIntent      DhcpServiceIntent
+	DisplayName          string
+	AntiAffinityPolicy   *AntiAffinityPolicy
+	VirtualNetworkPolicy VirtualNetworkPolicy
+	AsnAllocationPolicy  AsnAllocationPolicy
+	Capability           TemplateCapability
+	Spine                Spine
+	RackInfo             map[ObjectId]TemplateRackBasedRackInfo
+	DhcpServiceIntent    DhcpServiceIntent
 }
 
 type TemplateRackBasedRackInfo struct {
@@ -773,20 +738,19 @@ type DhcpServiceIntent struct {
 }
 
 type rawTemplateRackBased struct {
-	Id                     ObjectId                                  `json:"id"`
-	Type                   templateType                              `json:"type"`
-	DisplayName            string                                    `json:"display_name"`
-	AntiAffinityPolicy     *rawAntiAffinityPolicy                    `json:"anti_affinity_policy,omitempty"`
-	CreatedAt              time.Time                                 `json:"created_at"`
-	LastModifiedAt         time.Time                                 `json:"last_modified_at"`
-	VirtualNetworkPolicy   rawVirtualNetworkPolicy                   `json:"virtual_network_policy"`
-	AsnAllocationPolicy    rawAsnAllocationPolicy                    `json:"asn_allocation_policy"`
-	FabricAddressingPolicy *rawTemplateFabricAddressingPolicy410Only `json:"fabric_addressing_policy,omitempty"` // Apstra 4.1.0 only
-	Capability             templateCapability                        `json:"capability,omitempty"`
-	Spine                  rawSpine                                  `json:"spine"`
-	RackTypes              []rawRackType                             `json:"rack_types"`
-	RackTypeCounts         []RackTypeCount                           `json:"rack_type_counts"`
-	DhcpServiceIntent      DhcpServiceIntent                         `json:"dhcp_service_intent"`
+	Id                   ObjectId                `json:"id"`
+	Type                 templateType            `json:"type"`
+	DisplayName          string                  `json:"display_name"`
+	AntiAffinityPolicy   *rawAntiAffinityPolicy  `json:"anti_affinity_policy,omitempty"`
+	CreatedAt            time.Time               `json:"created_at"`
+	LastModifiedAt       time.Time               `json:"last_modified_at"`
+	VirtualNetworkPolicy rawVirtualNetworkPolicy `json:"virtual_network_policy"`
+	AsnAllocationPolicy  rawAsnAllocationPolicy  `json:"asn_allocation_policy"`
+	Capability           templateCapability      `json:"capability,omitempty"`
+	Spine                rawSpine                `json:"spine"`
+	RackTypes            []rawRackType           `json:"rack_types"`
+	RackTypeCounts       []RackTypeCount         `json:"rack_type_counts"`
+	DhcpServiceIntent    DhcpServiceIntent       `json:"dhcp_service_intent"`
 }
 
 func (o rawTemplateRackBased) polish() (*TemplateRackBased, error) {
@@ -801,13 +765,6 @@ func (o rawTemplateRackBased) polish() (*TemplateRackBased, error) {
 	a, err := o.AsnAllocationPolicy.polish()
 	if err != nil {
 		return nil, err
-	}
-	var f *TemplateFabricAddressingPolicy410Only
-	if o.FabricAddressingPolicy != nil {
-		f, err = o.FabricAddressingPolicy.polish()
-		if err != nil {
-			return nil, err
-		}
 	}
 	c, err := o.Capability.parse()
 	if err != nil {
@@ -855,15 +812,14 @@ OUTER:
 		CreatedAt:      o.CreatedAt,
 		LastModifiedAt: o.LastModifiedAt,
 		Data: &TemplateRackBasedData{
-			DisplayName:            o.DisplayName,
-			AntiAffinityPolicy:     aap,
-			VirtualNetworkPolicy:   *v,
-			AsnAllocationPolicy:    *a,
-			FabricAddressingPolicy: f,
-			Capability:             TemplateCapability(c),
-			Spine:                  *s,
-			RackInfo:               rackTypeInfos,
-			DhcpServiceIntent:      o.DhcpServiceIntent,
+			DisplayName:          o.DisplayName,
+			AntiAffinityPolicy:   aap,
+			VirtualNetworkPolicy: *v,
+			AsnAllocationPolicy:  *a,
+			Capability:           TemplateCapability(c),
+			Spine:                *s,
+			RackInfo:             rackTypeInfos,
+			DhcpServiceIntent:    o.DhcpServiceIntent,
 		},
 	}, nil
 }
@@ -902,12 +858,11 @@ func (o *TemplatePodBased) OverlayControlProtocol() OverlayControlProtocol {
 }
 
 type TemplatePodBasedData struct {
-	DisplayName            string
-	AntiAffinityPolicy     *AntiAffinityPolicy
-	FabricAddressingPolicy *TemplateFabricAddressingPolicy410Only // Apstra 4.1.0 only
-	Superspine             Superspine
-	Capability             TemplateCapability
-	PodInfo                map[ObjectId]TemplatePodBasedInfo
+	DisplayName        string
+	AntiAffinityPolicy *AntiAffinityPolicy
+	Superspine         Superspine
+	Capability         TemplateCapability
+	PodInfo            map[ObjectId]TemplatePodBasedInfo
 }
 
 type TemplatePodBasedInfo struct {
@@ -916,28 +871,19 @@ type TemplatePodBasedInfo struct {
 }
 
 type rawTemplatePodBased struct {
-	Id                      ObjectId                                  `json:"id"`
-	Type                    templateType                              `json:"type"`
-	DisplayName             string                                    `json:"display_name"`
-	AntiAffinityPolicy      *rawAntiAffinityPolicy                    `json:"anti_affinity_policy,omitempty"`
-	FabricAddressingPolicy  *rawTemplateFabricAddressingPolicy410Only `json:"fabric_addressing_policy,omitempty"` // Apstra 4.1.0 only
-	Superspine              rawSuperspine                             `json:"superspine"`
-	CreatedAt               time.Time                                 `json:"created_at"`
-	LastModifiedAt          time.Time                                 `json:"last_modified_at"`
-	Capability              templateCapability                        `json:"capability,omitempty"`
-	RackBasedTemplates      []rawTemplateRackBased                    `json:"rack_based_templates"`
-	RackBasedTemplateCounts []RackBasedTemplateCount                  `json:"rack_based_template_counts"`
+	Id                      ObjectId                 `json:"id"`
+	Type                    templateType             `json:"type"`
+	DisplayName             string                   `json:"display_name"`
+	AntiAffinityPolicy      *rawAntiAffinityPolicy   `json:"anti_affinity_policy,omitempty"`
+	Superspine              rawSuperspine            `json:"superspine"`
+	CreatedAt               time.Time                `json:"created_at"`
+	LastModifiedAt          time.Time                `json:"last_modified_at"`
+	Capability              templateCapability       `json:"capability,omitempty"`
+	RackBasedTemplates      []rawTemplateRackBased   `json:"rack_based_templates"`
+	RackBasedTemplateCounts []RackBasedTemplateCount `json:"rack_based_template_counts"`
 }
 
 func (o rawTemplatePodBased) polish() (*TemplatePodBased, error) {
-	var err error
-	var fap *TemplateFabricAddressingPolicy410Only
-	if o.FabricAddressingPolicy != nil {
-		fap, err = o.FabricAddressingPolicy.polish()
-		if err != nil {
-			return nil, err
-		}
-	}
 	superspine, err := o.Superspine.polish()
 	if err != nil {
 		return nil, err
@@ -1000,12 +946,11 @@ OUTER:
 		CreatedAt:      o.CreatedAt,
 		LastModifiedAt: o.LastModifiedAt,
 		Data: &TemplatePodBasedData{
-			DisplayName:            o.DisplayName,
-			AntiAffinityPolicy:     aap,
-			FabricAddressingPolicy: fap,
-			Superspine:             *superspine,
-			Capability:             TemplateCapability(capability),
-			PodInfo:                podTypeInfos,
+			DisplayName:        o.DisplayName,
+			AntiAffinityPolicy: aap,
+			Superspine:         *superspine,
+			Capability:         TemplateCapability(capability),
+			PodInfo:            podTypeInfos,
 		},
 	}, nil
 }
@@ -1369,14 +1314,13 @@ func (o *Client) getAllL3CollapsedTemplates(ctx context.Context) ([]rawTemplateL
 }
 
 type CreateRackBasedTemplateRequest struct {
-	DisplayName            string
-	Spine                  *TemplateElementSpineRequest
-	RackInfos              map[ObjectId]TemplateRackBasedRackInfo
-	DhcpServiceIntent      *DhcpServiceIntent
-	AntiAffinityPolicy     *AntiAffinityPolicy
-	AsnAllocationPolicy    *AsnAllocationPolicy
-	FabricAddressingPolicy *TemplateFabricAddressingPolicy410Only // Apstra 4.1.0 only
-	VirtualNetworkPolicy   *VirtualNetworkPolicy
+	DisplayName          string
+	Spine                *TemplateElementSpineRequest
+	RackInfos            map[ObjectId]TemplateRackBasedRackInfo
+	DhcpServiceIntent    *DhcpServiceIntent
+	AntiAffinityPolicy   *AntiAffinityPolicy
+	AsnAllocationPolicy  *AsnAllocationPolicy
+	VirtualNetworkPolicy *VirtualNetworkPolicy
 }
 
 func (o *CreateRackBasedTemplateRequest) raw(ctx context.Context, client *Client) (*rawCreateRackBasedTemplateRequest, error) {
@@ -1405,8 +1349,8 @@ func (o *CreateRackBasedTemplateRequest) raw(ctx context.Context, client *Client
 	switch {
 	case o.Spine == nil:
 		return nil, errors.New("spine cannot be <nil> when creating a rack-based template")
-	case o.AntiAffinityPolicy == nil && leApstra420.Check(client.apiVersion):
-		return nil, fmt.Errorf("anti-affinity policy cannot be <nil> when creating a rack-based template with Apstra %s", leApstra420)
+	case o.AntiAffinityPolicy == nil && templateRequestRequiresAntiAffinityPolicy.Check(client.apiVersion):
+		return nil, fmt.Errorf("anti-affinity policy cannot be <nil> when creating a rack-based template with Apstra %s", templateRequestRequiresAntiAffinityPolicy)
 	case o.AsnAllocationPolicy == nil:
 		return nil, errors.New("asn allocation policy cannot be <nil> when creating a rack-based template")
 	case o.VirtualNetworkPolicy == nil:
@@ -1431,38 +1375,31 @@ func (o *CreateRackBasedTemplateRequest) raw(ctx context.Context, client *Client
 
 	asnAllocationPolicy := o.AsnAllocationPolicy.raw()
 
-	var fabricAddressingPolicy *rawTemplateFabricAddressingPolicy410Only
-	if o.FabricAddressingPolicy != nil && legacyTemplateWithAddressingPolicy.Check(client.apiVersion) {
-		fabricAddressingPolicy = o.FabricAddressingPolicy.raw()
-	}
-
 	virtualNetworkPolicy := o.VirtualNetworkPolicy.raw()
 
 	return &rawCreateRackBasedTemplateRequest{
-		Type:                   templateTypeRackBased,
-		DisplayName:            o.DisplayName,
-		Spine:                  *spine,
-		RackTypes:              rackTypes,
-		RackTypeCounts:         rackTypeCounts,
-		DhcpServiceIntent:      dhcpServiceIntent,
-		AntiAffinityPolicy:     antiAffinityPolicy,
-		AsnAllocationPolicy:    *asnAllocationPolicy,
-		FabricAddressingPolicy: fabricAddressingPolicy,
-		VirtualNetworkPolicy:   *virtualNetworkPolicy,
+		Type:                 templateTypeRackBased,
+		DisplayName:          o.DisplayName,
+		Spine:                *spine,
+		RackTypes:            rackTypes,
+		RackTypeCounts:       rackTypeCounts,
+		DhcpServiceIntent:    dhcpServiceIntent,
+		AntiAffinityPolicy:   antiAffinityPolicy,
+		AsnAllocationPolicy:  *asnAllocationPolicy,
+		VirtualNetworkPolicy: *virtualNetworkPolicy,
 	}, nil
 }
 
 type rawCreateRackBasedTemplateRequest struct {
-	Type                   templateType                              `json:"type"`
-	DisplayName            string                                    `json:"display_name"`
-	Spine                  rawSpine                                  `json:"spine"`
-	RackTypes              []rawRackType                             `json:"rack_types"`
-	RackTypeCounts         []RackTypeCount                           `json:"rack_type_counts"`
-	DhcpServiceIntent      DhcpServiceIntent                         `json:"dhcp_service_intent"`
-	AntiAffinityPolicy     *rawAntiAffinityPolicy                    `json:"anti_affinity_policy,omitempty"`
-	AsnAllocationPolicy    rawAsnAllocationPolicy                    `json:"asn_allocation_policy"`
-	FabricAddressingPolicy *rawTemplateFabricAddressingPolicy410Only `json:"fabric_addressing_policy,omitempty"`
-	VirtualNetworkPolicy   rawVirtualNetworkPolicy                   `json:"virtual_network_policy"`
+	Type                 templateType            `json:"type"`
+	DisplayName          string                  `json:"display_name"`
+	Spine                rawSpine                `json:"spine"`
+	RackTypes            []rawRackType           `json:"rack_types"`
+	RackTypeCounts       []RackTypeCount         `json:"rack_type_counts"`
+	DhcpServiceIntent    DhcpServiceIntent       `json:"dhcp_service_intent"`
+	AntiAffinityPolicy   *rawAntiAffinityPolicy  `json:"anti_affinity_policy,omitempty"`
+	AsnAllocationPolicy  rawAsnAllocationPolicy  `json:"asn_allocation_policy"`
+	VirtualNetworkPolicy rawVirtualNetworkPolicy `json:"virtual_network_policy"`
 }
 
 func (o *Client) createRackBasedTemplate(ctx context.Context, in *rawCreateRackBasedTemplateRequest) (ObjectId, error) {
@@ -1496,11 +1433,10 @@ func (o *Client) updateRackBasedTemplate(ctx context.Context, id ObjectId, in *C
 }
 
 type CreatePodBasedTemplateRequest struct {
-	DisplayName            string
-	Superspine             *TemplateElementSuperspineRequest
-	PodInfos               map[ObjectId]TemplatePodBasedInfo
-	AntiAffinityPolicy     *AntiAffinityPolicy
-	FabricAddressingPolicy *TemplateFabricAddressingPolicy410Only // Apstra 4.1.0 only
+	DisplayName        string
+	Superspine         *TemplateElementSuperspineRequest
+	PodInfos           map[ObjectId]TemplatePodBasedInfo
+	AntiAffinityPolicy *AntiAffinityPolicy
 }
 
 func (o *CreatePodBasedTemplateRequest) raw(ctx context.Context, client *Client) (*rawCreatePodBasedTemplateRequest, error) {
@@ -1533,8 +1469,8 @@ func (o *CreatePodBasedTemplateRequest) raw(ctx context.Context, client *Client)
 	switch {
 	case o.Superspine == nil:
 		return nil, errors.New("super spine cannot be <nil> when creating a pod-based template")
-	case o.AntiAffinityPolicy == nil && leApstra420.Check(client.apiVersion):
-		return nil, fmt.Errorf("anti-affinity policy cannot be <nil> when creating a pod-based template with Apstra %s", leApstra420)
+	case o.AntiAffinityPolicy == nil && templateRequestRequiresAntiAffinityPolicy.Check(client.apiVersion):
+		return nil, fmt.Errorf("anti-affinity policy cannot be <nil> when creating a pod-based template with Apstra %s", templateRequestRequiresAntiAffinityPolicy)
 	}
 
 	var err error
@@ -1551,11 +1487,6 @@ func (o *CreatePodBasedTemplateRequest) raw(ctx context.Context, client *Client)
 		antiAffinityPolicy = o.AntiAffinityPolicy.raw()
 	}
 
-	var fabricAddressingPolicy *rawTemplateFabricAddressingPolicy410Only
-	if o.FabricAddressingPolicy != nil && legacyTemplateWithAddressingPolicy.Check(client.apiVersion) {
-		fabricAddressingPolicy = o.FabricAddressingPolicy.raw()
-	}
-
 	return &rawCreatePodBasedTemplateRequest{
 		Type:                    templateTypePodBased,
 		DisplayName:             o.DisplayName,
@@ -1563,18 +1494,16 @@ func (o *CreatePodBasedTemplateRequest) raw(ctx context.Context, client *Client)
 		RackBasedTemplates:      templatesRackBased,
 		RackBasedTemplateCounts: rackBasedTemplatesCounts,
 		AntiAffinityPolicy:      antiAffinityPolicy,
-		FabricAddressingPolicy:  fabricAddressingPolicy,
 	}, nil
 }
 
 type rawCreatePodBasedTemplateRequest struct {
-	Type                    templateType                              `json:"type"`
-	DisplayName             string                                    `json:"display_name"`
-	Superspine              rawSuperspine                             `json:"superspine"`
-	RackBasedTemplates      []rawTemplateRackBased                    `json:"rack_based_templates"`
-	RackBasedTemplateCounts []RackBasedTemplateCount                  `json:"rack_based_template_counts"`
-	AntiAffinityPolicy      *rawAntiAffinityPolicy                    `json:"anti_affinity_policy,omitempty"`
-	FabricAddressingPolicy  *rawTemplateFabricAddressingPolicy410Only `json:"fabric_addressing_policy,omitempty"` // Apstra 4.1.0 only
+	Type                    templateType             `json:"type"`
+	DisplayName             string                   `json:"display_name"`
+	Superspine              rawSuperspine            `json:"superspine"`
+	RackBasedTemplates      []rawTemplateRackBased   `json:"rack_based_templates"`
+	RackBasedTemplateCounts []RackBasedTemplateCount `json:"rack_based_template_counts"`
+	AntiAffinityPolicy      *rawAntiAffinityPolicy   `json:"anti_affinity_policy,omitempty"`
 }
 
 func (o *Client) createPodBasedTemplate(ctx context.Context, in *rawCreatePodBasedTemplateRequest) (ObjectId, error) {

--- a/apstra/api_metricdb_test.go
+++ b/apstra/api_metricdb_test.go
@@ -59,14 +59,16 @@ func TestUseAggregation(t *testing.T) {
 }
 
 func TestQueryMetricdb(t *testing.T) {
-	clients, err := getTestClients(context.Background(), t)
+	ctx := context.Background()
+
+	clients, err := getTestClients(ctx, t)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for clientName, client := range clients {
 		log.Printf("testing getMetricdbMetrics() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		metrics, err := client.client.getMetricdbMetrics(context.TODO())
+		metrics, err := client.client.getMetricdbMetrics(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -74,7 +76,7 @@ func TestQueryMetricdb(t *testing.T) {
 		var result *MetricDbQueryResponse
 		if len(metrics.Items) > 0 { // do not call rand.Intn() with '0'
 			i := rand.Intn(len(metrics.Items))
-			log.Printf("randomly requesting metric %d of %d available", i, len(metrics.Items))
+			log.Printf("randomly requesting metric %q (%d) of %d available", metrics.Items[i], i, len(metrics.Items))
 			q := MetricDbQueryRequest{
 				metric: metrics.Items[i],
 				begin:  time.Now().Add(-time.Hour),
@@ -82,7 +84,7 @@ func TestQueryMetricdb(t *testing.T) {
 			}
 
 			log.Printf("testing QueryMetricdb() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-			result, err = client.client.QueryMetricdb(context.TODO(), &q)
+			result, err = client.client.QueryMetricdb(ctx, &q)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/apstra/client.go
+++ b/apstra/client.go
@@ -265,6 +265,10 @@ func (o ClientCfg) validate() error {
 
 // NewClient creates a Client object
 func (o ClientCfg) NewClient(ctx context.Context) (*Client, error) {
+	if o.tuningParams == nil {
+		o.tuningParams = make(map[string]int)
+	}
+
 	err := o.validate()
 	if err != nil {
 		return nil, err
@@ -549,10 +553,6 @@ func (o *Client) UpdateAsnPool(ctx context.Context, id ObjectId, cfg *AsnPoolReq
 
 // GetIntegerPools returns Integer Pools configured on Apstra
 func (o *Client) GetIntegerPools(ctx context.Context) ([]IntPool, error) {
-	if integerPoolForbidden().Includes(o.apiVersion.String()) {
-		return nil, fmt.Errorf("integer pool operations not compatible with Apstra API %s", o.apiVersion)
-	}
-
 	rawPools, err := o.getIntPools(ctx, apiUrlResourcesIntegerPools)
 	if err != nil {
 		return nil, err
@@ -572,10 +572,6 @@ func (o *Client) GetIntegerPools(ctx context.Context) ([]IntPool, error) {
 
 // GetIntegerPoolByName returns Integer Pools configured on Apstra
 func (o *Client) GetIntegerPoolByName(ctx context.Context, desired string) (*IntPool, error) {
-	if integerPoolForbidden().Includes(o.apiVersion.String()) {
-		return nil, fmt.Errorf("integer pool operations not compatible with Apstra API %s", o.apiVersion)
-	}
-
 	raw, err := o.getIntPoolByName(ctx, desired)
 	if err != nil {
 		return nil, err
@@ -585,19 +581,11 @@ func (o *Client) GetIntegerPoolByName(ctx context.Context, desired string) (*Int
 
 // ListIntegerPoolIds returns Integer Pools configured on Apstra
 func (o *Client) ListIntegerPoolIds(ctx context.Context) ([]ObjectId, error) {
-	if integerPoolForbidden().Includes(o.apiVersion.String()) {
-		return nil, fmt.Errorf("integer pool operations not compatible with Apstra API %s", o.apiVersion)
-	}
-
 	return o.listIntPoolIds(ctx, apiUrlResourcesIntegerPools)
 }
 
 // CreateIntegerPool adds an Integer Pool to Apstra
 func (o *Client) CreateIntegerPool(ctx context.Context, in *IntPoolRequest) (ObjectId, error) {
-	if integerPoolForbidden().Includes(o.apiVersion.String()) {
-		return "", fmt.Errorf("integer pool operations not compatible with Apstra API %s", o.apiVersion)
-	}
-
 	response, err := o.createIntPool(ctx, in, apiUrlResourcesIntegerPools)
 	if err != nil {
 		return "", fmt.Errorf("error creating Integer Pool - %w", err)
@@ -607,10 +595,6 @@ func (o *Client) CreateIntegerPool(ctx context.Context, in *IntPoolRequest) (Obj
 
 // GetIntegerPool returns, by ObjectId, a specific Integer Pool
 func (o *Client) GetIntegerPool(ctx context.Context, in ObjectId) (*IntPool, error) {
-	if integerPoolForbidden().Includes(o.apiVersion.String()) {
-		return nil, fmt.Errorf("integer pool operations not compatible with Apstra API %s", o.apiVersion)
-	}
-
 	rawPool, err := o.getIntPool(ctx, apiUrlResourcesIntegerPoolById, in)
 	if err != nil {
 		return nil, err
@@ -620,19 +604,11 @@ func (o *Client) GetIntegerPool(ctx context.Context, in ObjectId) (*IntPool, err
 
 // DeleteIntegerPool deletes an Integer Pool, by ObjectId from Apstra
 func (o *Client) DeleteIntegerPool(ctx context.Context, in ObjectId) error {
-	if integerPoolForbidden().Includes(o.apiVersion.String()) {
-		return fmt.Errorf("integer pool operations not compatible with Apstra API %s", o.apiVersion)
-	}
-
 	return o.deleteIntPool(ctx, apiUrlResourcesIntegerPoolById, in)
 }
 
 // UpdateIntegerPool updates an Integer Pool by ObjectId with new Integer Pool config
 func (o *Client) UpdateIntegerPool(ctx context.Context, id ObjectId, cfg *IntPoolRequest) error {
-	if integerPoolForbidden().Includes(o.apiVersion.String()) {
-		return fmt.Errorf("integer pool operations not compatible with Apstra API %s", o.apiVersion)
-	}
-
 	return o.updateIntPool(ctx, apiUrlResourcesIntegerPoolById, id, cfg)
 }
 
@@ -872,12 +848,6 @@ func (o *Client) GetAllBlueprintStatus(ctx context.Context) ([]BlueprintStatus, 
 
 // CreateBlueprintFromTemplate creates a blueprint using the supplied reference design and template
 func (o *Client) CreateBlueprintFromTemplate(ctx context.Context, req *CreateBlueprintFromTemplateRequest) (ObjectId, error) {
-	if req.FabricSettings != nil &&
-		req.FabricSettings.FabricL3Mtu != nil &&
-		fabricL3MtuForbidden.Check(o.apiVersion) {
-		return "", errors.New(fabricL3MtuForbiddenError)
-	}
-
 	if req.FabricSettings != nil && req.FabricSettings.Ipv6Enabled != nil && *req.FabricSettings.Ipv6Enabled {
 		return "", errors.New("IPv6 cannot be enabled during blueprint creation")
 	}
@@ -885,13 +855,16 @@ func (o *Client) CreateBlueprintFromTemplate(ctx context.Context, req *CreateBlu
 	var id ObjectId
 	var err error
 	switch {
-	case geApstra421.Check(o.apiVersion):
-		id, err = o.createBlueprintFromTemplate(ctx, req.raw())
-	default:
+	case eqApstra420.Check(o.apiVersion):
 		id, err = o.createBlueprintFromTemplate420(ctx, req.raw420())
-	}
-	if err != nil {
-		return id, err
+		if err != nil {
+			return id, fmt.Errorf("failed while creating new blueprint - %w", err)
+		}
+	default:
+		id, err = o.createBlueprintFromTemplate(ctx, req.raw())
+		if err != nil {
+			return id, err
+		}
 	}
 
 	if req.SkipCablingReadinessCheck {

--- a/apstra/client_test.go
+++ b/apstra/client_test.go
@@ -132,13 +132,6 @@ func TestCRUDIntegerPools(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// remove clients which do not support integer pools
-	for clientName, client := range clients {
-		if integerPoolForbidden().Includes(client.client.apiVersion.String()) {
-			delete(clients, clientName)
-		}
-	}
-
 	validate := func(req *IntPoolRequest, resp *IntPool) {
 		if req.DisplayName != resp.DisplayName {
 			t.Fatalf("integer pool name mismatch - Requested: %q Actual %q", req.DisplayName, resp.DisplayName)
@@ -212,7 +205,7 @@ func TestCRUDIntegerPools(t *testing.T) {
 		beforePoolCount := len(pools)
 		request := IntPoolRequest{
 			DisplayName: randString(5, "hex"),
-			Ranges:      randomRanges(2, 5, 1, math.MaxUint32),
+			Ranges:      randomRanges(2, 5, 10000, 10999),
 			Tags:        randomTags(2, 5),
 		}
 

--- a/apstra/compatibility.go
+++ b/apstra/compatibility.go
@@ -17,14 +17,7 @@ var (
 	eqApstra420 = version.MustConstraints(version.NewConstraint(apstra420))
 	geApstra421 = version.MustConstraints(version.NewConstraint(">=" + apstra421))
 	geApstra500 = version.MustConstraints(version.NewConstraint(">=" + apstra500))
-	leApstra412 = version.MustConstraints(version.NewConstraint("<=" + apstra412))
-	leApstra420 = version.MustConstraints(version.NewConstraint("<=" + apstra420))
 	leApstra500 = version.MustConstraints(version.NewConstraint("<=" + apstra500))
-
-	fabricSettingsApiOk  = geApstra421
-	fabricL3MtuForbidden = leApstra412
-
-	legacyTemplateWithAddressingPolicy = version.MustConstraints(version.NewConstraint("<" + apstra411))
 
 	fabricSettingsApiOk                       = geApstra421
 	patchNodeSupportsUnsafeArg                = geApstra500

--- a/apstra/compatibility.go
+++ b/apstra/compatibility.go
@@ -1,61 +1,31 @@
 package apstra
 
 import (
-	"strings"
-
 	"github.com/hashicorp/go-version"
 )
 
 const (
-	apstra410  = "4.1.0"
-	apstra411  = "4.1.1"
-	apstra412  = "4.1.2"
 	apstra420  = "4.2.0"
 	apstra421  = "4.2.1"
 	apstra4211 = "4.2.1.1"
 	apstra422  = "4.2.2"
 	apstra500  = "5.0.0"
 	apstra510  = "5.1.0"
-
-	apstraSupportedApiVersions = "4.2.0, 4.2.1, 4.2.1.1, 4.2.2"
-	apstraSupportedVersionSep  = ","
-
-	fabricL3MtuForbiddenError = "fabric_l3_mtu permitted only with Apstra 4.2.0 and later"
-
-	integerPoolForbiddenVersions = "4.1.0, 4.1.1"
-
-	policyRuleTcpStateQualifierForbidenVersions = "4.1.0, 4.1.1"
-	policyRuleTcpStateQualifierForbidenError    = "tcp_state_qualifier permitted only with Apstra 4.1.2 and later"
-
-	securityZoneJunosEvpnIrbModeRequiredVersions = "4.2.0, 4.2.1, 4.2.1.1, 4.2.2"
-	securityZoneJunosEvpnIrbModeRequiredError    = "junos_evpn_irb_mode is required by Apstra 4.2 and later"
-
-	vnL3MtuForbiddenVersions = "4.1.0, 4.1.1, 4.1.2"
-	vnL3MtuForbiddenError    = "virtual network operations support L3 MTU option only with Apstra 4.2 and later"
 )
 
 var (
-	geApstra411 = version.MustConstraints(version.NewConstraint(">=" + apstra411))
-	geApstra420 = version.MustConstraints(version.NewConstraint(">=" + apstra420))
+	eqApstra420 = version.MustConstraints(version.NewConstraint(apstra420))
 	geApstra421 = version.MustConstraints(version.NewConstraint(">=" + apstra421))
 	geApstra500 = version.MustConstraints(version.NewConstraint(">=" + apstra500))
-	leApstra412 = version.MustConstraints(version.NewConstraint("<=" + apstra412))
-	leApstra420 = version.MustConstraints(version.NewConstraint("<=" + apstra420))
 
-	fabricSettingsApiOk  = geApstra421
-	fabricL3MtuForbidden = leApstra412
-
-	legacyTemplateWithAddressingPolicy = version.MustConstraints(version.NewConstraint("<" + apstra411))
-
-	patchNodeSupportsUnsafeArg = geApstra500
+	fabricSettingsApiOk                       = geApstra421
+	patchNodeSupportsUnsafeArg                = geApstra500
+	templateRequestRequiresAntiAffinityPolicy = eqApstra420
 )
 
 // SupportedApiVersions returns []string with each element representing an Apstra version number like "4.2.0"
 func SupportedApiVersions() []string {
 	return []string{
-		apstra410,
-		apstra411,
-		apstra412,
 		apstra420,
 		apstra421,
 		apstra4211,
@@ -72,14 +42,6 @@ func supportedApiVersionsAsConstraints() []version.Constraints {
 	return result
 }
 
-func parseVersionList(s string) StringSliceWithIncludes {
-	result := strings.Split(s, apstraSupportedVersionSep)
-	for i, s := range result {
-		result[i] = strings.TrimSpace(s)
-	}
-	return result
-}
-
 type StringSliceWithIncludes []string
 
 func (o StringSliceWithIncludes) Includes(s string) bool {
@@ -89,24 +51,4 @@ func (o StringSliceWithIncludes) Includes(s string) bool {
 		}
 	}
 	return false
-}
-
-func apstraSupportedApi() StringSliceWithIncludes {
-	return parseVersionList(apstraSupportedApiVersions)
-}
-
-func integerPoolForbidden() StringSliceWithIncludes {
-	return parseVersionList(integerPoolForbiddenVersions)
-}
-
-func policyRuleTcpStateQualifierForbidden() StringSliceWithIncludes {
-	return parseVersionList(policyRuleTcpStateQualifierForbidenVersions)
-}
-
-func securityZoneJunosEvpnIrbModeRequired() StringSliceWithIncludes {
-	return parseVersionList(securityZoneJunosEvpnIrbModeRequiredVersions)
-}
-
-func vnL3MtuForbidden() StringSliceWithIncludes {
-	return parseVersionList(vnL3MtuForbiddenVersions)
 }

--- a/apstra/talk_to_apstra.go
+++ b/apstra/talk_to_apstra.go
@@ -71,7 +71,7 @@ func convertTtaeToAceWherePossible(err error) error {
 	if errors.As(err, &ttae) {
 		switch ttae.Response.StatusCode {
 		case http.StatusNotFound:
-			if ttae.Request.URL.RawPath == apiUrlBlueprints {
+			if ttae.Request.URL.Path == apiUrlBlueprints {
 				return ClientErr{errType: ErrNotfound, retryable: true, err: err}
 			}
 			return ClientErr{errType: ErrNotfound, err: err}

--- a/apstra/two_stage_l3_clos_fabric_addressing_policy.go
+++ b/apstra/two_stage_l3_clos_fabric_addressing_policy.go
@@ -2,7 +2,6 @@ package apstra
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 )
@@ -36,13 +35,6 @@ func (o *TwoStageL3ClosClient) SetFabricAddressingPolicy(ctx context.Context, in
 		in.EsiMacMsb == nil &&
 		in.FabricL3Mtu == nil {
 		return nil // nothing to do if all relevant input fields are nil
-	}
-
-	if in.FabricL3Mtu != nil && fabricL3MtuForbidden.Check(o.client.apiVersion) {
-		return ClientErr{
-			errType: ErrCompatibility,
-			err:     errors.New(fabricL3MtuForbiddenError),
-		}
 	}
 
 	err := o.client.talkToApstra(ctx, &talkToApstraIn{

--- a/apstra/two_stage_l3_clos_fabric_addressing_policy_integration_test.go
+++ b/apstra/two_stage_l3_clos_fabric_addressing_policy_integration_test.go
@@ -8,6 +8,8 @@ import (
 	"log"
 	"math/rand"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -31,57 +33,37 @@ func TestGetSetGetFAP(t *testing.T) {
 
 		log.Printf("testing GetFabricAddressingPolicy() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		fap, err := bpClient.GetFabricAddressingPolicy(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if *fap.EsiMacMsb != defaultEsiMacMsb {
-			t.Fatalf("expected mac msb to be %d (apstra default?) got %d", defaultEsiMacMsb, fap.EsiMacMsb)
-		}
+		require.NotNil(t, fap.EsiMacMsb)
+		require.Equal(t, *fap.EsiMacMsb, uint8(defaultEsiMacMsb))
 
-		if *fap.Ipv6Enabled {
-			t.Fatal("expected ipv6 to be disabled")
-		}
+		require.NotNil(t, fap.Ipv6Enabled)
+		require.False(t, *fap.Ipv6Enabled)
 
 		newMsb := uint8(rand.Intn(100) + 100) // value 100 - 199
 		newMsb = newMsb + newMsb%2            // make it even
 
-		ipv6Enabled := true
-
-		var fabricL3Mtu *uint16
-		if !fabricL3MtuForbidden.Check(client.client.apiVersion) {
-			flm := uint16(rand.Intn(550)*2 + 8000) // even number 8000 - 9100
-			fabricL3Mtu = &flm
-		}
+		fabricL3Mtu := uint16(rand.Intn(550)*2 + 8000) // even number 8000 - 9100
 
 		log.Printf("testing SetFabricAddressingPolicy() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		err = bpClient.SetFabricAddressingPolicy(ctx, &TwoStageL3ClosFabricAddressingPolicy{
+		require.NoError(t, bpClient.SetFabricAddressingPolicy(ctx, &TwoStageL3ClosFabricAddressingPolicy{
 			EsiMacMsb:   &newMsb,
-			Ipv6Enabled: &ipv6Enabled,
-			FabricL3Mtu: fabricL3Mtu,
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
+			Ipv6Enabled: toPtr(true),
+			FabricL3Mtu: &fabricL3Mtu,
+		}))
 
 		log.Printf("testing GetFabricAddressingPolicy() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 		fap, err = bpClient.GetFabricAddressingPolicy(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if newMsb != *fap.EsiMacMsb {
-			t.Fatalf("new fabric addressing policy mac msb: expected %d got %d", newMsb, fap.EsiMacMsb)
-		}
+		require.NotNil(t, *fap.EsiMacMsb)
+		require.Equal(t, newMsb, *fap.EsiMacMsb)
 
-		if *fap.Ipv6Enabled != ipv6Enabled {
-			t.Fatal("enabling ipv6 in the fabric addressing policy failed")
-		}
+		require.NotNil(t, *fap.Ipv6Enabled)
+		require.True(t, *fap.Ipv6Enabled)
 
-		if fap.FabricL3Mtu != nil {
-			if *fabricL3Mtu != *fap.FabricL3Mtu {
-				t.Fatalf("expected fabric MTU %d, got %d", *fabricL3Mtu, *fap.FabricL3Mtu)
-			}
-		}
+		require.NotNil(t, fap.FabricL3Mtu)
+		require.Equal(t, fabricL3Mtu, *fap.FabricL3Mtu)
 	}
 }

--- a/apstra/two_stage_l3_clos_fabric_settings.go
+++ b/apstra/two_stage_l3_clos_fabric_settings.go
@@ -269,38 +269,6 @@ func (o *TwoStageL3ClosClient) getFabricSettings420(ctx context.Context) (*rawFa
 	}, nil
 }
 
-// getFabricSettings41x does the same job as setFabricSettings, but for Apstra 4.1.x, which collects
-// the parameters in rawFabricSettings from 3 different places
-func (o *TwoStageL3ClosClient) getFabricSettings41x(ctx context.Context) (*rawFabricSettings, error) {
-	fabricAddressingPolicy, err := o.GetFabricAddressingPolicy(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	virtualNetworkPolicy, err := o.getVirtualNetworkPolicy41x(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	antiAffinityPolicy, err := o.getAntiAffinityPolicy(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return &rawFabricSettings{
-		AntiAffinity:                antiAffinityPolicy,
-		EsiMacMsb:                   fabricAddressingPolicy.EsiMacMsb,
-		EvpnGenerateType5HostRoutes: virtualNetworkPolicy.EvpnGenerateType5HostRoutes,
-		ExternalRouterMtu:           virtualNetworkPolicy.ExternalRouterMtu,
-		Ipv6Enabled:                 fabricAddressingPolicy.Ipv6Enabled,
-		MaxEvpnRoutes:               virtualNetworkPolicy.MaxEvpnRoutes,
-		MaxExternalRoutes:           virtualNetworkPolicy.MaxExternalRoutes,
-		MaxFabricRoutes:             virtualNetworkPolicy.MaxFabricRoutes,
-		MaxMlagRoutes:               virtualNetworkPolicy.MaxMlagRoutes,
-		OverlayControlProtocol:      virtualNetworkPolicy.OverlayControlProtocol,
-	}, nil
-}
-
 func (o *TwoStageL3ClosClient) setFabricSettings(ctx context.Context, in *rawFabricSettings) error {
 	err := o.client.talkToApstra(ctx, &talkToApstraIn{
 		method:   http.MethodPatch,
@@ -332,30 +300,6 @@ func (o *TwoStageL3ClosClient) setFabricSettings420(ctx context.Context, in *raw
 	}
 
 	err = o.setSzFootprintOptimization420(ctx, in.OptimiseSzFootprint)
-	if err != nil {
-		return err
-	}
-
-	err = o.setAntiAffinityPolicy(ctx, in.AntiAffinity)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// setFabricSettings41x does the same job as setFabricSettings, but for Apstra 4.1.x, which controls
-// the parameters in rawFabricSettings in 3 different places
-func (o *TwoStageL3ClosClient) setFabricSettings41x(ctx context.Context, in *rawFabricSettings) error {
-	err := o.SetFabricAddressingPolicy(ctx, &TwoStageL3ClosFabricAddressingPolicy{
-		Ipv6Enabled: in.Ipv6Enabled,
-		EsiMacMsb:   in.EsiMacMsb,
-	})
-	if err != nil {
-		return err
-	}
-
-	err = o.setVirtualNetworkPolicy41x(ctx, in)
 	if err != nil {
 		return err
 	}

--- a/apstra/two_stage_l3_clos_fabric_settings_integration_test.go
+++ b/apstra/two_stage_l3_clos_fabric_settings_integration_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package apstra
 
@@ -10,6 +9,7 @@ import (
 
 	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"github.com/hashicorp/go-version"
+	"github.com/stretchr/testify/require"
 )
 
 func compareAntiAffinityPolicy(t testing.TB, set, get AntiAffinityPolicy) {
@@ -44,79 +44,83 @@ func compareFabricSettings(t testing.TB, set, get FabricSettings) {
 	t.Helper()
 
 	if set.AntiAffinityPolicy != nil {
+		require.NotNil(t, get.AntiAffinityPolicy)
 		compareAntiAffinityPolicy(t, *get.AntiAffinityPolicy, *set.AntiAffinityPolicy)
 	}
 
-	if set.DefaultSviL3Mtu != nil && *set.DefaultSviL3Mtu != *get.DefaultSviL3Mtu {
-		t.Errorf("set DefaultSviL3Mtu  %d got %d", *set.DefaultSviL3Mtu, *get.DefaultSviL3Mtu)
+	if set.DefaultSviL3Mtu != nil {
+		require.NotNil(t, get.DefaultSviL3Mtu)
+		require.Equalf(t, *set.DefaultSviL3Mtu, *get.DefaultSviL3Mtu, "DefaultSviL3Mtu: set %d get %d", *set.DefaultSviL3Mtu, *get.DefaultSviL3Mtu)
 	}
 
-	if set.EsiMacMsb != nil && *set.EsiMacMsb != *get.EsiMacMsb {
-		t.Errorf("set EsiMacMsb %d got %d", *set.EsiMacMsb, *get.EsiMacMsb)
+	if set.EsiMacMsb != nil {
+		require.NotNil(t, get.EsiMacMsb)
+		require.Equalf(t, *set.EsiMacMsb, *get.EsiMacMsb, "EsiMacMsb: set %d get %d", *set.EsiMacMsb, *get.EsiMacMsb)
 	}
 
 	if set.EvpnGenerateType5HostRoutes != nil && *set.EvpnGenerateType5HostRoutes != *get.EvpnGenerateType5HostRoutes {
-		t.Errorf("set EvpnGenerateType5HostRoutes %s got %s", *set.EvpnGenerateType5HostRoutes, *get.EvpnGenerateType5HostRoutes)
+		require.NotNil(t, get.EvpnGenerateType5HostRoutes)
+		require.Equalf(t, *set.EvpnGenerateType5HostRoutes, *get.EvpnGenerateType5HostRoutes, "EvpnGenerateType5HostRoutes: set %d get %d", *set.EvpnGenerateType5HostRoutes, *get.EvpnGenerateType5HostRoutes)
 	}
 
-	if set.ExternalRouterMtu != nil && *set.ExternalRouterMtu != *get.ExternalRouterMtu {
-		t.Errorf("set ExternalRouterMtu %d got %d", *set.ExternalRouterMtu, *get.ExternalRouterMtu)
+	if set.ExternalRouterMtu != nil {
+		require.NotNil(t, get.ExternalRouterMtu)
+		require.Equalf(t, *set.ExternalRouterMtu, *get.ExternalRouterMtu, "ExternalRouterMtu: set %d get %d", *set.ExternalRouterMtu, *get.ExternalRouterMtu)
 	}
 
 	if set.FabricL3Mtu != nil && *set.FabricL3Mtu != *get.FabricL3Mtu {
-		t.Errorf("set FabricL3Mtu  %d got %d", *set.FabricL3Mtu, *get.FabricL3Mtu)
+		require.NotNil(t, get.FabricL3Mtu)
+		require.Equalf(t, *set.FabricL3Mtu, *get.FabricL3Mtu, "FabricL3Mtu: set %d get %d", *set.FabricL3Mtu, *get.FabricL3Mtu)
 	}
 
-	if set.Ipv6Enabled != nil && *set.Ipv6Enabled != *get.Ipv6Enabled {
-		t.Errorf("set Ipv6Enabled %t got %t", *set.Ipv6Enabled, *get.Ipv6Enabled)
+	if set.Ipv6Enabled != nil {
+		require.NotNil(t, get.Ipv6Enabled)
+		require.Equalf(t, *set.Ipv6Enabled, *get.Ipv6Enabled, "Ipv6Enabled: set %d get %d", *set.Ipv6Enabled, *get.Ipv6Enabled)
 	}
 
-	if set.JunosEvpnDuplicateMacRecoveryTime != nil && *set.JunosEvpnDuplicateMacRecoveryTime != *get.JunosEvpnDuplicateMacRecoveryTime {
-		t.Errorf("set junosEvpnDuplicateMacRecoveryTime %d got %d", *set.JunosEvpnDuplicateMacRecoveryTime, *get.JunosEvpnDuplicateMacRecoveryTime)
+	if set.JunosEvpnDuplicateMacRecoveryTime != nil {
+		require.NotNil(t, get.JunosEvpnDuplicateMacRecoveryTime)
+		require.Equalf(t, *set.JunosEvpnDuplicateMacRecoveryTime, *get.JunosEvpnDuplicateMacRecoveryTime, "JunosEvpnDuplicateMacRecoveryTime: set %d get %d", *set.JunosEvpnDuplicateMacRecoveryTime, *get.JunosEvpnDuplicateMacRecoveryTime)
 	}
 
-	if set.JunosEvpnRoutingInstanceVlanAware != nil && *set.JunosEvpnRoutingInstanceVlanAware != *get.JunosEvpnRoutingInstanceVlanAware {
-		t.Errorf("set JunosEvpnRoutingInstanceVlanAware %s got %s", *set.JunosEvpnRoutingInstanceVlanAware, *get.JunosEvpnRoutingInstanceVlanAware)
+	if set.JunosEvpnRoutingInstanceVlanAware != nil {
+		require.NotNil(t, get.JunosEvpnRoutingInstanceVlanAware)
+		require.Equalf(t, *set.JunosEvpnRoutingInstanceVlanAware, *get.JunosEvpnRoutingInstanceVlanAware, "JunosEvpnRoutingInstanceVlanAware: set %d get %d", *set.JunosEvpnRoutingInstanceVlanAware, *get.JunosEvpnRoutingInstanceVlanAware)
 	}
 
-	if set.JunosEvpnMaxNexthopAndInterfaceNumber != nil && *set.JunosEvpnMaxNexthopAndInterfaceNumber != *get.JunosEvpnMaxNexthopAndInterfaceNumber {
-		t.Errorf("set JunosEvpnMaxNexthopAndInterfaceNumber %s got %s", *set.JunosEvpnMaxNexthopAndInterfaceNumber, *get.JunosEvpnMaxNexthopAndInterfaceNumber)
+	if set.JunosEvpnMaxNexthopAndInterfaceNumber != nil {
+		require.NotNil(t, get.JunosEvpnMaxNexthopAndInterfaceNumber)
+		require.Equalf(t, *set.JunosEvpnMaxNexthopAndInterfaceNumber, *get.JunosEvpnMaxNexthopAndInterfaceNumber, "JunosEvpnMaxNexthopAndInterfaceNumber: set %d get %d", *set.JunosEvpnMaxNexthopAndInterfaceNumber, *get.JunosEvpnMaxNexthopAndInterfaceNumber)
 	}
 
-	if set.JunosExOverlayEcmp != nil && *set.JunosExOverlayEcmp != *get.JunosExOverlayEcmp {
-		t.Errorf("set JunosExOverlayEcmp %s got %s", *set.JunosExOverlayEcmp, *get.JunosExOverlayEcmp)
+	if set.JunosExOverlayEcmp != nil {
+		require.NotNil(t, get.JunosExOverlayEcmp)
+		require.Equalf(t, *set.JunosExOverlayEcmp, *get.JunosExOverlayEcmp, "JunosExOverlayEcmp: set %d get %d", *set.JunosExOverlayEcmp, *get.JunosExOverlayEcmp)
 	}
 
-	if set.JunosGracefulRestart != nil && *set.JunosGracefulRestart != *get.JunosGracefulRestart {
-		t.Errorf("set JunosGracefulRestart %s got %s", *set.JunosGracefulRestart, *get.JunosGracefulRestart)
+	if set.JunosGracefulRestart != nil {
+		require.NotNil(t, get.JunosGracefulRestart)
+		require.Equalf(t, *set.JunosGracefulRestart, *get.JunosGracefulRestart, "JunosGracefulRestart: set %d get %d", *set.JunosGracefulRestart, *get.JunosGracefulRestart)
 	}
 
-	if (set.MaxEvpnRoutes == nil) != (get.MaxEvpnRoutes == nil) {
-		t.Errorf("set MaxEvpnRoutes - set nil: %t got nil: %t", set.MaxEvpnRoutes == nil, get.MaxEvpnRoutes == nil)
-	}
-	if set.MaxEvpnRoutes != nil && *set.MaxEvpnRoutes != *get.MaxEvpnRoutes {
-		t.Errorf("set MaxEvpnRoutes %d got %d", *set.MaxEvpnRoutes, *get.MaxEvpnRoutes)
+	if set.MaxEvpnRoutes != nil {
+		require.NotNil(t, get.MaxEvpnRoutes)
+		require.Equalf(t, *set.MaxEvpnRoutes, *get.MaxEvpnRoutes, "MaxEvpnRoutes: set %d get %d", *set.MaxEvpnRoutes, *get.MaxEvpnRoutes)
 	}
 
-	if (set.MaxExternalRoutes == nil) != (get.MaxExternalRoutes == nil) {
-		t.Errorf("set MaxExternalRoutes - set nil: %t got nil: %t", set.MaxExternalRoutes == nil, get.MaxExternalRoutes == nil)
-	}
-	if set.MaxExternalRoutes != nil && *set.MaxExternalRoutes != *get.MaxExternalRoutes {
-		t.Errorf("set MaxExternalRoutes %d got %d", *set.MaxExternalRoutes, *get.MaxExternalRoutes)
+	if set.MaxExternalRoutes != nil {
+		require.NotNil(t, get.MaxExternalRoutes)
+		require.Equalf(t, *set.MaxExternalRoutes, *get.MaxExternalRoutes, "MaxExternalRoutes: set %d get %d", *set.MaxExternalRoutes, *get.MaxExternalRoutes)
 	}
 
-	if (set.MaxFabricRoutes == nil) != (get.MaxFabricRoutes == nil) {
-		t.Errorf("set MaxFabricRoutes - set nil: %t got nil: %t", set.MaxFabricRoutes == nil, get.MaxFabricRoutes == nil)
-	}
-	if set.MaxFabricRoutes != nil && *set.MaxFabricRoutes != *get.MaxFabricRoutes {
-		t.Errorf("set MaxFabricRoutes %d got %d", *set.MaxFabricRoutes, *get.MaxFabricRoutes)
+	if set.MaxFabricRoutes != nil {
+		require.NotNil(t, get.MaxFabricRoutes)
+		require.Equalf(t, *set.MaxFabricRoutes, *get.MaxFabricRoutes, "MaxFabricRoutes: set %d get %d", *set.MaxFabricRoutes, *get.MaxFabricRoutes)
 	}
 
-	if (set.MaxMlagRoutes == nil) != (get.MaxMlagRoutes == nil) {
-		t.Errorf("set MaxMlagRoutes - set nil: %t got nil: %t", set.MaxMlagRoutes == nil, get.MaxMlagRoutes == nil)
-	}
-	if set.MaxMlagRoutes != nil && *set.MaxMlagRoutes != *get.MaxMlagRoutes {
-		t.Errorf("set MaxMlagRoutes %d got %d", *set.MaxMlagRoutes, *get.MaxMlagRoutes)
+	if set.MaxMlagRoutes != nil {
+		require.NotNil(t, get.MaxMlagRoutes)
+		require.Equalf(t, *set.MaxMlagRoutes, *get.MaxMlagRoutes, "MaxMlagRoutes: set %d get %d", *set.MaxMlagRoutes, *get.MaxMlagRoutes)
 	}
 
 	if set.OptimiseSzFootprint != nil && *set.OptimiseSzFootprint != *get.OptimiseSzFootprint {
@@ -145,48 +149,7 @@ func TestSetGetFabricSettings(t *testing.T) {
 		"no_fabric_settings": {
 			fabricSettings: FabricSettings{},
 		},
-		"41x_compatible_1": {
-			fabricSettings: FabricSettings{
-				AntiAffinityPolicy: &AntiAffinityPolicy{
-					Algorithm:                AlgorithmHeuristic,
-					MaxLinksPerPort:          2,
-					MaxLinksPerSlot:          2,
-					MaxPerSystemLinksPerPort: 2,
-					MaxPerSystemLinksPerSlot: 2,
-					Mode:                     AntiAffinityModeEnabledStrict,
-				},
-				EsiMacMsb:                   toPtr(uint8(4)),
-				EvpnGenerateType5HostRoutes: &enum.FeatureSwitchEnumEnabled,
-				ExternalRouterMtu:           toPtr(uint16(9002)),
-				Ipv6Enabled:                 toPtr(false), // do not enable because it's a one-way trip
-				MaxEvpnRoutes:               toPtr(uint32(10000)),
-				MaxExternalRoutes:           toPtr(uint32(11000)),
-				MaxFabricRoutes:             toPtr(uint32(12000)),
-				MaxMlagRoutes:               toPtr(uint32(13000)),
-			},
-		},
-		"412_compatible_2": {
-			fabricSettings: FabricSettings{
-				AntiAffinityPolicy: &AntiAffinityPolicy{
-					Algorithm:                AlgorithmHeuristic,
-					MaxLinksPerPort:          3,
-					MaxLinksPerSlot:          3,
-					MaxPerSystemLinksPerPort: 3,
-					MaxPerSystemLinksPerSlot: 3,
-					Mode:                     AntiAffinityModeEnabledLoose,
-				},
-				EsiMacMsb:                   toPtr(uint8(6)),
-				EvpnGenerateType5HostRoutes: &enum.FeatureSwitchEnumDisabled,
-				ExternalRouterMtu:           toPtr(uint16(9004)),
-				Ipv6Enabled:                 toPtr(false), // do not enable because it's a one-way trip
-				MaxEvpnRoutes:               toPtr(uint32(20000)),
-				MaxExternalRoutes:           toPtr(uint32(21000)),
-				MaxFabricRoutes:             toPtr(uint32(22000)),
-				MaxMlagRoutes:               toPtr(uint32(23000)),
-			},
-		},
 		"lots_of_values": {
-			versionConstraint: version.MustConstraints(version.NewConstraint(">" + apstra412)),
 			fabricSettings: FabricSettings{
 				JunosEvpnDuplicateMacRecoveryTime:     toPtr(uint16(16)),
 				MaxExternalRoutes:                     toPtr(uint32(239832)),
@@ -215,7 +178,6 @@ func TestSetGetFabricSettings(t *testing.T) {
 			},
 		},
 		"different_values": {
-			versionConstraint: version.MustConstraints(version.NewConstraint(">" + apstra412)),
 			fabricSettings: FabricSettings{
 				JunosEvpnDuplicateMacRecoveryTime:     toPtr(uint16(15)),
 				MaxExternalRoutes:                     toPtr(uint32(239732)),
@@ -246,31 +208,33 @@ func TestSetGetFabricSettings(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		client := client
-		bpClient := testBlueprintC(ctx, t, client.client)
+		clientName, client := clientName, client
+		t.Run(clientName, func(t *testing.T) {
+			bpClient := testBlueprintC(ctx, t, client.client)
 
-		for tName, tCase := range testCases {
-			tName, tCase := tName, tCase
-			t.Run(tName, func(t *testing.T) {
-				if tCase.versionConstraint != nil && !tCase.versionConstraint.Check(bpClient.client.apiVersion) {
-					t.Skipf("skipping test %q due to version constraints: %q. API version %q",
-						tName, tCase.versionConstraint, bpClient.client.apiVersion)
-				}
+			for tName, tCase := range testCases {
+				tName, tCase := tName, tCase
+				t.Run(tName, func(t *testing.T) {
+					if tCase.versionConstraint != nil && !tCase.versionConstraint.Check(bpClient.client.apiVersion) {
+						t.Skipf("skipping test %q due to version constraints: %q. API version %q",
+							tName, tCase.versionConstraint, bpClient.client.apiVersion)
+					}
 
-				log.Printf("testing SetFabricSettings() against %s %s (%s)", client.clientType, clientName, bpClient.client.apiVersion)
-				err = bpClient.SetFabricSettings(ctx, &tCase.fabricSettings)
-				if err != nil {
-					t.Fatal(err)
-				}
+					log.Printf("testing SetFabricSettings() against %s %s (%s)", client.clientType, clientName, bpClient.client.apiVersion)
+					err = bpClient.SetFabricSettings(ctx, &tCase.fabricSettings)
+					if err != nil {
+						t.Fatal(err)
+					}
 
-				log.Printf("testing GetFabricSettings() against %s %s (%s)", client.clientType, clientName, bpClient.client.apiVersion)
-				fs, err := bpClient.GetFabricSettings(ctx)
-				if err != nil {
-					t.Fatal(err)
-				}
-				compareFabricSettings(t, tCase.fabricSettings, *fs)
-			})
-		}
+					log.Printf("testing GetFabricSettings() against %s %s (%s)", client.clientType, clientName, bpClient.client.apiVersion)
+					fs, err := bpClient.GetFabricSettings(ctx)
+					if err != nil {
+						t.Fatal(err)
+					}
+					compareFabricSettings(t, tCase.fabricSettings, *fs)
+				})
+			}
+		})
 	}
 }
 
@@ -354,41 +318,43 @@ func TestSetGetFabricSettingsV6(t *testing.T) {
 	}
 
 	for clientName, client := range clients {
-		client := client
+		clientName, client := clientName, client
 
-		bpClient := testBlueprintC(ctx, t, client.client)
+		t.Run(clientName, func(t *testing.T) {
+			bpClient := testBlueprintC(ctx, t, client.client)
 
-		t.Run("enable_and_check_ipv6", func(t *testing.T) {
-			fsSet := &FabricSettings{
-				AntiAffinityPolicy: &AntiAffinityPolicy{
-					Algorithm:                AlgorithmHeuristic,
-					MaxLinksPerPort:          2,
-					MaxLinksPerSlot:          2,
-					MaxPerSystemLinksPerPort: 2,
-					MaxPerSystemLinksPerSlot: 2,
-					Mode:                     AntiAffinityModeEnabledStrict,
-				},
-				EsiMacMsb:                   toPtr(uint8(4)),
-				EvpnGenerateType5HostRoutes: &enum.FeatureSwitchEnumEnabled,
-				ExternalRouterMtu:           toPtr(uint16(9002)),
-				Ipv6Enabled:                 toPtr(true),
-				MaxEvpnRoutes:               toPtr(uint32(10000)),
-				MaxExternalRoutes:           toPtr(uint32(11000)),
-				MaxFabricRoutes:             toPtr(uint32(12000)),
-				MaxMlagRoutes:               toPtr(uint32(13000)),
-			}
-			log.Printf("testing SetFabricSettings() against %s %s (%s)", client.clientType, clientName, bpClient.client.apiVersion)
-			err = bpClient.SetFabricSettings(ctx, fsSet)
-			if err != nil {
-				t.Fatal(err)
-			}
-			log.Printf("testing GetFabricSettings() against %s %s (%s)", client.clientType, clientName, bpClient.client.apiVersion)
-			fsGet, err := bpClient.GetFabricSettings(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
+			t.Run("enable_and_check_ipv6", func(t *testing.T) {
+				fsSet := &FabricSettings{
+					AntiAffinityPolicy: &AntiAffinityPolicy{
+						Algorithm:                AlgorithmHeuristic,
+						MaxLinksPerPort:          2,
+						MaxLinksPerSlot:          2,
+						MaxPerSystemLinksPerPort: 2,
+						MaxPerSystemLinksPerSlot: 2,
+						Mode:                     AntiAffinityModeEnabledStrict,
+					},
+					EsiMacMsb:                   toPtr(uint8(4)),
+					EvpnGenerateType5HostRoutes: &enum.FeatureSwitchEnumEnabled,
+					ExternalRouterMtu:           toPtr(uint16(9002)),
+					Ipv6Enabled:                 toPtr(true),
+					MaxEvpnRoutes:               toPtr(uint32(10000)),
+					MaxExternalRoutes:           toPtr(uint32(11000)),
+					MaxFabricRoutes:             toPtr(uint32(12000)),
+					MaxMlagRoutes:               toPtr(uint32(13000)),
+				}
+				log.Printf("testing SetFabricSettings() against %s %s (%s)", client.clientType, clientName, bpClient.client.apiVersion)
+				err = bpClient.SetFabricSettings(ctx, fsSet)
+				if err != nil {
+					t.Fatal(err)
+				}
+				log.Printf("testing GetFabricSettings() against %s %s (%s)", client.clientType, clientName, bpClient.client.apiVersion)
+				fsGet, err := bpClient.GetFabricSettings(ctx)
+				if err != nil {
+					t.Fatal(err)
+				}
 
-			compareFabricSettings(t, *fsSet, *fsGet)
+				compareFabricSettings(t, *fsSet, *fsGet)
+			})
 		})
 	}
 }

--- a/apstra/two_stage_l3_clos_generic_system_loopback_test.go
+++ b/apstra/two_stage_l3_clos_generic_system_loopback_test.go
@@ -7,29 +7,23 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/go-version"
 	"math/rand"
 	"net"
 	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGenericSystemLoopbacks(t *testing.T) {
 	ctx := context.Background()
 
 	clients, err := getTestClients(ctx, t)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	for clientName, client := range clients {
 		t.Logf("creating test blueprint in %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		bpClient, bpDelete := testBlueprintH(ctx, t, client.client)
-		defer func() {
-			err := bpDelete(context.Background())
-			if err != nil {
-				t.Fatal(err)
-			}
-		}()
+		bpClient := testBlueprintH(ctx, t, client.client)
 
 		t.Logf("determining generic system node IDs in %s %s (%s)", client.clientType, clientName, client.client.apiVersion)
 		systemIds, err := getSystemIdsByRole(ctx, bpClient, "generic")
@@ -84,31 +78,27 @@ func TestGenericSystemLoopbacks(t *testing.T) {
 				},
 			},
 			{
-				name:           "v6_only_1",
-				apiConstraints: version.MustConstraints(version.NewConstraint("!=" + apstra410)),
+				name: "v6_only_1",
 				loopback: GenericSystemLoopback{
 					Ipv6Addr: &net.IPNet{IP: randomIpv6(), Mask: v6HostMask},
 				},
 			},
 			{
-				name:           "v6_only_2",
-				apiConstraints: version.MustConstraints(version.NewConstraint("!=" + apstra410)),
+				name: "v6_only_2",
 				loopback: GenericSystemLoopback{
 					Ipv6Addr: &net.IPNet{IP: randomIpv6(), Mask: v6HostMask},
 				},
 			},
 			{name: "none_1"},
 			{
-				name:           "v4_and_v6_1",
-				apiConstraints: version.MustConstraints(version.NewConstraint("!=" + apstra410)),
+				name: "v4_and_v6_1",
 				loopback: GenericSystemLoopback{
 					Ipv4Addr: &net.IPNet{IP: randomIpv4(), Mask: v4HostMask},
 					Ipv6Addr: &net.IPNet{IP: randomIpv6(), Mask: v6HostMask},
 				},
 			},
 			{
-				name:           "v4_and_v6_2",
-				apiConstraints: version.MustConstraints(version.NewConstraint("!=" + apstra410)),
+				name: "v4_and_v6_2",
 				loopback: GenericSystemLoopback{
 					Ipv4Addr: &net.IPNet{IP: randomIpv4(), Mask: v4HostMask},
 					Ipv6Addr: &net.IPNet{IP: randomIpv6(), Mask: v6HostMask},

--- a/apstra/two_stage_l3_clos_security_zones_integration_test.go
+++ b/apstra/two_stage_l3_clos_security_zones_integration_test.go
@@ -59,10 +59,8 @@ func TestCreateUpdateDeleteRoutingZone(t *testing.T) {
 		if zone.Id != zoneId {
 			t.Fatalf("created vs. fetched zone IDs don't match: '%s' and '%s'", zone.Id, zoneId)
 		}
-		if securityZoneJunosEvpnIrbModeRequired().Includes(client.client.apiVersion.String()) {
-			if zone.Data.JunosEvpnIrbMode.Value != enum.JunosEvpnIrbModeSymmetric.Value {
-				t.Fatal()
-			}
+		if zone.Data.JunosEvpnIrbMode.Value != enum.JunosEvpnIrbModeSymmetric.Value {
+			t.Fatal()
 		}
 
 		randStr2 := randString(5, "hex")
@@ -90,8 +88,7 @@ func TestCreateUpdateDeleteRoutingZone(t *testing.T) {
 		if zone.Data.VrfName != vrfName2 {
 			t.Fatal()
 		}
-		if securityZoneJunosEvpnIrbModeRequired().Includes(client.client.apiVersion.String()) &&
-			zone.Data.JunosEvpnIrbMode.Value != enum.JunosEvpnIrbModeAsymmetric.Value {
+		if zone.Data.JunosEvpnIrbMode.Value != enum.JunosEvpnIrbModeAsymmetric.Value {
 			t.Fatal()
 		}
 

--- a/apstra/two_stage_l3_clos_virtual_network_policy.go
+++ b/apstra/two_stage_l3_clos_virtual_network_policy.go
@@ -3,8 +3,9 @@ package apstra
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/go-version"
 	"net/http"
+
+	"github.com/hashicorp/go-version"
 )
 
 const (
@@ -73,61 +74,6 @@ func (o *TwoStageL3ClosClient) setVirtualNetworkPolicy420(ctx context.Context, i
 	})
 	if err != nil {
 		return convertTtaeToAceWherePossible(err)
-	}
-
-	return nil
-}
-
-type rawVirtualNetworkPolicy41x struct {
-	EvpnGenerateType5HostRoutes *string `json:"evpn_generate_type5_host_routes,omitempty"`
-	ExternalRouterMtu           *uint16 `json:"external_router_mtu,omitempty"`
-	MaxFabricRoutes             *uint32 `json:"max_fabric_routes"`
-	MaxMlagRoutes               *uint32 `json:"max_mlag_routes"`
-	MaxEvpnRoutes               *uint32 `json:"max_evpn_routes"`
-	MaxExternalRoutes           *uint32 `json:"max_external_routes"`
-	OverlayControlProtocol      *string `json:"overlay_control_protocol,omitempty"`
-}
-
-func (o *TwoStageL3ClosClient) getVirtualNetworkPolicy41x(ctx context.Context) (*rawVirtualNetworkPolicy41x, error) {
-	vnpNodeIds, err := o.NodeIdsByType(ctx, NodeTypeVirtualNetworkPolicy)
-	if err != nil {
-		return nil, err
-	}
-	if len(vnpNodeIds) != 1 {
-		return nil, fmt.Errorf("expected 1 %s node, got %d", NodeTypeVirtualNetworkPolicy.String(), len(vnpNodeIds))
-	}
-
-	var result rawVirtualNetworkPolicy41x
-
-	err = o.client.GetNode(ctx, o.blueprintId, vnpNodeIds[0], &result)
-	if err != nil {
-		return nil, err
-	}
-
-	return &result, nil
-}
-
-func (o *TwoStageL3ClosClient) setVirtualNetworkPolicy41x(ctx context.Context, in *rawFabricSettings) error {
-	patch := rawVirtualNetworkPolicy41x{
-		EvpnGenerateType5HostRoutes: in.EvpnGenerateType5HostRoutes,
-		ExternalRouterMtu:           in.ExternalRouterMtu,
-		MaxEvpnRoutes:               in.MaxEvpnRoutes,
-		MaxExternalRoutes:           in.MaxExternalRoutes,
-		MaxFabricRoutes:             in.MaxFabricRoutes,
-		MaxMlagRoutes:               in.MaxMlagRoutes,
-	}
-
-	fabricNodeIds, err := o.NodeIdsByType(ctx, NodeTypeVirtualNetworkPolicy)
-	if err != nil {
-		return err
-	}
-	if len(fabricNodeIds) != 1 {
-		return fmt.Errorf("expected 1 %s node ID, got %d", NodeTypeFabricAddressingPolicy, len(fabricNodeIds))
-	}
-
-	err = o.PatchNode(ctx, fabricNodeIds[0], &patch, nil)
-	if err != nil {
-		return fmt.Errorf("failed patching %s node %q - %w", NodeTypeFabricAddressingPolicy, fabricNodeIds[0], err)
 	}
 
 	return nil

--- a/apstra/two_stage_l3_clos_virtual_networks_integration_test.go
+++ b/apstra/two_stage_l3_clos_virtual_networks_integration_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func compareRtPolicy(t *testing.T, a, b *RtPolicy) {
-	if (a != nil) != (b != nil) { //XOR
+	if (a != nil) != (b != nil) { // XOR
 		t.Fatalf("RtPolicy exists mismatch: %t vs %t", a != nil, b != nil)
 	}
 
@@ -111,7 +111,7 @@ func compareVirtualNetworkData(t *testing.T, a, b *VirtualNetworkData, strict bo
 
 	aL3Mtu := a.L3Mtu != nil
 	bL3Mtu := b.L3Mtu != nil
-	if (aL3Mtu || bL3Mtu) && !(aL3Mtu && bL3Mtu) { //xor
+	if (aL3Mtu || bL3Mtu) && !(aL3Mtu && bL3Mtu) { // xor
 		t.Fatalf("L3 MTU setting mismatch: set %t vs. set %t", aL3Mtu, bL3Mtu)
 	}
 
@@ -243,11 +243,7 @@ func TestCreateUpdateDeleteVirtualNetwork(t *testing.T) {
 			}
 		}
 
-		var l3Mtu *int
-		if !vnL3MtuForbidden().Includes(client.client.apiVersion.String()) {
-			x := 1280 + (2 * rand.Intn(3969)) // 1280 - 9216 even numbers only
-			l3Mtu = &x
-		}
+		l3Mtu := toPtr(1280 + (2 * rand.Intn(3969))) // 1280 - 9216 even numbers only
 
 		createData := VirtualNetworkData{
 			Ipv4Enabled:               true,
@@ -299,10 +295,7 @@ func TestCreateUpdateDeleteVirtualNetwork(t *testing.T) {
 		newVlan := Vlan(100)
 		createData.ReservedVlanId = &newVlan
 		createData.Label = randString(10, "hex")
-		if !vnL3MtuForbidden().Includes(client.client.apiVersion.String()) {
-			x := 1280 + (2 * rand.Intn(3969)) // 1280 - 9216 even numbers only
-			createData.L3Mtu = &x
-		}
+		createData.L3Mtu = toPtr(1280 + (2 * rand.Intn(3969))) // 1280 - 9216 even numbers only
 
 		for i := range createData.VnBindings {
 			createData.VnBindings[i].VlanId = &newVlan


### PR DESCRIPTION
Apstra 4.1.x reached end of engineering on 05/02/2024 and will reach end of support on 05/02/2025.

This PR removes methods, objects, and tests which support Apstra 4.1.x releases. It does not preclude us from continuing to support earlier versions of this SDK or products built on top of it between now and 05/02/2025.

Tests are passing with:

- Apstra 4.2.0-236
- Apstra 4.2.1-207
- Apstra 4.2.1.1-10
- Apstra 4.2.2-2

Some bugs got fixed along the way:

- `getAllBlueprintStatus()` [retries more than once](https://github.com/Juniper/apstra-go-sdk/blob/4216e875f2275633199aacbef2792685f5ac60cf/apstra/api_blueprints.go#L408C1-L438C1) on 404 due to AOS-45313
- `NewClient()` [makes the tuning params map if necessary](https://github.com/Juniper/apstra-go-sdk/blob/4216e875f2275633199aacbef2792685f5ac60cf/apstra/client.go#L268C1-L271C1).
- `convertTtaeToAceWherePossible()` [now compares](https://github.com/Juniper/apstra-go-sdk/blob/4216e875f2275633199aacbef2792685f5ac60cf/apstra/talk_to_apstra.go#L74C1-L75C1) the correct bit of the request (`URL.Path` vs. `URL.RawPath`) when testing for a retryable error.
