### PR TITLE
Introduce support for Security Zone loopbacks API

### DIFF
--- a/apstra/compatibility/constraints.go
+++ b/apstra/compatibility/constraints.go
@@ -32,11 +32,11 @@ var (
 	PatchNodeSupportsUnsafeArg = Constraint{
 		constraints: version.MustConstraints(version.NewConstraint(">=" + apstra500)),
 	}
-	TemplateRequestRequiresAntiAffinityPolicy = Constraint{
-		constraints: version.MustConstraints(version.NewConstraint("<=" + apstra420)),
-	}
 	RoutingPolicyExportHasL3EdgeLinks = Constraint{
 		constraints: version.MustConstraints(version.NewConstraint("<" + apstra500)),
+	}
+	SecurityZoneLoopbackApiSupported = Constraint{
+		constraints: version.MustConstraints(version.NewConstraint(">=" + apstra500)),
 	}
 	ServerVersionSupported = Constraint{
 		constraints:             version.MustConstraints(version.NewConstraint(strings.Join(SupportedApiVersions(), ","))),
@@ -45,5 +45,8 @@ var (
 	}
 	SystemManagerHasSkipInterfaceShutdownOnUpgrade = Constraint{
 		constraints: version.MustConstraints(version.NewConstraint(">=" + apstra500)),
+	}
+	TemplateRequestRequiresAntiAffinityPolicy = Constraint{
+		constraints: version.MustConstraints(version.NewConstraint("<=" + apstra420)),
 	}
 )

--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -427,8 +427,8 @@ func testBlueprintE(ctx context.Context, t *testing.T, client *Client) (*TwoStag
 	return bpClient, bpDeleteFunc
 }
 
-// testBlueprintH creates a test blueprint using client and returns a *TwoStageL3ClosClient and a cleanup function
-// which deletes the test blueprint. The blueprint will use a dual-stack fabric and have ipv6 enabled.
+// testBlueprintH creates a test blueprint using client and returns a *TwoStageL3ClosClient.
+// The blueprint will use a dual-stack fabric and have ipv6 enabled.
 func testBlueprintH(ctx context.Context, t *testing.T, client *Client) *TwoStageL3ClosClient {
 	t.Helper()
 

--- a/apstra/query_node.go
+++ b/apstra/query_node.go
@@ -28,6 +28,7 @@ const (
 	NodeTypeRouteTargetPolicy
 	NodeTypeRoutingPolicy
 	NodeTypeSecurityZone
+	NodeTypeSecurityZoneInstance
 	NodeTypeSecurityZonePolicy
 	NodeTypeSystem
 	NodeTypeTag
@@ -57,6 +58,7 @@ const (
 	nodeTypeRouteTargetPolicy      = nodeType("route_target_policy")
 	nodeTypeRoutingPolicy          = nodeType("routing_policy")
 	nodeTypeSecurityZone           = nodeType("security_zone")
+	nodeTypeSecurityZoneInstance   = nodeType("sz_instance")
 	nodeTypeSecurityZonePolicy     = nodeType("security_zone_policy")
 	nodeTypeSystem                 = nodeType("system")
 	nodeTypeTag                    = nodeType("tag")
@@ -115,6 +117,8 @@ func (o NodeType) String() string {
 		return string(nodeTypeRoutingPolicy)
 	case NodeTypeSecurityZone:
 		return string(nodeTypeSecurityZone)
+	case NodeTypeSecurityZoneInstance:
+		return string(nodeTypeSecurityZoneInstance)
 	case NodeTypeSecurityZonePolicy:
 		return string(nodeTypeSecurityZonePolicy)
 	case NodeTypeSystem:

--- a/apstra/two_stage_l3_clos_security_zones_integration_test.go
+++ b/apstra/two_stage_l3_clos_security_zones_integration_test.go
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration
-// +build integration
 
 package apstra
 

--- a/apstra/two_stage_l3_clos_security_zones_loopbacks.go
+++ b/apstra/two_stage_l3_clos_security_zones_loopbacks.go
@@ -1,0 +1,105 @@
+package apstra
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/Juniper/apstra-go-sdk/apstra/compatibility"
+	"net/http"
+	"net/netip"
+)
+
+const apiUrlBlueprintSecurityZoneLoopbacksById = apiUrlBlueprintSecurityZoneById + apiUrlPathDelim + "loopbacks"
+
+var _ json.Marshaler = (*SecurityZoneLoopback)(nil)
+
+// SecurityZoneLoopback is intended to be used with the SetSecurityZoneLoopbacks() method
+// and the apiUrlBlueprintSecurityZoneLoopbacksById API endpoint. It is possible to produce
+// three different outcomes in the rendered JSON for both IPv4Addr and IPv6Addr elements:
+//
+//  1. When the element and its IP and Mask elements are non-nil, a string will be produced
+//     when the struct is marshaled as JSON.
+//  2. When the element is non-nil but contains a nil IP or Mask, a `null` will be produced
+//     when the struct is marshaled as JSON.
+//  3. When the element is nil, no output will be produced for that element when the struct
+//     is marshaled as JSON.
+//
+// Example:
+//
+//	aVal := netip.MustParsePrefix("192.0.2.0/32")
+//	a := apstra.SecurityZoneLoopback{IPv4Addr: &aVal}
+//	b := apstra.SecurityZoneLoopback{IPv4Addr: &netip.Prefix{}}
+//	c := apstra.SecurityZoneLoopback{IPv4Addr: nil}
+//
+//	aJson, _ := json.Marshal(a)
+//	bJson, _ := json.Marshal(b)
+//	cJson, _ := json.Marshal(c)
+//
+//	fmt.Print(string(aJson) + "\n" + string(bJson) + "\n" + string(cJson) + "\n")
+//
+// Output:
+//
+//	{"ipv4_addr":"192.0.2.0/32"}
+//	{"ipv4_addr":null}
+//	{}
+type SecurityZoneLoopback struct {
+	IPv4Addr *netip.Prefix
+	IPv6Addr *netip.Prefix
+}
+
+func (o SecurityZoneLoopback) MarshalJSON() ([]byte, error) {
+	ipInfo := make(map[string]*string)
+
+	if o.IPv4Addr != nil {
+		if o.IPv4Addr.IsValid() {
+			//if o.IPv4Addr.IP != nil || o.IPv4Addr.Mask != nil {
+			ipInfo["ipv4_addr"] = toPtr(o.IPv4Addr.String())
+		} else {
+			ipInfo["ipv4_addr"] = nil
+		}
+	}
+
+	if o.IPv6Addr != nil {
+		if o.IPv6Addr.IsValid() {
+			//if o.IPv6Addr.IP != nil || o.IPv6Addr.Mask != nil {
+			ipInfo["ipv6_addr"] = toPtr(o.IPv6Addr.String())
+		} else {
+			ipInfo["ipv6_addr"] = nil
+		}
+	}
+
+	return json.Marshal(ipInfo)
+}
+
+// SetSecurityZoneLoopbacks takes a map of SecurityZoneLoopback keyed by the loopback interface graph node ID.
+func (o TwoStageL3ClosClient) SetSecurityZoneLoopbacks(ctx context.Context, szId ObjectId, loopbacks map[ObjectId]SecurityZoneLoopback) error {
+	if !compatibility.SecurityZoneLoopbackApiSupported.Check(o.client.apiVersion) {
+		return fmt.Errorf("SetSecurityZoneLoopbacks requires Apstra version %s, have version %s",
+			compatibility.SecurityZoneLoopbackApiSupported, o.client.apiVersion,
+		)
+	}
+
+	var apiInput struct {
+		Loopbacks map[ObjectId]json.RawMessage `json:"loopbacks"`
+	}
+	apiInput.Loopbacks = make(map[ObjectId]json.RawMessage)
+
+	for k, v := range loopbacks {
+		rawJson, err := json.Marshal(v)
+		if err != nil {
+			return err
+		}
+		apiInput.Loopbacks[k] = rawJson
+	}
+
+	err := o.client.talkToApstra(ctx, &talkToApstraIn{
+		method:   http.MethodPatch,
+		urlStr:   fmt.Sprintf(apiUrlBlueprintSecurityZoneLoopbacksById, o.blueprintId, szId),
+		apiInput: apiInput,
+	})
+	if err != nil {
+		return convertTtaeToAceWherePossible(err)
+	}
+
+	return nil
+}

--- a/apstra/two_stage_l3_clos_security_zones_loopbacks.go
+++ b/apstra/two_stage_l3_clos_security_zones_loopbacks.go
@@ -1,12 +1,17 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/Juniper/apstra-go-sdk/apstra/compatibility"
 	"net/http"
 	"net/netip"
+
+	"github.com/Juniper/apstra-go-sdk/apstra/compatibility"
 )
 
 const apiUrlBlueprintSecurityZoneLoopbacksById = apiUrlBlueprintSecurityZoneById + apiUrlPathDelim + "loopbacks"
@@ -52,7 +57,6 @@ func (o SecurityZoneLoopback) MarshalJSON() ([]byte, error) {
 
 	if o.IPv4Addr != nil {
 		if o.IPv4Addr.IsValid() {
-			//if o.IPv4Addr.IP != nil || o.IPv4Addr.Mask != nil {
 			ipInfo["ipv4_addr"] = toPtr(o.IPv4Addr.String())
 		} else {
 			ipInfo["ipv4_addr"] = nil
@@ -61,7 +65,6 @@ func (o SecurityZoneLoopback) MarshalJSON() ([]byte, error) {
 
 	if o.IPv6Addr != nil {
 		if o.IPv6Addr.IsValid() {
-			//if o.IPv6Addr.IP != nil || o.IPv6Addr.Mask != nil {
 			ipInfo["ipv6_addr"] = toPtr(o.IPv6Addr.String())
 		} else {
 			ipInfo["ipv6_addr"] = nil

--- a/apstra/two_stage_l3_clos_security_zones_loopbacks.go
+++ b/apstra/two_stage_l3_clos_security_zones_loopbacks.go
@@ -130,7 +130,7 @@ func (o *TwoStageL3ClosClient) GetSecurityZoneLoopbacks(ctx context.Context, szI
 				Id       ObjectId `json:"id"`
 				IPv4Addr *string  `json:"ipv4_addr"`
 				IPv6Addr *string  `json:"ipv6_addr"`
-			} `json:"n_interface""`
+			} `json:"n_interface"`
 		} `json:"items"`
 	}
 

--- a/apstra/two_stage_l3_clos_security_zones_loopbacks_integration_test.go
+++ b/apstra/two_stage_l3_clos_security_zones_loopbacks_integration_test.go
@@ -1,0 +1,223 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package apstra
+
+import (
+	"context"
+	"fmt"
+	"github.com/Juniper/apstra-go-sdk/apstra/compatibility"
+	"github.com/stretchr/testify/require"
+	"net/netip"
+	"testing"
+)
+
+func TestTwoStageL3ClosClient_SetSecurityZoneLoopbacks(t *testing.T) {
+	ctx := context.Background()
+
+	mustParsePrefixPtr := func(s string) *netip.Prefix {
+		p := netip.MustParsePrefix(s)
+		return &p
+	}
+
+	ipV4PoolId := ObjectId("Private-10_0_0_0-8")
+	ipv4PoolPrefix := netip.MustParsePrefix("10.0.0.0/8")
+
+	ipV6PoolId := ObjectId("Private-fc01-a05-fab-48")
+	ipv6PoolPrefix := netip.MustParsePrefix("fc01:a05:fab::/48")
+
+	type testCase struct {
+		ipv4 *netip.Prefix
+		ipv6 *netip.Prefix
+	}
+
+	persistIpv4 := mustParsePrefixPtr("192.0.2.8/32")
+	persistIpv6 := mustParsePrefixPtr("3fff::8/128")
+	testCases := []testCase{
+		{
+			ipv4: mustParsePrefixPtr("192.0.2.7/32"),
+			ipv6: mustParsePrefixPtr("3fff::7/128"),
+		},
+		{
+			ipv4: &netip.Prefix{},
+			ipv6: &netip.Prefix{},
+		},
+		{
+			ipv4: persistIpv4,
+			ipv6: persistIpv6,
+		},
+		{
+			ipv4: nil,
+			ipv6: nil,
+		},
+	}
+
+	clients, err := getTestClients(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	getLoopbackNodeId := func(t *testing.T, ctx context.Context, bpClient *TwoStageL3ClosClient, systemId, securityZoenId ObjectId) ObjectId {
+		query := new(PathQuery).
+			SetBlueprintId(bpClient.Id()).
+			SetClient(bpClient.client).
+			Node([]QEEAttribute{
+				NodeTypeSystem.QEEAttribute(),
+				{"id", QEStringVal(systemId)},
+			}).
+			Out([]QEEAttribute{RelationshipTypeHostedInterfaces.QEEAttribute()}).
+			Node([]QEEAttribute{
+				NodeTypeInterface.QEEAttribute(),
+				{Key: "if_type", Value: QEStringVal("loopback")},
+				{Key: "name", Value: QEStringVal("n_interface")},
+			}).
+			In([]QEEAttribute{RelationshipTypeMemberInterfaces.QEEAttribute()}).
+			Node([]QEEAttribute{NodeTypeSecurityZoneInstance.QEEAttribute()}).
+			In([]QEEAttribute{RelationshipTypeInstantiatedBy.QEEAttribute()}).
+			Node([]QEEAttribute{
+				NodeTypeSecurityZone.QEEAttribute(),
+				{"id", QEStringVal(securityZoenId)},
+			})
+
+		var response struct {
+			Items []struct {
+				Interface struct {
+					Id ObjectId `json:"id"`
+				} `json:"n_interface"`
+			} `json:"items"`
+		}
+
+		err := query.Do(ctx, &response)
+		require.NoError(t, err)
+		require.Equalf(t, 1, len(response.Items), "expected 1 loopback, found %d", len(response.Items))
+
+		return response.Items[0].Interface.Id
+	}
+
+	getLoopback := func(ctx context.Context, t *testing.T, bpClient *TwoStageL3ClosClient, id ObjectId) *SecurityZoneLoopback {
+		t.Helper()
+		var response struct {
+			Nodes map[ObjectId]struct {
+				IPv4Addr *string `json:"ipv4_addr"`
+				IPv6Addr *string `json:"ipv6_addr"`
+			} `json:"nodes"`
+		}
+		err := bpClient.GetNodes(ctx, NodeTypeInterface, &response)
+		require.NoError(t, err)
+
+		node, ok := response.Nodes[id]
+		require.Truef(t, ok, "Didn't find interface node %s", id)
+		require.NotNil(t, node.IPv4Addr)
+		require.NotNil(t, node.IPv6Addr)
+
+		ipv4Addr, err := netip.ParsePrefix(*node.IPv4Addr)
+		require.NoError(t, err)
+		ipv6Addr, err := netip.ParsePrefix(*node.IPv6Addr)
+		require.NoError(t, err)
+
+		return &SecurityZoneLoopback{
+			IPv4Addr: &ipv4Addr,
+			IPv6Addr: &ipv6Addr,
+		}
+	}
+
+	for _, client := range clients {
+		t.Run(client.name(), func(t *testing.T) {
+			t.Parallel()
+
+			if !compatibility.SecurityZoneLoopbackApiSupported.Check(client.client.apiVersion) {
+				t.Skipf("skipping due to version constraint %q", compatibility.SecurityZoneLoopbackApiSupported)
+			}
+
+			// create a blueprint with IPv6 enabled
+			bpClient := testBlueprintH(ctx, t, client.client)
+
+			// fetch all security zones
+			szs, err := bpClient.GetAllSecurityZones(ctx)
+			require.NoError(t, err)
+			require.Greater(t, len(szs), 0)
+
+			// find the default security zone ID
+			var szId ObjectId
+			for _, sz := range szs {
+				if sz.Data.Label == "Default routing zone" {
+					szId = sz.Id
+				}
+			}
+			require.NotEmpty(t, szId)
+
+			// assign an IPv4 pool to leaf loopbacks so that we can "remove" (cause it to revert to a pool address) a loopback IPv4 address
+			err = bpClient.SetResourceAllocation(ctx, &ResourceGroupAllocation{
+				ResourceGroup: ResourceGroup{
+					Type: ResourceTypeIp4Pool,
+					Name: ResourceGroupNameLeafIp4,
+				},
+				PoolIds: []ObjectId{ipV4PoolId},
+			})
+			require.NoError(t, err)
+
+			// assign an IPv6 pool to leaf loopbacks so that we can "remove" (cause it to revert to a pool) address a loopback IPv6 address
+			err = bpClient.SetResourceAllocation(ctx, &ResourceGroupAllocation{
+				ResourceGroup: ResourceGroup{
+					Type: ResourceTypeIp6Pool,
+					Name: ResourceGroupNameLeafIp6,
+				},
+				PoolIds: []ObjectId{ipV6PoolId},
+			})
+			require.NoError(t, err)
+
+			leafIds, err := getSystemIdsByRole(ctx, bpClient, "leaf")
+			require.NoError(t, err)
+			require.Greater(t, len(leafIds), 0)
+
+			loopbackNodeId := getLoopbackNodeId(t, ctx, bpClient, leafIds[0], szId)
+
+			for i, tCase := range testCases {
+				t.Run(fmt.Sprintf("test_case_%d", i), func(t *testing.T) {
+					err := bpClient.SetSecurityZoneLoopbacks(ctx, szId, map[ObjectId]SecurityZoneLoopback{
+						loopbackNodeId: {
+							IPv4Addr: tCase.ipv4,
+							IPv6Addr: tCase.ipv6,
+						},
+					})
+					require.NoError(t, err)
+
+					actual := getLoopback(ctx, t, bpClient, loopbackNodeId)
+					require.NotNil(t, actual.IPv4Addr)
+					require.NotNil(t, actual.IPv6Addr)
+
+					switch {
+					case tCase.ipv4 == nil:
+						require.Equalf(t, persistIpv4.String(), actual.IPv4Addr.String(),
+							"we sent <nil>, so actual ipv4 address should use the old value %s, got %s",
+							persistIpv4.String(), actual.IPv4Addr.String())
+					case !tCase.ipv4.IsValid():
+						require.Truef(t, ipv4PoolPrefix.Contains(actual.IPv4Addr.Addr()),
+							"we sent <invalid>, so actual ipv4 address should fall within the pool prefix %s, got %s",
+							ipv4PoolPrefix, tCase.ipv4)
+					default:
+						require.Equalf(t, tCase.ipv4.String(), actual.IPv4Addr.String(), "expected: %s actual %s",
+							tCase.ipv4.String(), actual.IPv4Addr.String())
+					}
+
+					switch {
+					case tCase.ipv6 == nil:
+						require.Equalf(t, persistIpv6.String(), actual.IPv6Addr.String(),
+							"we sent <nil>, so actual ipv6 address should use the old value %s, got %s",
+							persistIpv6.String(), actual.IPv6Addr.String())
+					case !tCase.ipv6.IsValid():
+						require.Truef(t, ipv6PoolPrefix.Contains(actual.IPv6Addr.Addr()),
+							"we sent <invalid>, so actual ipv6 address should fall within the pool prefix %s, got %s",
+							ipv6PoolPrefix, tCase.ipv6)
+					default:
+						require.Equalf(t, tCase.ipv6.String(), actual.IPv6Addr.String(), "expected: %s actual %s",
+							tCase.ipv6.String(), actual.IPv6Addr.String())
+					}
+				})
+			}
+		})
+	}
+}

--- a/apstra/two_stage_l3_clos_security_zones_loopbacks_integration_test.go
+++ b/apstra/two_stage_l3_clos_security_zones_loopbacks_integration_test.go
@@ -9,10 +9,11 @@ package apstra
 import (
 	"context"
 	"fmt"
-	"github.com/Juniper/apstra-go-sdk/apstra/compatibility"
-	"github.com/stretchr/testify/require"
 	"net/netip"
 	"testing"
+
+	"github.com/Juniper/apstra-go-sdk/apstra/compatibility"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTwoStageL3ClosClient_SetSecurityZoneLoopbacks(t *testing.T) {

--- a/apstra/two_stage_l3_clos_security_zones_loopbacks_unit_test.go
+++ b/apstra/two_stage_l3_clos_security_zones_loopbacks_unit_test.go
@@ -1,12 +1,17 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra_test
 
 import (
 	"encoding/json"
-	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/stretchr/testify/require"
 	"log"
 	"net/netip"
 	"testing"
+
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSecurityZoneLoopback_MarshalJSON(t *testing.T) {

--- a/apstra/two_stage_l3_clos_security_zones_loopbacks_unit_test.go
+++ b/apstra/two_stage_l3_clos_security_zones_loopbacks_unit_test.go
@@ -1,0 +1,78 @@
+package apstra_test
+
+import (
+	"encoding/json"
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/stretchr/testify/require"
+	"log"
+	"net/netip"
+	"testing"
+)
+
+func TestSecurityZoneLoopback_MarshalJSON(t *testing.T) {
+	mustParsePrefixPtr := func(s string) *netip.Prefix {
+		p := netip.MustParsePrefix(s)
+		return &p
+	}
+
+	type testCase struct {
+		data     apstra.SecurityZoneLoopback
+		expected string
+	}
+
+	testCases := map[string]testCase{
+		"both_have_values": {
+			data: apstra.SecurityZoneLoopback{
+				IPv4Addr: mustParsePrefixPtr("192.0.2.1/32"),
+				IPv6Addr: mustParsePrefixPtr("3fff::/128"),
+			},
+			expected: `{"ipv4_addr":"192.0.2.1/32","ipv6_addr":"3fff::/128"}`,
+		},
+		"both_omit_values": {
+			data:     apstra.SecurityZoneLoopback{},
+			expected: `{}`,
+		},
+		"both_null_values": {
+			data: apstra.SecurityZoneLoopback{
+				IPv4Addr: &netip.Prefix{},
+				IPv6Addr: &netip.Prefix{},
+			},
+			expected: `{"ipv4_addr":null,"ipv6_addr":null}`,
+		},
+		"omit_ipv4_value_ipv6": {
+			data: apstra.SecurityZoneLoopback{
+				IPv6Addr: mustParsePrefixPtr("3fff::/128"),
+			},
+			expected: `{"ipv6_addr":"3fff::/128"}`,
+		},
+		"omit_ipv6_value_ipv4": {
+			data: apstra.SecurityZoneLoopback{
+				IPv4Addr: mustParsePrefixPtr("192.0.2.1/32"),
+			},
+			expected: `{"ipv4_addr":"192.0.2.1/32"}`,
+		},
+		"null_ipv4_value_ipv6": {
+			data: apstra.SecurityZoneLoopback{
+				IPv4Addr: &netip.Prefix{},
+				IPv6Addr: mustParsePrefixPtr("3fff::/128"),
+			},
+			expected: `{"ipv4_addr":null,"ipv6_addr":"3fff::/128"}`,
+		},
+		"value_ipv4_null_ipv6": {
+			data: apstra.SecurityZoneLoopback{
+				IPv4Addr: mustParsePrefixPtr("192.0.2.1/32"),
+				IPv6Addr: &netip.Prefix{},
+			},
+			expected: `{"ipv4_addr":"192.0.2.1/32","ipv6_addr":null}`,
+		},
+	}
+
+	for tName, tCase := range testCases {
+		t.Run(tName, func(t *testing.T) {
+			actual, err := json.Marshal(tCase.data)
+			require.NoError(t, err)
+			log.Println(string(actual))
+			require.JSONEq(t, tCase.expected, string(actual))
+		})
+	}
+}


### PR DESCRIPTION
Apstra 5.x introduced `/api/blueprints/{blueprint_id}/security-zones/{security_zone_id}/loopbacks` (PATCH only) which takes input like:

```json
{
  "loopbacks": {
    "<interface-node-id>": {
      "ipv4_addr": "192.0.2.7/32",
      "ipv6_addr": "3fff::7/128"
    }
  }
}
```

This PR introduces a data structure and client method to make use of this new API.