### PR TITLE
Introduce `Test-ID` HTTP header for test tracing

### DIFF
--- a/apstra/api_blueprints_integration_test.go
+++ b/apstra/api_blueprints_integration_test.go
@@ -16,23 +16,29 @@ import (
 )
 
 func TestListAllBlueprintIds(t *testing.T) {
-	clients, err := getTestClients(context.Background(), t)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ctx := context.Background()
 
+	clients, err := getTestClients(ctx, t)
+	require.NoError(t, err)
+
+	ctx = wrapCtxWithTestId(t, ctx)
 	for clientName, client := range clients {
-		log.Printf("testing listAllBlueprintIds() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		blueprints, err := client.client.listAllBlueprintIds(context.TODO())
-		if err != nil {
-			t.Fatal(err)
-		}
+		clientName, client := clientName, client
 
-		result, err := json.Marshal(blueprints)
-		if err != nil {
-			t.Fatal(err)
-		}
-		log.Println(string(result))
+		t.Run(client.name(), func(t *testing.T) {
+			t.Parallel()
+			ctx := wrapCtxWithTestId(t, ctx)
+			//ctx := context.WithValue(ctx, CtxKeyTestId, fmt.Sprintf("%s/%s", testId.String(), t.Name()))
+
+			log.Printf("testing listAllBlueprintIds() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+			blueprints, err := client.client.listAllBlueprintIds(ctx)
+			require.NoError(t, err)
+
+			result, err := json.Marshal(blueprints)
+			require.NoError(t, err)
+
+			log.Println(string(result))
+		})
 	}
 }
 

--- a/apstra/api_blueprints_integration_test.go
+++ b/apstra/api_blueprints_integration_test.go
@@ -28,7 +28,7 @@ func TestListAllBlueprintIds(t *testing.T) {
 		t.Run(client.name(), func(t *testing.T) {
 			t.Parallel()
 			ctx := wrapCtxWithTestId(t, ctx)
-			//ctx := context.WithValue(ctx, CtxKeyTestId, fmt.Sprintf("%s/%s", testId.String(), t.Name()))
+			// ctx := context.WithValue(ctx, CtxKeyTestId, fmt.Sprintf("%s/%s", testId.String(), t.Name()))
 
 			log.Printf("testing listAllBlueprintIds() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 			blueprints, err := client.client.listAllBlueprintIds(ctx)

--- a/apstra/api_design_logical_devices_integration_test.go
+++ b/apstra/api_design_logical_devices_integration_test.go
@@ -12,16 +12,20 @@ import (
 )
 
 func TestListAndGetAllLogicalDevices(t *testing.T) {
-	clients, err := getTestClients(context.Background(), t)
+	ctx := context.Background()
+
+	clients, err := getTestClients(ctx, t)
 	require.NoError(t, err)
 
+	ctx = wrapCtxWithTestId(t, ctx)
 	for clientName, client := range clients {
 		clientName, client := clientName, client
-		t.Run(fmt.Sprintf("%s_%s", client.client.apiVersion, clientName), func(t *testing.T) {
+		t.Run(client.name(), func(t *testing.T) {
 			t.Parallel()
+			ctx = wrapCtxWithTestId(t, ctx)
 
 			log.Printf("testing listLogicalDeviceIds() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-			ids, err := client.client.listLogicalDeviceIds(context.TODO())
+			ids, err := client.client.listLogicalDeviceIds(ctx)
 			require.NoError(t, err)
 			require.NotEqual(t, len(ids), 0)
 
@@ -29,8 +33,9 @@ func TestListAndGetAllLogicalDevices(t *testing.T) {
 				id := ids[i]
 				t.Run(fmt.Sprintf("GET_%s", id), func(t *testing.T) {
 					t.Parallel()
+					ctx = wrapCtxWithTestId(t, ctx)
 
-					ld, err := client.client.GetLogicalDevice(context.TODO(), id)
+					ld, err := client.client.GetLogicalDevice(ctx, id)
 					require.NoError(t, err)
 					require.Equal(t, id, ld.Id)
 				})

--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -988,6 +988,14 @@ func newUUID(t testing.TB) uuid.UUID {
 	return result
 }
 
+// wrapCtxWithTestId produces contexts with the following values:
+// - Test-UUID: a uuid.UUID representing this test and all sub-tests.
+// - Test-ID: a string of the form uuid/test/subtest/subsubtest...
+// the Test-UUID is generated only if not found.
+// HTTP transactions related to these tests can be picked out from wireshark
+// using filters like:
+// - http.request.line contains "843a754c-cc35-4383-807f-833ad991e554"
+// - http.request.line contains "843a754c-cc35-4383-807f-833ad991e554/test/subtest"
 func wrapCtxWithTestId(t testing.TB, ctx context.Context) context.Context {
 	var UUID *uuid.UUID
 

--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/Juniper/apstra-go-sdk/apstra/compatibility"
 	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -977,4 +978,27 @@ func testResourceGroupIpv6(ctx context.Context, t testing.TB, client *FreeformCl
 	require.NoError(t, err)
 
 	return id
+}
+
+func newUUID(t testing.TB) uuid.UUID {
+	t.Helper()
+
+	result, err := uuid.NewRandom()
+	require.NoError(t, err)
+	return result
+}
+
+func wrapCtxWithTestId(t testing.TB, ctx context.Context) context.Context {
+	var UUID *uuid.UUID
+
+	switch v := ctx.Value(CtxKeyTestUUID).(type) {
+	case uuid.UUID:
+		UUID = &v
+	default:
+		UUID = toPtr(newUUID(t))
+		ctx = context.WithValue(ctx, CtxKeyTestUUID, *UUID)
+		log.Println("Test UUID: ", UUID.String())
+	}
+
+	return context.WithValue(ctx, CtxKeyTestID, UUID.String()+"/"+t.Name())
 }

--- a/apstra/talk_to_apstra.go
+++ b/apstra/talk_to_apstra.go
@@ -17,6 +17,9 @@ import (
 )
 
 const (
+	CtxKeyTestID   = "Test-ID"   // context.Context key for a test ID string
+	CtxKeyTestUUID = "Test-UUID" // context.Context key for a uuid.UUID upon which the test ID string is based
+
 	apstraApiAsyncParamKey          = "async"
 	apstraApiAsyncParamValFull      = "full"
 	apstraApiAsyncParamValPartial   = "partial" // default?
@@ -217,6 +220,12 @@ func (o *Client) talkToApstra(ctx context.Context, in *talkToApstraIn) error {
 	// set the Content-Type request header if we're sending any payload
 	if in.apiInput != nil {
 		req.Header.Set("Content-Type", "application/json")
+	}
+
+	// set the Test-ID header if the context has one.
+	switch testId := ctx.Value(CtxKeyTestID).(type) {
+	case string:
+		req.Header.Set(CtxKeyTestID, testId)
 	}
 
 	o.lock(mutexKeyHttpHeaders)

--- a/apstra/test_clients_test.go
+++ b/apstra/test_clients_test.go
@@ -33,6 +33,11 @@ type testClientCfg struct {
 type testClient struct {
 	clientType string
 	client     *Client
+	id         string
+}
+
+func (o testClient) name() string {
+	return fmt.Sprintf("%s/%s/%s", o.clientType, o.id, o.client.apiVersion)
 }
 
 var testClients map[string]testClient
@@ -65,6 +70,7 @@ func getTestClients(ctx context.Context, t *testing.T) (map[string]testClient, e
 		testClients[k] = testClient{
 			clientType: cfg.cfgType,
 			client:     client,
+			id:         k,
 		}
 	}
 


### PR DESCRIPTION
This PR introduces new testing features intended to make it easier to identify test anomalies in packet captures and server logs.

If the `context.Context` passed to `talkToApstra()` contains a Test-ID value, that value will be added to the HTTP request header.

Supporting this are some context wrapper functions which build up the test ID in tested tests/subtests, and a modest improvement to the test client which facilitates sub-test naming.

Closes #409