### PR TITLE
Gofumpt entire project

### DIFF
--- a/apstra/api_blueprints_deploy.go
+++ b/apstra/api_blueprints_deploy.go
@@ -15,8 +15,10 @@ const (
 	apiUrlBlueprintRevisions = apiUrlBlueprintById + apiUrlPathDelim + "revisions"
 )
 
-type DeployStatus int
-type deployStatus string
+type (
+	DeployStatus int
+	deployStatus string
+)
 
 const (
 	DeployStatusSuccess = DeployStatus(iota)

--- a/apstra/api_design_configlet_structures.go
+++ b/apstra/api_design_configlet_structures.go
@@ -13,8 +13,10 @@ import (
 //'sonic': ('system', 'file', 'frr', 'ospf'),
 //}
 
-type PlatformOS int
-type platformOS string
+type (
+	PlatformOS int
+	platformOS string
+)
 
 const (
 	PlatformOSCumulus = PlatformOS(iota)
@@ -146,8 +148,10 @@ func AllPlatformOSes() []PlatformOS {
 	}
 }
 
-type ConfigletSection int
-type configletSection string
+type (
+	ConfigletSection int
+	configletSection string
+)
 
 const (
 	ConfigletSectionSystem = ConfigletSection(iota)

--- a/apstra/api_design_configlets_test.go
+++ b/apstra/api_design_configlets_test.go
@@ -60,7 +60,6 @@ func TestCreateUpdateGetDeleteConfiglet(t *testing.T) {
 			RefArchs:    c.Data.RefArchs,
 			Generators:  c.Data.Generators,
 		})
-
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/apstra/api_design_interface_maps_test.go
+++ b/apstra/api_design_interface_maps_test.go
@@ -192,5 +192,4 @@ func TestGetInterfaceMapByName(t *testing.T) {
 		}
 		log.Printf("%s <---> %s", interfaceMap.Data.LogicalDeviceId, interfaceMap.Data.DeviceProfileId)
 	}
-
 }

--- a/apstra/api_design_logical_devices.go
+++ b/apstra/api_design_logical_devices.go
@@ -20,8 +20,10 @@ const (
 	PortIndexingSchemaAbsolute  = "absolute"
 )
 
-type LogicalDevicePortRoleFlags uint16
-type logicalDevicePortRole string
+type (
+	LogicalDevicePortRoleFlags uint16
+	logicalDevicePortRole      string
+)
 
 // class PortGroupSchema (scotch/schemas/logical_device.py) specifies:
 // validate=validate.OneOf(

--- a/apstra/api_design_rack_types.go
+++ b/apstra/api_design_rack_types.go
@@ -13,8 +13,10 @@ const (
 	apiUrlDesignRackTypeById    = apiUrlDesignRackTypesPrefix + "%s"
 )
 
-type AccessRedundancyProtocol int
-type accessRedundancyProtocol string
+type (
+	AccessRedundancyProtocol int
+	accessRedundancyProtocol string
+)
 
 const (
 	AccessRedundancyProtocolNone = AccessRedundancyProtocol(iota)
@@ -26,8 +28,10 @@ const (
 	accessRedundancyProtocolUnknown = "unknown redundancy protocol '%d'"
 )
 
-type LeafRedundancyProtocol int
-type leafRedundancyProtocol string
+type (
+	LeafRedundancyProtocol int
+	leafRedundancyProtocol string
+)
 
 const (
 	LeafRedundancyProtocolNone = LeafRedundancyProtocol(iota)
@@ -41,8 +45,10 @@ const (
 	leafRedundancyProtocolUnknown = "unknown type %d"
 )
 
-type FabricConnectivityDesign int
-type fabricConnectivityDesign string
+type (
+	FabricConnectivityDesign int
+	fabricConnectivityDesign string
+)
 
 const (
 	FabricConnectivityDesignL3Clos = FabricConnectivityDesign(iota)
@@ -54,8 +60,10 @@ const (
 	fabricConnectivityDesignUnknown     = "unknown connectivity design '%d'"
 )
 
-type FeatureSwitch int
-type featureSwitch string
+type (
+	FeatureSwitch int
+	featureSwitch string
+)
 
 const (
 	FeatureSwitchDisabled = FeatureSwitch(iota)
@@ -67,8 +75,10 @@ const (
 	featureSwitchUnknown  = "unknown feature switch state '%d'"
 )
 
-type SystemManagementLevel int
-type systemManagementLevel string
+type (
+	SystemManagementLevel int
+	systemManagementLevel string
+)
 
 const (
 	SystemManagementLevelUnmanaged = SystemManagementLevel(iota)
@@ -84,8 +94,10 @@ const (
 	systemManagementLevelUnknown       = "unknown generic system management level '%d'"
 )
 
-type RackLinkAttachmentType int
-type rackLinkAttachmentType string
+type (
+	RackLinkAttachmentType int
+	rackLinkAttachmentType string
+)
 
 const (
 	RackLinkAttachmentTypeSingle = RackLinkAttachmentType(iota)
@@ -97,8 +109,10 @@ const (
 	rackLinkAttachmentTypeUnknown = "unknown link attachment scheme '%d'"
 )
 
-type RackLinkLagMode int
-type rackLinkLagMode string
+type (
+	RackLinkLagMode int
+	rackLinkLagMode string
+)
 
 const (
 	RackLinkLagModeNone = RackLinkLagMode(iota)
@@ -114,8 +128,10 @@ const (
 	rackLinkLagModeUnknown = "unknown lag mode '%d'"
 )
 
-type RackLinkSwitchPeer int
-type rackLinkSwitchPeer string
+type (
+	RackLinkSwitchPeer int
+	rackLinkSwitchPeer string
+)
 
 const (
 	RackLinkSwitchPeerNone = RackLinkSwitchPeer(iota)
@@ -314,6 +330,7 @@ func (o SystemManagementLevel) String() string {
 func (o systemManagementLevel) string() string {
 	return string(o)
 }
+
 func (o systemManagementLevel) parse() (int, error) {
 	switch o {
 	case systemManagementLevelUnmanaged:
@@ -347,6 +364,7 @@ func (o RackLinkAttachmentType) String() string {
 func (o rackLinkAttachmentType) string() string {
 	return string(o)
 }
+
 func (o rackLinkAttachmentType) parse() (int, error) {
 	switch o {
 	case rackLinkAttachmentTypeSingle:
@@ -384,12 +402,12 @@ func (o *RackLinkLagMode) FromString(in string) error {
 	}
 	*o = RackLinkLagMode(i)
 	return nil
-
 }
 
 func (o rackLinkLagMode) string() string {
 	return string(o)
 }
+
 func (o rackLinkLagMode) parse() (int, error) {
 	switch o {
 	case rackLinkLagModeNone:
@@ -434,6 +452,7 @@ func (o *RackLinkSwitchPeer) FromString(in string) error {
 func (o rackLinkSwitchPeer) string() string {
 	return string(o)
 }
+
 func (o rackLinkSwitchPeer) parse() (int, error) {
 	switch o {
 	case rackLinkSwitchPeerNone:

--- a/apstra/api_resources_pools.go
+++ b/apstra/api_resources_pools.go
@@ -2,8 +2,10 @@ package apstra
 
 import "fmt"
 
-type PoolStatus int
-type poolStatus string
+type (
+	PoolStatus int
+	poolStatus string
+)
 
 const (
 	PoolStatusUnused = PoolStatus(iota)

--- a/apstra/api_system_agent_profiles.go
+++ b/apstra/api_system_agent_profiles.go
@@ -236,7 +236,7 @@ func (o *Client) getAgentProfileByLabel(ctx context.Context, label string) (*Age
 		return nil, convertTtaeToAceWherePossible(err)
 	}
 
-	found := -1 //slice index where the matching System Agent Profile can be found
+	found := -1 // slice index where the matching System Agent Profile can be found
 	for i, sap := range response.Items {
 		if sap.Label == label {
 			if found >= 0 {

--- a/apstra/api_system_agent_profiles_test.go
+++ b/apstra/api_system_agent_profiles_test.go
@@ -7,9 +7,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"log"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateListGetDeleteSystemAgentProfile(t *testing.T) {

--- a/apstra/api_system_agents.go
+++ b/apstra/api_system_agents.go
@@ -163,7 +163,6 @@ func (o rawAgentJobState) parse() int {
 	default:
 		return int(AgentJobStateUnknown)
 	}
-
 }
 
 type AgentJobType int
@@ -223,7 +222,6 @@ func (o rawAgentJobType) parse() int {
 	default:
 		return int(AgentJobTypeUnknown)
 	}
-
 }
 
 type AgentPlatform int
@@ -296,7 +294,6 @@ func (o AgentCxnState) String() string {
 	default:
 		return fmt.Sprintf(agentCxnStateUnknown, o)
 	}
-
 }
 
 type rawAgentCxnState string
@@ -328,7 +325,7 @@ type AgentPackages map[string]string
 
 func (o *AgentPackages) raw() rawAgentPackages {
 	// todo: one of these lines causes 'null' in JSON output, while the other causes '[]' ... which one is correct for the API?
-	//raw := rawAgentPackages{}
+	// raw := rawAgentPackages{}
 	var raw rawAgentPackages
 	for k, v := range *o {
 		raw = append(raw, k+apstraSystemAgentPlatformStringSep+v)
@@ -1031,7 +1028,7 @@ func (o *Client) systemAgentWaitForConnection(ctx context.Context, agentId Objec
 		}
 
 		switch agentInfo.Status.ConnectionState {
-		case AgentCxnStateNone: //onbox agents don't "connect"
+		case AgentCxnStateNone: // onbox agents don't "connect"
 			return nil
 		case AgentCxnStateConnected:
 			return nil

--- a/apstra/api_systems_configuration.go
+++ b/apstra/api_systems_configuration.go
@@ -17,8 +17,8 @@ var _ json.Unmarshaler = new(SystemConfig)
 
 type SystemConfig struct {
 	SystemId ObjectId
-	//DeployState                   string
-	//ConfigurationServiceState     string
+	// DeployState                   string
+	// ConfigurationServiceState     string
 	LastBootTime                  time.Time
 	Deviated                      bool
 	ErrorMessage                  *string
@@ -33,8 +33,8 @@ type SystemConfig struct {
 func (o *SystemConfig) UnmarshalJSON(bytes []byte) error {
 	var raw struct {
 		SystemId ObjectId `json:"system_id"`
-		//DeployState                   string   `json:"deploy_state"`
-		//ConfigurationServiceState     string   `json:"configuration_service_state"`
+		// DeployState                   string   `json:"deploy_state"`
+		// ConfigurationServiceState     string   `json:"configuration_service_state"`
 		LastBootTime                  float64 `json:"last_boot_time"`
 		Deviated                      bool    `json:"deviated"`
 		ErrorMessage                  string  `json:"error_message,omitempty"`

--- a/apstra/api_telemetry_services_test.go
+++ b/apstra/api_telemetry_services_test.go
@@ -6,9 +6,10 @@ package apstra
 import (
 	"bytes"
 	"context"
-	"github.com/stretchr/testify/require"
 	"log"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetTelemetryServicesDeviceMapping(t *testing.T) {

--- a/apstra/int_pool.go
+++ b/apstra/int_pool.go
@@ -203,12 +203,12 @@ type rawIntRange struct {
 }
 
 func (o rawIntRange) first() uint32 {
-	//TODO implement me
+	// TODO implement me
 	return o.First
 }
 
 func (o rawIntRange) last() uint32 {
-	//TODO implement me
+	// TODO implement me
 	return o.Last
 }
 
@@ -248,7 +248,7 @@ func (o *Client) createIntPool(ctx context.Context, in *IntPoolRequest, apiUrlRe
 	response := &objectIdResponse{}
 	err := o.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodPost,
-		urlStr:      apiUrlResourcePool, //Will be apiUrlResourcesAsnPool or apiUrlResourcesVniPool
+		urlStr:      apiUrlResourcePool, // Will be apiUrlResourcesAsnPool or apiUrlResourcesVniPool
 		apiInput:    in.raw(),
 		apiResponse: response,
 	})
@@ -264,7 +264,7 @@ func (o *Client) listIntPoolIds(ctx context.Context, apiUrlResourcePool string) 
 	}
 	err := o.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodOptions,
-		urlStr:      apiUrlResourcePool, //Will be apiUrlResourcesAsnPool or apiUrlResourcesVniPool
+		urlStr:      apiUrlResourcePool, // Will be apiUrlResourcesAsnPool or apiUrlResourcesVniPool
 		apiResponse: &response,
 	})
 	if err != nil {
@@ -296,7 +296,7 @@ func (o *Client) getIntPool(ctx context.Context, apiUrlResourcePoolById string, 
 	response := &rawIntPool{}
 	err := o.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodGet,
-		urlStr:      fmt.Sprintf(apiUrlResourcePoolById, poolId), //ApiUrl
+		urlStr:      fmt.Sprintf(apiUrlResourcePoolById, poolId), // ApiUrl
 		apiResponse: response,
 	})
 	if err != nil {

--- a/apstra/query_engine.go
+++ b/apstra/query_engine.go
@@ -23,9 +23,11 @@ type QEQuery interface {
 	setRawResult([]byte)
 }
 
-var _ QEQuery = &PathQuery{}
-var _ QEQuery = &MatchQuery{}
-var _ QEQuery = &RawQuery{}
+var (
+	_ QEQuery = &PathQuery{}
+	_ QEQuery = &MatchQuery{}
+	_ QEQuery = &RawQuery{}
+)
 
 type QEEType int
 
@@ -253,9 +255,11 @@ func (o *PathQuery) addElement(elementType string, attributes []QEEAttribute) *P
 func (o *PathQuery) Node(attributes []QEEAttribute) *PathQuery {
 	return o.addElement(qEETypeNode, attributes)
 }
+
 func (o *PathQuery) Out(attributes []QEEAttribute) *PathQuery {
 	return o.addElement(qEETypeOut, attributes)
 }
+
 func (o *PathQuery) In(attributes []QEEAttribute) *PathQuery {
 	return o.addElement(qEETypeIn, attributes)
 }
@@ -305,10 +309,9 @@ type MatchQuery struct {
 	rawResult     []byte
 }
 
-//func (o *MatchQuery) Having(v QEAttrVal) *MatchQuery          {} // todo
-//func (o *MatchQuery) Where(v QEAttrVal) *MatchQuery           {} // todo
-//func (o *MatchQuery) EnsureDifferent(v QEAttrVal) *MatchQuery {} // todo
-
+// func (o *MatchQuery) Having(v QEAttrVal) *MatchQuery          {} // todo
+// func (o *MatchQuery) Where(v QEAttrVal) *MatchQuery           {} // todo
+// func (o *MatchQuery) EnsureDifferent(v QEAttrVal) *MatchQuery {} // todo
 func (o *MatchQuery) Distinct(distinct MatchQueryDistinct) *MatchQuery {
 	o.addElement("distinct", distinct)
 	return o
@@ -325,7 +328,6 @@ func (o *MatchQuery) addElement(t string, v QEAttrVal) *MatchQuery {
 	}
 	o.firstElement.getLast().next = &newElement
 	return o
-
 }
 
 func (o *MatchQuery) getBlueprintType() BlueprintType {

--- a/apstra/query_relationship.go
+++ b/apstra/query_relationship.go
@@ -58,8 +58,10 @@ const (
 	relationshipTypeUnknown           = "unknown node type %d"
 )
 
-type RelationshipType int
-type relationshipType string
+type (
+	RelationshipType int
+	relationshipType string
+)
 
 func (o RelationshipType) String() string {
 	switch o {

--- a/apstra/stream_target.go
+++ b/apstra/stream_target.go
@@ -8,12 +8,13 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"google.golang.org/protobuf/proto"
 	"io"
 	"net"
 	"strconv"
 	"strings"
 	"sync"
+
+	"google.golang.org/protobuf/proto"
 )
 
 const (

--- a/apstra/streaming-telemetry.pb.go
+++ b/apstra/streaming-telemetry.pb.go
@@ -7711,6 +7711,7 @@ var (
 		(*AosSequencedMessage)(nil),              // 75: aos.streaming.AosSequencedMessage
 	}
 )
+
 var file_apstra_streaming_telemetry_proto_depIdxs = []int32{
 	0,  // 0: aos.streaming.DeviceStateEvent.state:type_name -> aos.streaming.DeviceState
 	1,  // 1: aos.streaming.TrafficEvent.node_role:type_name -> aos.streaming.Feature

--- a/apstra/streaming-telemetry.pb.go
+++ b/apstra/streaming-telemetry.pb.go
@@ -10,10 +10,11 @@
 package apstra
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -7628,86 +7629,88 @@ func file_apstra_streaming_telemetry_proto_rawDescGZIP() []byte {
 	return file_apstra_streaming_telemetry_proto_rawDescData
 }
 
-var file_apstra_streaming_telemetry_proto_enumTypes = make([]protoimpl.EnumInfo, 22)
-var file_apstra_streaming_telemetry_proto_msgTypes = make([]protoimpl.MessageInfo, 54)
-var file_apstra_streaming_telemetry_proto_goTypes = []interface{}{
-	(DeviceState)(0),                         // 0: aos.streaming.DeviceState
-	(Feature)(0),                             // 1: aos.streaming.Feature
-	(StreamingType)(0),                       // 2: aos.streaming.StreamingType
-	(StreamingProtocol)(0),                   // 3: aos.streaming.StreamingProtocol
-	(StreamingStatus)(0),                     // 4: aos.streaming.StreamingStatus
-	(StreamingSequencingMode)(0),             // 5: aos.streaming.StreamingSequencingMode
-	(BgpSessionAddressFamily)(0),             // 6: aos.streaming.BgpSessionAddressFamily
-	(LinkStatus)(0),                          // 7: aos.streaming.LinkStatus
-	(MacState)(0),                            // 8: aos.streaming.MacState
-	(ArpState)(0),                            // 9: aos.streaming.ArpState
-	(MlagDomainState)(0),                     // 10: aos.streaming.MlagDomainState
-	(MlagIntfState)(0),                       // 11: aos.streaming.MlagIntfState
-	(RouteState)(0),                          // 12: aos.streaming.RouteState
-	(AlertSeverity)(0),                       // 13: aos.streaming.AlertSeverity
-	(RouteEntryStatus)(0),                    // 14: aos.streaming.RouteEntryStatus
-	(NextHopStatus)(0),                       // 15: aos.streaming.NextHopStatus
-	(RouteType)(0),                           // 16: aos.streaming.RouteType
-	(DeploymentStatus)(0),                    // 17: aos.streaming.DeploymentStatus
-	(StreamingAlertReason)(0),                // 18: aos.streaming.StreamingAlertReason
-	(BgpSessionState)(0),                     // 19: aos.streaming.BgpSessionState
-	(AggregationType)(0),                     // 20: aos.streaming.AggregationType
-	(HeadroomType)(0),                        // 21: aos.streaming.HeadroomType
-	(*DeviceStateEvent)(nil),                 // 22: aos.streaming.DeviceStateEvent
-	(*TrafficEvent)(nil),                     // 23: aos.streaming.TrafficEvent
-	(*StreamingEvent)(nil),                   // 24: aos.streaming.StreamingEvent
-	(*CablePeerEvent)(nil),                   // 25: aos.streaming.CablePeerEvent
-	(*BGPNeighborEvent)(nil),                 // 26: aos.streaming.BGPNeighborEvent
-	(*LinkStatusEvent)(nil),                  // 27: aos.streaming.LinkStatusEvent
-	(*MacEvent)(nil),                         // 28: aos.streaming.MacEvent
-	(*ArpEvent)(nil),                         // 29: aos.streaming.ArpEvent
-	(*LagEvent)(nil),                         // 30: aos.streaming.LagEvent
-	(*MlagEvent)(nil),                        // 31: aos.streaming.MlagEvent
-	(*ExtensibleServiceEvent)(nil),           // 32: aos.streaming.ExtensibleServiceEvent
-	(*RouteEvent)(nil),                       // 33: aos.streaming.RouteEvent
-	(*EvpnType3RouteEvent)(nil),              // 34: aos.streaming.EvpnType3RouteEvent
-	(*ActiveFloodlistEvent)(nil),             // 35: aos.streaming.ActiveFloodlistEvent
-	(*EvpnType5RouteEvent)(nil),              // 36: aos.streaming.EvpnType5RouteEvent
-	(*Event)(nil),                            // 37: aos.streaming.Event
-	(*HostnameAlert)(nil),                    // 38: aos.streaming.HostnameAlert
-	(*ConfigDeviationAlert)(nil),             // 39: aos.streaming.ConfigDeviationAlert
-	(*LivenessAlert)(nil),                    // 40: aos.streaming.LivenessAlert
-	(*ExtensibleAlert)(nil),                  // 41: aos.streaming.ExtensibleAlert
-	(*DeploymentAlert)(nil),                  // 42: aos.streaming.DeploymentAlert
-	(*BlueprintRenderingAlert)(nil),          // 43: aos.streaming.BlueprintRenderingAlert
-	(*RouteAlert)(nil),                       // 44: aos.streaming.RouteAlert
-	(*LagAlert)(nil),                         // 45: aos.streaming.LagAlert
-	(*StreamingAlert)(nil),                   // 46: aos.streaming.StreamingAlert
-	(*CablePeerMismatchAlert)(nil),           // 47: aos.streaming.CablePeerMismatchAlert
-	(*BGPNeighborMismatchAlert)(nil),         // 48: aos.streaming.BGPNeighborMismatchAlert
-	(*InterfaceLinkStatusMismatchAlert)(nil), // 49: aos.streaming.InterfaceLinkStatusMismatchAlert
-	(*CountersAlert)(nil),                    // 50: aos.streaming.CountersAlert
-	(*KeyValuePair)(nil),                     // 51: aos.streaming.KeyValuePair
-	(*ProbeAlert)(nil),                       // 52: aos.streaming.ProbeAlert
-	(*ConfigMismatchAlert)(nil),              // 53: aos.streaming.ConfigMismatchAlert
-	(*HeadroomAlert)(nil),                    // 54: aos.streaming.HeadroomAlert
-	(*MacAlert)(nil),                         // 55: aos.streaming.MacAlert
-	(*ArpAlert)(nil),                         // 56: aos.streaming.ArpAlert
-	(*MlagAlert)(nil),                        // 57: aos.streaming.MlagAlert
-	(*TestAlert)(nil),                        // 58: aos.streaming.TestAlert
-	(*InterfaceCounters)(nil),                // 59: aos.streaming.InterfaceCounters
-	(*SystemInfo)(nil),                       // 60: aos.streaming.SystemInfo
-	(*ProcessInfo)(nil),                      // 61: aos.streaming.ProcessInfo
-	(*FileInfo)(nil),                         // 62: aos.streaming.FileInfo
-	(*SysResourceCounters)(nil),              // 63: aos.streaming.SysResourceCounters
-	(*Tag)(nil),                              // 64: aos.streaming.Tag
-	(*Field)(nil),                            // 65: aos.streaming.Field
-	(*ProbeProperty)(nil),                    // 66: aos.streaming.ProbeProperty
-	(*InterfaceCountersUtilization)(nil),     // 67: aos.streaming.InterfaceCountersUtilization
-	(*SystemInterfaceUtilization)(nil),       // 68: aos.streaming.SystemInterfaceUtilization
-	(*ProbeMessage)(nil),                     // 69: aos.streaming.ProbeMessage
-	(*GenericPerfmonMessage)(nil),            // 70: aos.streaming.GenericPerfmonMessage
-	(*ProbeData)(nil),                        // 71: aos.streaming.ProbeData
-	(*PerfMon)(nil),                          // 72: aos.streaming.PerfMon
-	(*Alert)(nil),                            // 73: aos.streaming.Alert
-	(*AosMessage)(nil),                       // 74: aos.streaming.AosMessage
-	(*AosSequencedMessage)(nil),              // 75: aos.streaming.AosSequencedMessage
-}
+var (
+	file_apstra_streaming_telemetry_proto_enumTypes = make([]protoimpl.EnumInfo, 22)
+	file_apstra_streaming_telemetry_proto_msgTypes  = make([]protoimpl.MessageInfo, 54)
+	file_apstra_streaming_telemetry_proto_goTypes   = []interface{}{
+		(DeviceState)(0),                         // 0: aos.streaming.DeviceState
+		(Feature)(0),                             // 1: aos.streaming.Feature
+		(StreamingType)(0),                       // 2: aos.streaming.StreamingType
+		(StreamingProtocol)(0),                   // 3: aos.streaming.StreamingProtocol
+		(StreamingStatus)(0),                     // 4: aos.streaming.StreamingStatus
+		(StreamingSequencingMode)(0),             // 5: aos.streaming.StreamingSequencingMode
+		(BgpSessionAddressFamily)(0),             // 6: aos.streaming.BgpSessionAddressFamily
+		(LinkStatus)(0),                          // 7: aos.streaming.LinkStatus
+		(MacState)(0),                            // 8: aos.streaming.MacState
+		(ArpState)(0),                            // 9: aos.streaming.ArpState
+		(MlagDomainState)(0),                     // 10: aos.streaming.MlagDomainState
+		(MlagIntfState)(0),                       // 11: aos.streaming.MlagIntfState
+		(RouteState)(0),                          // 12: aos.streaming.RouteState
+		(AlertSeverity)(0),                       // 13: aos.streaming.AlertSeverity
+		(RouteEntryStatus)(0),                    // 14: aos.streaming.RouteEntryStatus
+		(NextHopStatus)(0),                       // 15: aos.streaming.NextHopStatus
+		(RouteType)(0),                           // 16: aos.streaming.RouteType
+		(DeploymentStatus)(0),                    // 17: aos.streaming.DeploymentStatus
+		(StreamingAlertReason)(0),                // 18: aos.streaming.StreamingAlertReason
+		(BgpSessionState)(0),                     // 19: aos.streaming.BgpSessionState
+		(AggregationType)(0),                     // 20: aos.streaming.AggregationType
+		(HeadroomType)(0),                        // 21: aos.streaming.HeadroomType
+		(*DeviceStateEvent)(nil),                 // 22: aos.streaming.DeviceStateEvent
+		(*TrafficEvent)(nil),                     // 23: aos.streaming.TrafficEvent
+		(*StreamingEvent)(nil),                   // 24: aos.streaming.StreamingEvent
+		(*CablePeerEvent)(nil),                   // 25: aos.streaming.CablePeerEvent
+		(*BGPNeighborEvent)(nil),                 // 26: aos.streaming.BGPNeighborEvent
+		(*LinkStatusEvent)(nil),                  // 27: aos.streaming.LinkStatusEvent
+		(*MacEvent)(nil),                         // 28: aos.streaming.MacEvent
+		(*ArpEvent)(nil),                         // 29: aos.streaming.ArpEvent
+		(*LagEvent)(nil),                         // 30: aos.streaming.LagEvent
+		(*MlagEvent)(nil),                        // 31: aos.streaming.MlagEvent
+		(*ExtensibleServiceEvent)(nil),           // 32: aos.streaming.ExtensibleServiceEvent
+		(*RouteEvent)(nil),                       // 33: aos.streaming.RouteEvent
+		(*EvpnType3RouteEvent)(nil),              // 34: aos.streaming.EvpnType3RouteEvent
+		(*ActiveFloodlistEvent)(nil),             // 35: aos.streaming.ActiveFloodlistEvent
+		(*EvpnType5RouteEvent)(nil),              // 36: aos.streaming.EvpnType5RouteEvent
+		(*Event)(nil),                            // 37: aos.streaming.Event
+		(*HostnameAlert)(nil),                    // 38: aos.streaming.HostnameAlert
+		(*ConfigDeviationAlert)(nil),             // 39: aos.streaming.ConfigDeviationAlert
+		(*LivenessAlert)(nil),                    // 40: aos.streaming.LivenessAlert
+		(*ExtensibleAlert)(nil),                  // 41: aos.streaming.ExtensibleAlert
+		(*DeploymentAlert)(nil),                  // 42: aos.streaming.DeploymentAlert
+		(*BlueprintRenderingAlert)(nil),          // 43: aos.streaming.BlueprintRenderingAlert
+		(*RouteAlert)(nil),                       // 44: aos.streaming.RouteAlert
+		(*LagAlert)(nil),                         // 45: aos.streaming.LagAlert
+		(*StreamingAlert)(nil),                   // 46: aos.streaming.StreamingAlert
+		(*CablePeerMismatchAlert)(nil),           // 47: aos.streaming.CablePeerMismatchAlert
+		(*BGPNeighborMismatchAlert)(nil),         // 48: aos.streaming.BGPNeighborMismatchAlert
+		(*InterfaceLinkStatusMismatchAlert)(nil), // 49: aos.streaming.InterfaceLinkStatusMismatchAlert
+		(*CountersAlert)(nil),                    // 50: aos.streaming.CountersAlert
+		(*KeyValuePair)(nil),                     // 51: aos.streaming.KeyValuePair
+		(*ProbeAlert)(nil),                       // 52: aos.streaming.ProbeAlert
+		(*ConfigMismatchAlert)(nil),              // 53: aos.streaming.ConfigMismatchAlert
+		(*HeadroomAlert)(nil),                    // 54: aos.streaming.HeadroomAlert
+		(*MacAlert)(nil),                         // 55: aos.streaming.MacAlert
+		(*ArpAlert)(nil),                         // 56: aos.streaming.ArpAlert
+		(*MlagAlert)(nil),                        // 57: aos.streaming.MlagAlert
+		(*TestAlert)(nil),                        // 58: aos.streaming.TestAlert
+		(*InterfaceCounters)(nil),                // 59: aos.streaming.InterfaceCounters
+		(*SystemInfo)(nil),                       // 60: aos.streaming.SystemInfo
+		(*ProcessInfo)(nil),                      // 61: aos.streaming.ProcessInfo
+		(*FileInfo)(nil),                         // 62: aos.streaming.FileInfo
+		(*SysResourceCounters)(nil),              // 63: aos.streaming.SysResourceCounters
+		(*Tag)(nil),                              // 64: aos.streaming.Tag
+		(*Field)(nil),                            // 65: aos.streaming.Field
+		(*ProbeProperty)(nil),                    // 66: aos.streaming.ProbeProperty
+		(*InterfaceCountersUtilization)(nil),     // 67: aos.streaming.InterfaceCountersUtilization
+		(*SystemInterfaceUtilization)(nil),       // 68: aos.streaming.SystemInterfaceUtilization
+		(*ProbeMessage)(nil),                     // 69: aos.streaming.ProbeMessage
+		(*GenericPerfmonMessage)(nil),            // 70: aos.streaming.GenericPerfmonMessage
+		(*ProbeData)(nil),                        // 71: aos.streaming.ProbeData
+		(*PerfMon)(nil),                          // 72: aos.streaming.PerfMon
+		(*Alert)(nil),                            // 73: aos.streaming.Alert
+		(*AosMessage)(nil),                       // 74: aos.streaming.AosMessage
+		(*AosSequencedMessage)(nil),              // 75: aos.streaming.AosSequencedMessage
+	}
+)
 var file_apstra_streaming_telemetry_proto_depIdxs = []int32{
 	0,  // 0: aos.streaming.DeviceStateEvent.state:type_name -> aos.streaming.DeviceState
 	1,  // 1: aos.streaming.TrafficEvent.node_role:type_name -> aos.streaming.Feature

--- a/apstra/task_monitor.go
+++ b/apstra/task_monitor.go
@@ -413,7 +413,7 @@ func blueprintIdFromUrl(in *url.URL) ObjectId {
 // *getTaskResponse
 func waitForTaskCompletion(bId ObjectId, tId TaskId, mon chan *taskMonitorMonReq) (*getTaskResponse, error) {
 	// todo: restore log message below
-	//debugStr(1, fmt.Sprintf("awaiting completion of blueprint '%s' task '%s", bId, tId))
+	// debugStr(1, fmt.Sprintf("awaiting completion of blueprint '%s' task '%s", bId, tId))
 	// task status update channel (how we'll learn the task is complete
 	reply := make(chan *taskCompleteInfo, 1) // Task Complete Info Channel
 	defer close(reply)
@@ -427,5 +427,4 @@ func waitForTaskCompletion(bId ObjectId, tId TaskId, mon chan *taskMonitorMonReq
 
 	tci := <-reply
 	return tci.status, tci.err
-
 }

--- a/apstra/two_stage_l3_clos_cabling_map.go
+++ b/apstra/two_stage_l3_clos_cabling_map.go
@@ -15,8 +15,10 @@ const (
 	linksBySystemParam = "system_node_id"
 )
 
-type InterfaceType int
-type interfaceType string
+type (
+	InterfaceType int
+	interfaceType string
+)
 
 const (
 	InterfaceTypeEthernet = InterfaceType(iota)
@@ -110,8 +112,10 @@ func (o interfaceType) parse() (int, error) {
 	}
 }
 
-type InterfaceOperationState int
-type interfaceOperationState string
+type (
+	InterfaceOperationState int
+	interfaceOperationState string
+)
 
 const (
 	InterfaceOperationStateNone = InterfaceOperationState(iota)
@@ -169,8 +173,10 @@ func (o interfaceOperationState) parse() (int, error) {
 	}
 }
 
-type LinkRole int
-type linkRole string
+type (
+	LinkRole int
+	linkRole string
+)
 
 const (
 	LinkRoleAccessL3PeerLink = LinkRole(iota)
@@ -303,8 +309,10 @@ func (o linkRole) parse() (int, error) {
 	}
 }
 
-type SystemNodeRole int
-type systemNodeRole string
+type (
+	SystemNodeRole int
+	systemNodeRole string
+)
 
 const (
 	SystemNodeRoleNone = SystemNodeRole(iota)
@@ -390,8 +398,10 @@ func (o systemNodeRole) parse() (int, error) {
 	}
 }
 
-type LinkType int
-type linkType string
+type (
+	LinkType int
+	linkType string
+)
 
 const (
 	LinkTypeAggregateLink = LinkType(iota)

--- a/apstra/two_stage_l3_clos_configlet.go
+++ b/apstra/two_stage_l3_clos_configlet.go
@@ -110,8 +110,7 @@ func (o *TwoStageL3ClosClient) getConfiglet(ctx context.Context, id ObjectId) (*
 	return response, nil
 }
 
-func (o *TwoStageL3ClosClient) getConfigletByName(ctx context.Context, name string) (*rawTwoStageL3ClosConfiglet,
-	error) {
+func (o *TwoStageL3ClosClient) getConfigletByName(ctx context.Context, name string) (*rawTwoStageL3ClosConfiglet, error) {
 	cgs, err := o.getAllConfiglets(ctx)
 	if err != nil {
 		return nil, convertTtaeToAceWherePossible(err)
@@ -138,8 +137,7 @@ func (o *TwoStageL3ClosClient) getConfigletByName(ctx context.Context, name stri
 	}
 }
 
-func (o *TwoStageL3ClosClient) createConfiglet(ctx context.Context, in *rawTwoStageL3ClosConfigletData) (ObjectId,
-	error) {
+func (o *TwoStageL3ClosClient) createConfiglet(ctx context.Context, in *rawTwoStageL3ClosConfigletData) (ObjectId, error) {
 	response := &objectIdResponse{}
 	if len(in.Label) == 0 {
 		in.Label = in.Data.DisplayName
@@ -157,8 +155,7 @@ func (o *TwoStageL3ClosClient) createConfiglet(ctx context.Context, in *rawTwoSt
 	return response.Id, nil
 }
 
-func (o *TwoStageL3ClosClient) updateConfiglet(ctx context.Context, id ObjectId,
-	in *rawTwoStageL3ClosConfigletData) error {
+func (o *TwoStageL3ClosClient) updateConfiglet(ctx context.Context, id ObjectId, in *rawTwoStageL3ClosConfigletData) error {
 	err := o.client.talkToApstra(ctx, &talkToApstraIn{
 		method:   http.MethodPut,
 		urlStr:   fmt.Sprintf(apiUrlBlueprintConfigletsById, o.blueprintId.String(), id),

--- a/apstra/two_stage_l3_clos_connectivity_template_assignment_integration_test.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_assignment_integration_test.go
@@ -136,7 +136,7 @@ func TestAssignClearCtToInterface(t *testing.T) {
 			SetBlueprintType(BlueprintTypeStaging).
 			SetBlueprintId(bpClient.blueprintId).
 			SetClient(bpClient.client).
-			//Node([]QEEAttribute{{"id", QEStringVal(leaf1Id.String())}}).
+			// Node([]QEEAttribute{{"id", QEStringVal(leaf1Id.String())}}).
 			Node([]QEEAttribute{
 				NodeTypeSystem.QEEAttribute(),
 				{"role", QEStringVal("leaf")},

--- a/apstra/two_stage_l3_clos_connectivity_template_integration_test.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_integration_test.go
@@ -8,12 +8,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/go-version"
 	"log"
 	"math/rand"
 	"net"
 	"sort"
 	"testing"
+
+	"github.com/hashicorp/go-version"
 )
 
 func compareCts(t *testing.T, a, b *ConnectivityTemplate, info string) {
@@ -363,7 +364,7 @@ func TestCtLayout(t *testing.T) {
 			Subpolicies: []*ConnectivityTemplatePrimitive{
 				{
 					Attributes: &ConnectivityTemplatePrimitiveAttributesAttachLogicalLink{
-						//SecurityZone:       &sz.Id,
+						// SecurityZone:       &sz.Id,
 						SecurityZone:       &sz.Id,
 						Tagged:             false,
 						Vlan:               &vlan,

--- a/apstra/two_stage_l3_clos_connectivity_template_iota.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_iota.go
@@ -2,8 +2,10 @@ package apstra
 
 import "fmt"
 
-type CtPrimitivePolicyTypeName int
-type ctPrimitivePolicyTypeName string
+type (
+	CtPrimitivePolicyTypeName int
+	ctPrimitivePolicyTypeName string
+)
 
 const (
 	CtPrimitivePolicyTypeNameNone = CtPrimitivePolicyTypeName(iota)
@@ -116,8 +118,10 @@ func (o ctPrimitivePolicyTypeName) parse() (int, error) {
 	}
 }
 
-type CtPrimitiveBgpPeerTo int
-type ctPrimitiveBgpPeerTo string
+type (
+	CtPrimitiveBgpPeerTo int
+	ctPrimitiveBgpPeerTo string
+)
 
 const (
 	CtPrimitiveBgpPeerToLoopback = CtPrimitiveBgpPeerTo(iota)
@@ -170,8 +174,10 @@ func (o ctPrimitiveBgpPeerTo) parse() (int, error) {
 	}
 }
 
-type CtPrimitiveIPv4ProtocolSessionAddressing int
-type ctPrimitiveIPv4ProtocolSessionAddressing string
+type (
+	CtPrimitiveIPv4ProtocolSessionAddressing int
+	ctPrimitiveIPv4ProtocolSessionAddressing string
+)
 
 const (
 	CtPrimitiveIPv4ProtocolSessionAddressingNone = CtPrimitiveIPv4ProtocolSessionAddressing(iota)
@@ -218,8 +224,10 @@ func (o ctPrimitiveIPv4ProtocolSessionAddressing) parse() (int, error) {
 	}
 }
 
-type CtPrimitiveIPv6ProtocolSessionAddressing int
-type ctPrimitiveIPv6ProtocolSessionAddressing string
+type (
+	CtPrimitiveIPv6ProtocolSessionAddressing int
+	ctPrimitiveIPv6ProtocolSessionAddressing string
+)
 
 const (
 	CtPrimitiveIPv6ProtocolSessionAddressingNone = CtPrimitiveIPv6ProtocolSessionAddressing(iota)
@@ -272,8 +280,10 @@ func (o ctPrimitiveIPv6ProtocolSessionAddressing) parse() (int, error) {
 	}
 }
 
-type CtPrimitiveIPv4AddressingType int
-type ctPrimitiveIPv4AddressingType string
+type (
+	CtPrimitiveIPv4AddressingType int
+	ctPrimitiveIPv4AddressingType string
+)
 
 const (
 	CtPrimitiveIPv4AddressingTypeNone     = CtPrimitiveIPv4AddressingType(iota)
@@ -320,8 +330,10 @@ func (o ctPrimitiveIPv4AddressingType) parse() (int, error) {
 	}
 }
 
-type CtPrimitiveIPv6AddressingType int
-type ctPrimitiveIPv6AddressingType string
+type (
+	CtPrimitiveIPv6AddressingType int
+	ctPrimitiveIPv6AddressingType string
+)
 
 const (
 	CtPrimitiveIPv6AddressingTypeLinkLocal = CtPrimitiveIPv6AddressingType(iota)
@@ -374,8 +386,10 @@ func (o ctPrimitiveIPv6AddressingType) parse() (int, error) {
 	}
 }
 
-type CtPrimitiveStatus int
-type ctPrimitiveStatus string
+type (
+	CtPrimitiveStatus int
+	ctPrimitiveStatus string
+)
 
 const (
 	CtPrimitiveStatusAssigned = CtPrimitiveStatus(iota)

--- a/apstra/two_stage_l3_clos_interface_transformation.go
+++ b/apstra/two_stage_l3_clos_interface_transformation.go
@@ -158,7 +158,8 @@ func (o *TwoStageL3ClosClient) GetTransformationIdByIfName(ctx context.Context, 
 func transformByIfName(ifName string, in []struct {
 	Mapping []int  `json:"mapping"`
 	Name    string `json:"name"`
-}) (int, error) {
+},
+) (int, error) {
 	for _, iMapInterface := range in {
 		if iMapInterface.Name != ifName {
 			continue
@@ -171,5 +172,4 @@ func transformByIfName(ifName string, in []struct {
 		errType: ErrNotfound,
 		err:     fmt.Errorf("no mapping for interface %q found in interface map", ifName),
 	}
-
 }

--- a/apstra/two_stage_l3_clos_leaf_server_bonding.go
+++ b/apstra/two_stage_l3_clos_leaf_server_bonding.go
@@ -6,8 +6,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/google/uuid"
 	"net/http"
+
+	"github.com/google/uuid"
 )
 
 const (

--- a/apstra/two_stage_l3_clos_links.go
+++ b/apstra/two_stage_l3_clos_links.go
@@ -32,9 +32,7 @@ func (o *TwoStageL3ClosClient) systemNodesFromLinkIds(ctx context.Context, linkI
 	for _, linkId := range linkIds {
 		linkQuery.Match(
 			new(PathQuery).
-				Node([]QEEAttribute{NodeTypeLink.QEEAttribute(),
-					{"id", QEStringVal(linkId.String())},
-				}).
+				Node([]QEEAttribute{NodeTypeLink.QEEAttribute(), {"id", QEStringVal(linkId.String())}}).
 				In([]QEEAttribute{RelationshipTypeLink.QEEAttribute()}).
 				Node([]QEEAttribute{NodeTypeInterface.QEEAttribute()}).
 				In([]QEEAttribute{RelationshipTypeHostedInterfaces.QEEAttribute()}).

--- a/apstra/two_stage_l3_clos_lock_status.go
+++ b/apstra/two_stage_l3_clos_lock_status.go
@@ -10,8 +10,10 @@ const (
 	apiUrlBlueprintLockStatus = apiUrlBlueprintById + apiUrlPathDelim + "lock-status"
 )
 
-type LockStatus int
-type lockStatus string
+type (
+	LockStatus int
+	lockStatus string
+)
 
 const (
 	LockStatusUnlocked = LockStatus(iota)

--- a/apstra/two_stage_l3_clos_property_sets.go
+++ b/apstra/two_stage_l3_clos_property_sets.go
@@ -31,7 +31,6 @@ type importPropertySetResponse struct {
 }
 
 func (o *TwoStageL3ClosClient) importPropertySet(ctx context.Context, psid ObjectId, keys ...string) (ObjectId, error) {
-
 	importPropertySetUrl, err := url.Parse(fmt.Sprintf(apiUrlBlueprintPropertySets, o.blueprintId.String()))
 	if err != nil {
 		return "", err
@@ -96,7 +95,6 @@ func (o *TwoStageL3ClosClient) getPropertySet(ctx context.Context, psid ObjectId
 }
 
 func (o *TwoStageL3ClosClient) updatePropertySet(ctx context.Context, psid ObjectId, keys ...string) error {
-
 	updateImportedPropertySetUrl, err := url.Parse(fmt.Sprintf(apiUrlBlueprintPropertySet, o.blueprintId.String(), psid.String()))
 	if err != nil {
 		return err

--- a/apstra/two_stage_l3_clos_routing_policies.go
+++ b/apstra/two_stage_l3_clos_routing_policies.go
@@ -13,8 +13,10 @@ const (
 	apiUrlBlueprintRoutingPolicyById     = apiUrlBlueprintRoutingPoliciesPrefix + "%s"
 )
 
-type DcRoutingPolicyType int
-type dcRoutingPolicyType string
+type (
+	DcRoutingPolicyType int
+	dcRoutingPolicyType string
+)
 
 const (
 	DcRoutingPolicyTypeNone = DcRoutingPolicyType(iota)
@@ -75,8 +77,10 @@ func (o dcRoutingPolicyType) parse() (int, error) {
 	}
 }
 
-type PrefixFilterAction int
-type prefixFilterAction string
+type (
+	PrefixFilterAction int
+	prefixFilterAction string
+)
 
 const (
 	PrefixFilterActionNone = PrefixFilterAction(iota)
@@ -153,8 +157,10 @@ func AllPrefixFilterActions() []PrefixFilterAction {
 	}
 }
 
-type DcRoutingPolicyImportPolicy int
-type dcRoutingPolicyImportPolicy string
+type (
+	DcRoutingPolicyImportPolicy int
+	dcRoutingPolicyImportPolicy string
+)
 
 const (
 	DcRoutingPolicyImportPolicyNone = DcRoutingPolicyImportPolicy(iota)

--- a/apstra/two_stage_l3_clos_virtual_networks.go
+++ b/apstra/two_stage_l3_clos_virtual_networks.go
@@ -19,8 +19,10 @@ const (
 	dhcpServiceEnabled  = dhcpServiceMode("dhcpServiceEnabled")
 )
 
-type DhcpServiceEnabled bool
-type dhcpServiceMode string
+type (
+	DhcpServiceEnabled bool
+	dhcpServiceMode    string
+)
 
 func (o DhcpServiceEnabled) raw() dhcpServiceMode {
 	if o {
@@ -52,8 +54,10 @@ func (o dhcpServiceMode) polish() DhcpServiceEnabled {
 //	return o == l3ConnectivityEnabled
 //}
 
-type SviIpRequirement int
-type sviIpRequirement string
+type (
+	SviIpRequirement int
+	sviIpRequirement string
+)
 
 const (
 	SviIpRequirementNone = SviIpRequirement(iota)
@@ -74,9 +78,11 @@ const (
 func (o SviIpRequirement) String() string {
 	return string(o.raw())
 }
+
 func (o SviIpRequirement) int() int {
 	return int(o)
 }
+
 func (o SviIpRequirement) raw() sviIpRequirement {
 	switch o {
 	case SviIpRequirementNone:
@@ -115,8 +121,10 @@ func (o sviIpRequirement) parse() (int, error) {
 	}
 }
 
-type Ipv4Mode int
-type ipv4Mode string
+type (
+	Ipv4Mode int
+	ipv4Mode string
+)
 
 const (
 	Ipv4ModeNone = Ipv4Mode(iota)
@@ -174,8 +182,10 @@ func (o ipv4Mode) parse() (int, error) {
 	}
 }
 
-type Ipv6Mode int
-type ipv6Mode string
+type (
+	Ipv6Mode int
+	ipv6Mode string
+)
 
 const (
 	Ipv6ModeNone = Ipv6Mode(iota)
@@ -239,8 +249,10 @@ func (o ipv6Mode) parse() (int, error) {
 	}
 }
 
-type VnType int
-type vnType string
+type (
+	VnType int
+	vnType string
+)
 
 const (
 	VnTypeExternal = VnType(iota)
@@ -283,9 +295,11 @@ func (o VnType) raw() vnType {
 		return vnType(fmt.Sprintf(vnTypeUnknown, o))
 	}
 }
+
 func (o vnType) string() string {
 	return string(o)
 }
+
 func (o vnType) parse() (int, error) {
 	switch o {
 	case vnTypeExternal:
@@ -315,8 +329,10 @@ func AllVirtualNetworkTypes() []VnType {
 	}
 }
 
-type SystemRole int
-type systemRole string
+type (
+	SystemRole int
+	systemRole string
+)
 
 const (
 	SystemRoleNone = SystemRole(iota)
@@ -488,12 +504,12 @@ func (o *rawSviIp) parse() (*SviIp, error) {
 }
 
 type VnBinding struct {
-	//AccessSwitches []interface `json:"access_switches"`
+	// AccessSwitches []interface `json:"access_switches"`
 	AccessSwitchNodeIds []ObjectId `json:"access_switch_node_ids"`
-	//Role                string     `json:"role"`      // so far: "leaf", possibly graphdb "role" element
+	// Role                string     `json:"role"`      // so far: "leaf", possibly graphdb "role" element
 	SystemId ObjectId `json:"system_id"` // graphdb node id of a leaf (so far) switch
 	VlanId   *Vlan    `json:"vlan_id"`   // optional (auto-assign)
-	//Selected            bool       `json:"selected?"`
+	// Selected            bool       `json:"selected?"`
 	// Tags []interface `json:"tags"` //sent as empty string by 4.1.2 web UI, not seen in 4.1.0 or 4.1.1
 
 	//PodData struct {
@@ -619,15 +635,15 @@ type rawVirtualNetwork struct {
 	VnId                      string          `json:"vn_id,omitempty"` // VNI as a string, null when unset
 	VnType                    vnType          `json:"vn_type"`
 	VirtualMac                string          `json:"virtual_mac,omitempty"`
-	//CreatePolicyTagged      bool            `json:"create_policy_tagged"`
-	//CreatePolicyUntagged    bool            `json:"create_policy_untagged"`
-	//DefaultEndpointTagTypes interface{}     `json:"default_endpoint_tag_types"`    // what is this? not present in 4.1.1 api response
-	//Description             string          `json:"description"`                   // not used in the web UI
-	//FloatingIps             []interface{}   `json:"floating_ips"`                  // seen in 4.1.1 api response
-	//ForceMoveUntaggedEndpoints bool         `json:"force_move_untagged_endpoints"` // not used in post/get with web UI
-	//L3Connectivity          *l3ConnectivityMode `json:"l3_connectivity,omitempty"` // does not appear in 4.1.2 swagger
-	//VniIds                  []interface{}   `json:"vni_ids,omitempty"`             // unknown, sent by web UI as empty list
-	//Endpoints               []interface{}   `json:"endpoints"`                     // unknown, maybe relates to servers, etc?
+	// CreatePolicyTagged      bool            `json:"create_policy_tagged"`
+	// CreatePolicyUntagged    bool            `json:"create_policy_untagged"`
+	// DefaultEndpointTagTypes interface{}     `json:"default_endpoint_tag_types"`    // what is this? not present in 4.1.1 api response
+	// Description             string          `json:"description"`                   // not used in the web UI
+	// FloatingIps             []interface{}   `json:"floating_ips"`                  // seen in 4.1.1 api response
+	// ForceMoveUntaggedEndpoints bool         `json:"force_move_untagged_endpoints"` // not used in post/get with web UI
+	// L3Connectivity          *l3ConnectivityMode `json:"l3_connectivity,omitempty"` // does not appear in 4.1.2 swagger
+	// VniIds                  []interface{}   `json:"vni_ids,omitempty"`             // unknown, sent by web UI as empty list
+	// Endpoints               []interface{}   `json:"endpoints"`                     // unknown, maybe relates to servers, etc?
 }
 
 func (o rawVirtualNetwork) polish() (*VirtualNetwork, error) {
@@ -823,7 +839,6 @@ func (o *TwoStageL3ClosClient) createVirtualNetwork(ctx context.Context, cfg *ra
 		apiInput:    cfg,
 		apiResponse: response,
 	})
-
 	if err != nil {
 		return "", convertTtaeToAceWherePossible(err)
 	}
@@ -841,7 +856,6 @@ func (o *TwoStageL3ClosClient) updateVirtualNetwork(ctx context.Context, id Obje
 		urlStr:   fmt.Sprintf(apiUrlVirtualNetworkById, o.blueprintId, id),
 		apiInput: cfg,
 	})
-
 	if err != nil {
 		return convertTtaeToAceWherePossible(err)
 	}
@@ -854,7 +868,6 @@ func (o *TwoStageL3ClosClient) deleteVirtualNetwork(ctx context.Context, id Obje
 		method: http.MethodDelete,
 		urlStr: fmt.Sprintf(apiUrlVirtualNetworkById, o.blueprintId, id),
 	})
-
 	if err != nil {
 		return convertTtaeToAceWherePossible(err)
 	}


### PR DESCRIPTION
No code changes. Just formatting from `gofumpt`.

This is the big merge I'd been avoiding by slow-rolling "touched files only" formatting enforcement.

The stragglers are now formatted.