### PR TITLE
Add license headers

### DIFF
--- a/.ci/scripts/gofmt_check.sh
+++ b/.ci/scripts/gofmt_check.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright (c) Juniper Networks, Inc., 2024-2024.
+# Copyright (c) Juniper Networks, Inc., 2022-2024.
 # All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.ci/scripts/gofmt_check.sh
+++ b/.ci/scripts/gofmt_check.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Copyright (c) Juniper Networks, Inc., 2024-2024.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 echo -n "Check formatting... "
 require_formatting=$(gofmt -l .)
 

--- a/.ci/scripts/gofumpt_check.sh
+++ b/.ci/scripts/gofumpt_check.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+# Copyright (c) Juniper Networks, Inc., 2024-2024.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 # init array of files which need updating by gofumpt

--- a/.ci/scripts/license_header_check.sh
+++ b/.ci/scripts/license_header_check.sh
@@ -4,10 +4,6 @@
 # All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-git log --follow apstra/helpers.go
-echo
-echo
-
 set -euo pipefail
 
 # files we're not interested in
@@ -61,8 +57,6 @@ do
   # assume current year for both values if git log didn't find anything (new file)
   [ -z "$first_year" ] && first_year=$(date '+%Y')
   [ -z "$recent_year" ] && recent_year=$(date '+%Y')
-
-  echo -n "$first_year-$recent_year  "
 
   # shellcheck disable=SC2059
   copyright_line=$(printf "${copyright_template}" "$first_year" "$recent_year")

--- a/.ci/scripts/license_header_check.sh
+++ b/.ci/scripts/license_header_check.sh
@@ -4,6 +4,10 @@
 # All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+git log --follow apstra/helpers.go
+echo
+echo
+
 set -euo pipefail
 
 # files we're not interested in

--- a/.ci/scripts/license_header_check.sh
+++ b/.ci/scripts/license_header_check.sh
@@ -15,7 +15,7 @@ skip_regexes+=("^Third_Party_Code/.*$")
 skip_regexes+=("^\.gitignore$")
 skip_regexes+=("^\.notices.tpl$")
 
-copyright_template="Copyright \(c\) Juniper Networks, Inc\., %s-%s\."
+copyright_template="Copyright \\(c\\) Juniper Networks, Inc\\., %s-%s\\."
 arr_line="All rights reserved\."
 spdx_line="SPDX-License-Identifier: Apache-2.0"
 leading_comment="[ #/]{0,3}"

--- a/.ci/scripts/license_header_check.sh
+++ b/.ci/scripts/license_header_check.sh
@@ -39,7 +39,7 @@ do
   [ -n "$skip" ] && printf "skipping %s" "$file" && continue
 
   # shellcheck disable=SC2059
-  printf "checking %s\n" "$file"
+  printf "checking %s...  " "$file"
 
   # determine the the the file was introduced and the year it was most recently modified
   first_year=""
@@ -70,8 +70,11 @@ do
   grep -Eq "${leading_comment}${arr_line}"       <<< "$head" || ((failed+=2))
   grep -Eq "${leading_comment}${spdx_line}"      <<< "$head" || ((failed+=4))
 
-  if [ "$failed" -gt 0 ]
+  if [ "$failed" -eq 0 ]
   then
+    echo "ok"
+  else
+    echo "failure reason: $failed"
     problem_files+=("$file")
     problem_headers+=("${copyright_line//\\/}\n${arr_line//\\/}\n${spdx_line//\\/}")
   fi

--- a/.ci/scripts/license_header_check.sh
+++ b/.ci/scripts/license_header_check.sh
@@ -52,10 +52,11 @@ do
     else
       first_year="$line"
     fi
-  done <<< "$(git log --follow --pretty=format:"%ad" --date=format:'%Y' "$file" | sed -n '1p;$p')"
+  done <<< "$((git log --follow --pretty=format:"%ad" --date=format:'%Y' "$file"; echo) | sed -n '1p;$p')"
 
   # assume current year for both values if git log didn't find anything (new file)
-  [ -z "$first_year" ] && [ -z "$recent_year" ] && first_year=$(date '+%Y') && recent_year=$(date '+%Y')
+  [ -z "$first_year" ] && first_year=$(date '+%Y')
+  [ -z "$recent_year" ] && recent_year=$(date '+%Y')
 
   # shellcheck disable=SC2059
   copyright_line=$(printf "${copyright_template}" "$first_year" "$recent_year")

--- a/.ci/scripts/license_header_check.sh
+++ b/.ci/scripts/license_header_check.sh
@@ -58,6 +58,8 @@ do
   [ -z "$first_year" ] && first_year=$(date '+%Y')
   [ -z "$recent_year" ] && recent_year=$(date '+%Y')
 
+  echo -n "$first_year-$recent_year  "
+
   # shellcheck disable=SC2059
   copyright_line=$(printf "${copyright_template}" "$first_year" "$recent_year")
 

--- a/.github/workflows/go_tools.yml
+++ b/.github/workflows/go_tools.yml
@@ -1,3 +1,7 @@
+# Copyright (c) Juniper Networks, Inc., 2023-2024.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 name: Go package
 
 on: [push]

--- a/.github/workflows/license_header_check.yml
+++ b/.github/workflows/license_header_check.yml
@@ -16,4 +16,5 @@ jobs:
       - name: license header check
         run: |
           git fetch origin main
+          git pull --unshallow
           make license-header-check

--- a/.github/workflows/license_header_check.yml
+++ b/.github/workflows/license_header_check.yml
@@ -13,8 +13,14 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - name: license header check
+      - name: fetch main
         run: |
           git fetch origin main
+
+      - name: unshallow
+        run: |
           git pull --unshallow
+
+      - name: license header check
+        run: |
           make license-header-check

--- a/.github/workflows/license_header_check.yml
+++ b/.github/workflows/license_header_check.yml
@@ -16,4 +16,4 @@ jobs:
       - name: license header check
         run: |
           git fetch origin main --depth 1
-          make fumpt-check
+          make license-header-check

--- a/.github/workflows/license_header_check.yml
+++ b/.github/workflows/license_header_check.yml
@@ -15,5 +15,5 @@ jobs:
 
       - name: license header check
         run: |
-          git fetch origin main --depth 1
+          git fetch origin main
           make license-header-check

--- a/apstra/api_anomalies.go
+++ b/apstra/api_anomalies.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_anomalies_integration_test.go
+++ b/apstra/api_anomalies_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package apstra

--- a/apstra/api_blueprints.go
+++ b/apstra/api_blueprints.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_blueprints_deploy.go
+++ b/apstra/api_blueprints_deploy.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_blueprints_deploy_test.go
+++ b/apstra/api_blueprints_deploy_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import "testing"

--- a/apstra/api_blueprints_integration_test.go
+++ b/apstra/api_blueprints_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package apstra

--- a/apstra/api_config.go
+++ b/apstra/api_config.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 const (

--- a/apstra/api_config_audit.go
+++ b/apstra/api_config_audit.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_design.go
+++ b/apstra/api_design.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 const (

--- a/apstra/api_design_configlet_structures.go
+++ b/apstra/api_design_configlet_structures.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_design_configlets.go
+++ b/apstra/api_design_configlets.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_design_configlets_test.go
+++ b/apstra/api_design_configlets_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/api_design_interface_map_digests.go
+++ b/apstra/api_design_interface_map_digests.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_design_interface_map_digests_test.go
+++ b/apstra/api_design_interface_map_digests_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/api_design_interface_maps.go
+++ b/apstra/api_design_interface_maps.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_design_interface_maps_test.go
+++ b/apstra/api_design_interface_maps_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/api_design_logical_devices.go
+++ b/apstra/api_design_logical_devices.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_design_logical_devices_integration_test.go
+++ b/apstra/api_design_logical_devices_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package apstra

--- a/apstra/api_design_logical_devices_unit_test.go
+++ b/apstra/api_design_logical_devices_unit_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_design_rack_types.go
+++ b/apstra/api_design_rack_types.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_design_rack_types_test.go
+++ b/apstra/api_design_rack_types_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/api_design_tags.go
+++ b/apstra/api_design_tags.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_design_tags_test.go
+++ b/apstra/api_design_tags_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/api_design_templates.go
+++ b/apstra/api_design_templates.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_design_templates_test.go
+++ b/apstra/api_design_templates_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package apstra

--- a/apstra/api_device_profiles.go
+++ b/apstra/api_device_profiles.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_device_profiles_modular.go
+++ b/apstra/api_device_profiles_modular.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_device_profiles_modular_test.go
+++ b/apstra/api_device_profiles_modular_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/api_device_profiles_test.go
+++ b/apstra/api_device_profiles_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package apstra

--- a/apstra/api_features.go
+++ b/apstra/api_features.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_features_integration_test.go
+++ b/apstra/api_features_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package apstra

--- a/apstra/api_iba_dashboards.go
+++ b/apstra/api_iba_dashboards.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_iba_dashboards_test.go
+++ b/apstra/api_iba_dashboards_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package apstra

--- a/apstra/api_iba_predefined_probes.go
+++ b/apstra/api_iba_predefined_probes.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_iba_predefined_probes_test.go
+++ b/apstra/api_iba_predefined_probes_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/api_iba_probes.go
+++ b/apstra/api_iba_probes.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_iba_probes_test.go
+++ b/apstra/api_iba_probes_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/api_iba_widgets.go
+++ b/apstra/api_iba_widgets.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_iba_widgets_test.go
+++ b/apstra/api_iba_widgets_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package apstra

--- a/apstra/api_metricdb.go
+++ b/apstra/api_metricdb.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_metricdb_integration_test.go
+++ b/apstra/api_metricdb_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package apstra

--- a/apstra/api_property_sets.go
+++ b/apstra/api_property_sets.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_property_sets_test.go
+++ b/apstra/api_property_sets_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/api_ready.go
+++ b/apstra/api_ready.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_ready_test.go
+++ b/apstra/api_ready_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/api_resources_int.go
+++ b/apstra/api_resources_int.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_resources_int_test.go
+++ b/apstra/api_resources_int_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/api_resources_ip.go
+++ b/apstra/api_resources_ip.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_resources_ip_test.go
+++ b/apstra/api_resources_ip_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/api_resources_pools.go
+++ b/apstra/api_resources_pools.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import "fmt"

--- a/apstra/api_resources_pools_test.go
+++ b/apstra/api_resources_pools_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import "testing"

--- a/apstra/api_streaming_config.go
+++ b/apstra/api_streaming_config.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_streaming_config_test.go
+++ b/apstra/api_streaming_config_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/api_system_agent.go
+++ b/apstra/api_system_agent.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_system_agent_profiles.go
+++ b/apstra/api_system_agent_profiles.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_system_agent_profiles_test.go
+++ b/apstra/api_system_agent_profiles_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/api_system_agent_test.go
+++ b/apstra/api_system_agent_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/api_system_agents.go
+++ b/apstra/api_system_agents.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_system_agents_test.go
+++ b/apstra/api_system_agents_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/api_systems.go
+++ b/apstra/api_systems.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_systems_configuration.go
+++ b/apstra/api_systems_configuration.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_systems_test.go
+++ b/apstra/api_systems_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/api_telemetry_service_registry.go
+++ b/apstra/api_telemetry_service_registry.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_telemetry_service_registry_test.go
+++ b/apstra/api_telemetry_service_registry_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/api_telemetry_services.go
+++ b/apstra/api_telemetry_services.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_telemetry_services_test.go
+++ b/apstra/api_telemetry_services_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/api_user.go
+++ b/apstra/api_user.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_user_test.go
+++ b/apstra/api_user_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/api_version.go
+++ b/apstra/api_version.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_version_test.go
+++ b/apstra/api_version_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/api_versions.go
+++ b/apstra/api_versions.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_versions_test.go
+++ b/apstra/api_versions_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/api_virtual_infra_manager.go
+++ b/apstra/api_virtual_infra_manager.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/api_virtual_infra_manager_test.go
+++ b/apstra/api_virtual_infra_manager_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/client.go
+++ b/apstra/client.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/client_test.go
+++ b/apstra/client_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package apstra

--- a/apstra/compatibility/compatibility.go
+++ b/apstra/compatibility/compatibility.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package compatibility
 
 import (

--- a/apstra/compatibility/constraint.go
+++ b/apstra/compatibility/constraint.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package compatibility
 
 import (

--- a/apstra/compatibility/constraints.go
+++ b/apstra/compatibility/constraints.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package compatibility
 
 import (

--- a/apstra/compatibility/constraints_test.go
+++ b/apstra/compatibility/constraints_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package compatibility_test
 
 import (

--- a/apstra/enum/enum.go
+++ b/apstra/enum/enum.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package enum
 
 import (

--- a/apstra/enum/enum_test.go
+++ b/apstra/enum/enum_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package enum
 
 import (

--- a/apstra/enum/error.go
+++ b/apstra/enum/error.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package enum
 
 import "fmt"

--- a/apstra/freeform.go
+++ b/apstra/freeform.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 type FreeformClient struct {

--- a/apstra/freeform_allocation_groups.go
+++ b/apstra/freeform_allocation_groups.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/freeform_allocation_groups_integration_test.go
+++ b/apstra/freeform_allocation_groups_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/freeform_config_template_assignment.go
+++ b/apstra/freeform_config_template_assignment.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/freeform_config_template_assignment_integration_test.go
+++ b/apstra/freeform_config_template_assignment_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package apstra

--- a/apstra/freeform_config_templates.go
+++ b/apstra/freeform_config_templates.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/freeform_config_templates_integration_test.go
+++ b/apstra/freeform_config_templates_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/freeform_device_profile.go
+++ b/apstra/freeform_device_profile.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/freeform_group_generators.go
+++ b/apstra/freeform_group_generators.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/freeform_group_generators_integration_test.go
+++ b/apstra/freeform_group_generators_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package apstra

--- a/apstra/freeform_link.go
+++ b/apstra/freeform_link.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/freeform_link_integration_test.go
+++ b/apstra/freeform_link_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/freeform_nodes.go
+++ b/apstra/freeform_nodes.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import "context"

--- a/apstra/freeform_nodes_integration_test.go
+++ b/apstra/freeform_nodes_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package apstra

--- a/apstra/freeform_property_sets.go
+++ b/apstra/freeform_property_sets.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/freeform_property_sets_integration_test.go
+++ b/apstra/freeform_property_sets_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/freeform_ra_group_generators.go
+++ b/apstra/freeform_ra_group_generators.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/freeform_ra_group_generators_integration_test.go
+++ b/apstra/freeform_ra_group_generators_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/freeform_ra_local_int_pool_generators.go
+++ b/apstra/freeform_ra_local_int_pool_generators.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/freeform_ra_local_int_pool_generators_integration_test.go
+++ b/apstra/freeform_ra_local_int_pool_generators_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/freeform_ra_local_pools.go
+++ b/apstra/freeform_ra_local_pools.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/freeform_ra_local_pools_integration_test.go
+++ b/apstra/freeform_ra_local_pools_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package apstra

--- a/apstra/freeform_ra_resource.go
+++ b/apstra/freeform_ra_resource.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/freeform_ra_resource_integration_test.go
+++ b/apstra/freeform_ra_resource_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/freeform_ra_resource_unit_test.go
+++ b/apstra/freeform_ra_resource_unit_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/freeform_resource_assignments.go
+++ b/apstra/freeform_resource_assignments.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/freeform_resource_generators.go
+++ b/apstra/freeform_resource_generators.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/freeform_resource_generators_integration_test.go
+++ b/apstra/freeform_resource_generators_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package apstra

--- a/apstra/freeform_resource_groups.go
+++ b/apstra/freeform_resource_groups.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/freeform_resource_groups_integration_test.go
+++ b/apstra/freeform_resource_groups_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/freeform_system.go
+++ b/apstra/freeform_system.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/freeform_system_integration_test.go
+++ b/apstra/freeform_system_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/helpers.go
+++ b/apstra/helpers.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/int_pool.go
+++ b/apstra/int_pool.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/logging.go
+++ b/apstra/logging.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/mutex.go
+++ b/apstra/mutex.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/query_engine.go
+++ b/apstra/query_engine.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/query_engine_test.go
+++ b/apstra/query_engine_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/query_node.go
+++ b/apstra/query_node.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import "fmt"

--- a/apstra/query_relationship.go
+++ b/apstra/query_relationship.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import "fmt"

--- a/apstra/stream_target.go
+++ b/apstra/stream_target.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/streaming-telemetry.pb.go
+++ b/apstra/streaming-telemetry.pb.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 // Copyright (c) 2016 Apstrktr, Inc.  All rights reserved.
 // Apstrktr, Inc. Confidential and Proprietary.
 

--- a/apstra/talk_to_apstra.go
+++ b/apstra/talk_to_apstra.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/talk_to_apstra_test.go
+++ b/apstra/talk_to_apstra_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/task_monitor.go
+++ b/apstra/task_monitor.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/task_monitor_test.go
+++ b/apstra/task_monitor_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/telemetry_query.go
+++ b/apstra/telemetry_query.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/test_clients_aws_test.go
+++ b/apstra/test_clients_aws_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/test_clients_cloudlabs_test.go
+++ b/apstra/test_clients_cloudlabs_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/test_clients_slicer_test.go
+++ b/apstra/test_clients_slicer_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/test_clients_test.go
+++ b/apstra/test_clients_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/test_config_test.go
+++ b/apstra/test_config_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/test_helpers.go
+++ b/apstra/test_helpers.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/test_helpers_test.go
+++ b/apstra/test_helpers_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_anti_affinity_policy.go
+++ b/apstra/two_stage_l3_clos_anti_affinity_policy.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_cabling_map.go
+++ b/apstra/two_stage_l3_clos_cabling_map.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_cabling_map_integration_test.go
+++ b/apstra/two_stage_l3_clos_cabling_map_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/two_stage_l3_clos_cabling_map_unit_test.go
+++ b/apstra/two_stage_l3_clos_cabling_map_unit_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import "testing"

--- a/apstra/two_stage_l3_clos_client.go
+++ b/apstra/two_stage_l3_clos_client.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_client_integration_test.go
+++ b/apstra/two_stage_l3_clos_client_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/two_stage_l3_clos_configlet.go
+++ b/apstra/two_stage_l3_clos_configlet.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_configlet_integration_test.go
+++ b/apstra/two_stage_l3_clos_configlet_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/two_stage_l3_clos_connectivity_template.go
+++ b/apstra/two_stage_l3_clos_connectivity_template.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_connectivity_template_assignment.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_assignment.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_connectivity_template_assignment_integration_test.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_assignment_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/two_stage_l3_clos_connectivity_template_integration_test.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/two_stage_l3_clos_connectivity_template_iota.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_iota.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import "fmt"

--- a/apstra/two_stage_l3_clos_connectivity_template_primitive_attributes.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_primitive_attributes.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_connectivity_template_unit_test.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_unit_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_fabric_addressing_policy.go
+++ b/apstra/two_stage_l3_clos_fabric_addressing_policy.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_fabric_addressing_policy_integration_test.go
+++ b/apstra/two_stage_l3_clos_fabric_addressing_policy_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package apstra

--- a/apstra/two_stage_l3_clos_fabric_settings.go
+++ b/apstra/two_stage_l3_clos_fabric_settings.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_fabric_settings_integration_test.go
+++ b/apstra/two_stage_l3_clos_fabric_settings_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package apstra

--- a/apstra/two_stage_l3_clos_generic_system_loopback.go
+++ b/apstra/two_stage_l3_clos_generic_system_loopback.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_generic_system_loopback_test.go
+++ b/apstra/two_stage_l3_clos_generic_system_loopback_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/two_stage_l3_clos_interface_map.go
+++ b/apstra/two_stage_l3_clos_interface_map.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_interface_map_test.go
+++ b/apstra/two_stage_l3_clos_interface_map_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/two_stage_l3_clos_interface_transformation.go
+++ b/apstra/two_stage_l3_clos_interface_transformation.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_interface_transformation_integration_test.go
+++ b/apstra/two_stage_l3_clos_interface_transformation_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/two_stage_l3_clos_leaf_server_bonding.go
+++ b/apstra/two_stage_l3_clos_leaf_server_bonding.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_leaf_server_bonding_integration_test.go
+++ b/apstra/two_stage_l3_clos_leaf_server_bonding_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package apstra

--- a/apstra/two_stage_l3_clos_links.go
+++ b/apstra/two_stage_l3_clos_links.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_lock_status.go
+++ b/apstra/two_stage_l3_clos_lock_status.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_lock_status_integration_test.go
+++ b/apstra/two_stage_l3_clos_lock_status_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/two_stage_l3_clos_lock_status_test.go
+++ b/apstra/two_stage_l3_clos_lock_status_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import "testing"

--- a/apstra/two_stage_l3_clos_mutex.go
+++ b/apstra/two_stage_l3_clos_mutex.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_mutex_integration_test.go
+++ b/apstra/two_stage_l3_clos_mutex_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package apstra

--- a/apstra/two_stage_l3_clos_policies.go
+++ b/apstra/two_stage_l3_clos_policies.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_policies_test.go
+++ b/apstra/two_stage_l3_clos_policies_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/two_stage_l3_clos_policy_rules.go
+++ b/apstra/two_stage_l3_clos_policy_rules.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_policy_rules_test.go
+++ b/apstra/two_stage_l3_clos_policy_rules_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_property_sets.go
+++ b/apstra/two_stage_l3_clos_property_sets.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_property_sets_test.go
+++ b/apstra/two_stage_l3_clos_property_sets_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/two_stage_l3_clos_racks.go
+++ b/apstra/two_stage_l3_clos_racks.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_racks_integration_test.go
+++ b/apstra/two_stage_l3_clos_racks_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/two_stage_l3_clos_remote_gateways.go
+++ b/apstra/two_stage_l3_clos_remote_gateways.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_remote_gateways_test.go
+++ b/apstra/two_stage_l3_clos_remote_gateways_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/two_stage_l3_clos_resources.go
+++ b/apstra/two_stage_l3_clos_resources.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_resources_test.go
+++ b/apstra/two_stage_l3_clos_resources_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package apstra

--- a/apstra/two_stage_l3_clos_routing_policies.go
+++ b/apstra/two_stage_l3_clos_routing_policies.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_routing_policies_integration_test.go
+++ b/apstra/two_stage_l3_clos_routing_policies_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/two_stage_l3_clos_routing_policies_unit_test.go
+++ b/apstra/two_stage_l3_clos_routing_policies_unit_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_routing_zone_constraints.go
+++ b/apstra/two_stage_l3_clos_routing_zone_constraints.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_routing_zone_constraints_integration_test.go
+++ b/apstra/two_stage_l3_clos_routing_zone_constraints_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package apstra

--- a/apstra/two_stage_l3_clos_security_zones.go
+++ b/apstra/two_stage_l3_clos_security_zones.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_security_zones_integration_test.go
+++ b/apstra/two_stage_l3_clos_security_zones_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/two_stage_l3_clos_subinterface.go
+++ b/apstra/two_stage_l3_clos_subinterface.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_subinterface_integration_test.go
+++ b/apstra/two_stage_l3_clos_subinterface_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package apstra

--- a/apstra/two_stage_l3_clos_subinterface_link.go
+++ b/apstra/two_stage_l3_clos_subinterface_link.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_switch_system_links.go
+++ b/apstra/two_stage_l3_clos_switch_system_links.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_switch_system_links_integration_test.go
+++ b/apstra/two_stage_l3_clos_switch_system_links_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/two_stage_l3_clos_switch_system_links_unit_test.go
+++ b/apstra/two_stage_l3_clos_switch_system_links_unit_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import "testing"

--- a/apstra/two_stage_l3_clos_system_node_info.go
+++ b/apstra/two_stage_l3_clos_system_node_info.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_system_node_info_integration_test.go
+++ b/apstra/two_stage_l3_clos_system_node_info_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/two_stage_l3_clos_tags.go
+++ b/apstra/two_stage_l3_clos_tags.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_tags_integration_test.go
+++ b/apstra/two_stage_l3_clos_tags_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package apstra

--- a/apstra/two_stage_l3_clos_virtual_network_policy.go
+++ b/apstra/two_stage_l3_clos_virtual_network_policy.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_virtual_networks.go
+++ b/apstra/two_stage_l3_clos_virtual_networks.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_virtual_networks_integration_test.go
+++ b/apstra/two_stage_l3_clos_virtual_networks_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/two_stage_l3_clos_virtual_networks_unit_test.go
+++ b/apstra/two_stage_l3_clos_virtual_networks_unit_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/apstra/types.go
+++ b/apstra/types.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import "fmt"

--- a/cmd/example_streaming/main.go
+++ b/cmd/example_streaming/main.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build tools
 
 package tools


### PR DESCRIPTION
This PR adds license headers to each source file.

It also fixes some bugs in the license header CI script. These mostly come down to the fact that the shallow clone used in the CI job doesn't have the whole git history for each file, so it winds up calculating the wrong "file introduced" date.