### PR TITLE
Add CI checks to ensure that source files have the required license header

### DIFF
--- a/.ci/scripts/license_header_check.sh
+++ b/.ci/scripts/license_header_check.sh
@@ -14,8 +14,6 @@ skip_regexes+=("^README.md$")
 skip_regexes+=("^Third_Party_Code/.*$")
 skip_regexes+=("^\.gitignore$")
 skip_regexes+=("^\.notices.tpl$")
-skip_regexes+=("^foo bar$")
-skip_regexes+=("^bar$")
 
 copyright_template="Copyright \(c\) Juniper Networks, Inc\., %s-%s\."
 arr_line="All rights reserved\."

--- a/.ci/scripts/license_header_check.sh
+++ b/.ci/scripts/license_header_check.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Juniper Networks, Inc., 2024-2024.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+# files we're not interested in
+skip_regexes=()
+skip_regexes+=("^LICENSE$")
+skip_regexes+=("^NOTICE$")
+skip_regexes+=("^README.md$")
+skip_regexes+=("^Third_Party_Code/.*$")
+skip_regexes+=("^\.gitignore$")
+skip_regexes+=("^\.notices.tpl$")
+skip_regexes+=("^foo bar$")
+skip_regexes+=("^bar$")
+
+copyright_template="Copyright \(c\) Juniper Networks, Inc\., %s-%s\."
+arr_line="All rights reserved\."
+spdx_line="SPDX-License-Identifier: Apache-2.0"
+leading_comment="[ #/]{0,3}"
+
+problem_files=()
+problem_headers=()
+
+# loop over files changed relative to "main" branch
+for file in $(git diff --name-only origin/main)
+do
+  # skip over non-files and files which don't exist in this branch
+  [ ! -f "$file" ] && continue
+
+  # skip over files which don't require the license header
+  skip=""
+  for re in "${skip_regexes[@]}"
+  do
+    grep -Eq "$re" <<< "$file" && skip="yes" && break
+  done
+  # shellcheck disable=SC2059
+  [ -n "$skip" ] && printf "skipping %s" "$file" && continue
+
+  # shellcheck disable=SC2059
+  printf "checking %s\n" "$file"
+
+  # determine the the the file was introduced and the year it was most recently modified
+  first_year=""
+  recent_year=""
+  while read -r line
+  do
+    if [ -z "$recent_year" ]
+    then
+      recent_year="$line"
+    else
+      first_year="$line"
+    fi
+  done <<< "$(git log --follow --pretty=format:"%ad" --date=format:'%Y' "$file" | sed -n '1p;$p')"
+
+  # assume current year for both values if git log didn't find anything (new file)
+  [ -z "$first_year" ] && [ -z "$recent_year" ] && first_year=$(date '+%Y') && recent_year=$(date '+%Y')
+
+  # shellcheck disable=SC2059
+  copyright_line=$(printf "${copyright_template}" "$first_year" "$recent_year")
+
+  # collect the first few lines of the file
+  head=$(head "$file")
+
+  # check the file head
+  failed=0
+  grep -Eq "${leading_comment}${copyright_line}" <<< "$head" || ((failed+=1))
+  grep -Eq "${leading_comment}${arr_line}"       <<< "$head" || ((failed+=2))
+  grep -Eq "${leading_comment}${spdx_line}"      <<< "$head" || ((failed+=4))
+
+  if [ "$failed" -gt 0 ]
+  then
+    problem_files+=("$file")
+    problem_headers+=("${copyright_line//\\/}\n${arr_line//\\/}\n${spdx_line//\\/}")
+  fi
+done
+
+# print a report if necessary
+if [ "${#problem_files[@]}" -gt 0 ]
+then
+  printf "\nThe following files need to have their license header updated:\n\n"
+
+  for i in $(seq 0 $(( ${#problem_files[@]} - 1 )) )
+  do
+    printf '%s\n' "${problem_files[$i]}"
+    printf -- '-%.0s' {1..40}
+    # shellcheck disable=SC2059
+    printf "\n${problem_headers[$i]}\n\n"
+  done
+
+  exit 1
+fi

--- a/.github/workflows/license_header_check.yml
+++ b/.github/workflows/license_header_check.yml
@@ -11,7 +11,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: license check
         run: |

--- a/.github/workflows/license_header_check.yml
+++ b/.github/workflows/license_header_check.yml
@@ -1,0 +1,19 @@
+#  Copyright (c) Juniper Networks, Inc., 2024-2024.
+#  All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+name: Go package
+
+on: [push]
+
+jobs:
+  license-header-check:
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      - name: license check
+        run: |
+          git fetch origin main --depth 1
+          make fumpt-check

--- a/.github/workflows/license_header_check.yml
+++ b/.github/workflows/license_header_check.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - name: license check
+      - name: license header check
         run: |
           git fetch origin main --depth 1
           make fumpt-check

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-all: compliance-check verify unit-tests integration-tests
+# Copyright (c) Juniper Networks, Inc., 2022-2024.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+all: compliance-check license-header-check verify unit-tests integration-tests
 
 check-repo-clean:
 	git update-index --refresh && git diff-index --quiet HEAD --
@@ -9,6 +13,8 @@ compliance:
 
 compliance-check: compliance check-repo-clean
 
+license-header-check:
+	@sh -c "$(CURDIR)/.ci/scripts/license_header_check.sh"
 
 fast-check: verify unit-tests
 
@@ -35,4 +41,4 @@ lint-staticcheck:
 vet:
 	go vet -v ./apstra/...
 
-.PHONY: all fmt-check lint lint-revive lint-staticcheck unit-tests verify vet
+.PHONY: all fmt-check license-header-check lint lint-revive lint-staticcheck unit-tests verify vet


### PR DESCRIPTION
The policy:

https://core.juniper.net/sites/legal/ip/opensource/docs/palamida_guide_submitters.pdf