### PR TITLE
Use pre-release-friendly constraint

### DIFF
--- a/apstra/api_property_sets_test.go
+++ b/apstra/api_property_sets_test.go
@@ -6,10 +6,11 @@ package apstra
 import (
 	"context"
 	"encoding/json"
-	"github.com/hashicorp/go-version"
 	"log"
 	"math/rand"
 	"testing"
+
+	"github.com/hashicorp/go-version"
 )
 
 func TestCreateGetUpdateGetDeletePropertySet(t *testing.T) {

--- a/apstra/client.go
+++ b/apstra/client.go
@@ -1849,10 +1849,10 @@ func (o *Client) GetLastDeployedRevision(ctx context.Context, id ObjectId) (*Blu
 func (o *Client) BlueprintOverlayControlProtocol(ctx context.Context, id ObjectId) (OverlayControlProtocol, error) {
 	nodeAttributes := []QEEAttribute{{"name", QEStringVal("node")}}
 	switch {
-	case compatibility.GeApstra421.Check(o.apiVersion):
-		nodeAttributes = append(nodeAttributes, NodeTypeFabricPolicy.QEEAttribute())
-	default:
+	case compatibility.BpHasVirtualNetworkPolicyNode.Check(o.apiVersion):
 		nodeAttributes = append(nodeAttributes, NodeTypeVirtualNetworkPolicy.QEEAttribute())
+	default:
+		nodeAttributes = append(nodeAttributes, NodeTypeFabricPolicy.QEEAttribute())
 	}
 
 	query := new(PathQuery).

--- a/apstra/compatibility/constraints.go
+++ b/apstra/compatibility/constraints.go
@@ -10,6 +10,9 @@ var (
 	BpHasFabricAddressingPolicyNode = Constraint{
 		constraints: version.MustConstraints(version.NewConstraint("<=" + apstra420)),
 	}
+	BpHasVirtualNetworkPolicyNode = Constraint{
+		constraints: version.MustConstraints(version.NewConstraint("<=" + apstra420)),
+	}
 	FabricSettingsApiOk = Constraint{
 		constraints: version.MustConstraints(version.NewConstraint(">=" + apstra421)),
 	}


### PR DESCRIPTION
It is confirmed: #374 was is an issue with the AI build's pre-release tag.

Tests now passing with:
- 4.2.1.1
- 5.0.0
- 5.0.0-a-6

Closes #374