### PR TITLE
Add 5.0.0 to the list of supported API versions

### DIFF
--- a/apstra/compatibility/compatibility.go
+++ b/apstra/compatibility/compatibility.go
@@ -27,5 +27,6 @@ func SupportedApiVersions() []string {
 		apstra421,
 		apstra4211,
 		apstra422,
+		apstra500,
 	}
 }


### PR DESCRIPTION
All tests are currently passing with the following versions:
- 4.2.0-236
- 4.2.1-207
- 4.2.1.1-10
- 4.2.2-2
- 5.0.0-63

...with the caveat that IBA stuff is explicitly not supported (refuses to run) with 5.0.0