### PR TITLE
Introduce `GetSecurityZoneLoopbacksBySystemId()`

### DIFF
--- a/apstra/two_stage_l3_clos_security_zones_loopbacks.go
+++ b/apstra/two_stage_l3_clos_security_zones_loopbacks.go
@@ -47,11 +47,40 @@ var _ json.Marshaler = (*SecurityZoneLoopback)(nil)
 //	{"ipv4_addr":"192.0.2.0/32"}
 //	{"ipv4_addr":null}
 //	{}
+//
+// Note that the API is only concerned with the IPv4Addr and IPv6Addr elements.
+// We include those other elements in various GET methods for convenience.
 type SecurityZoneLoopback struct {
-	IPv4Addr *netip.Prefix
-	IPv6Addr *netip.Prefix
+	Id             ObjectId
+	IPv4Addr       *netip.Prefix
+	IPv6Addr       *netip.Prefix
+	LoopbackId     int
+	SecurityZoneId ObjectId
 }
 
+func (o *SecurityZoneLoopback) loadIpsFromStringPointers(ipv4Addr, ipv6Addr *string) error {
+	if ipv4Addr != nil {
+		ip, err := netip.ParsePrefix(*ipv4Addr)
+		if err != nil {
+			return fmt.Errorf("failed parsing ipv4_addr value %q - %w", *ipv4Addr, err)
+		}
+		o.IPv4Addr = &ip
+	}
+
+	if ipv6Addr != nil {
+		ip, err := netip.ParsePrefix(*ipv6Addr)
+		if err != nil {
+			return fmt.Errorf("failed parsing ipv6_addr value %q - %w", *ipv6Addr, err)
+		}
+		o.IPv6Addr = &ip
+	}
+
+	return nil
+}
+
+// MarshalJSON only concerns itself with the IPv4Addr and IPv6Addr elements.
+// All other elements are ignored because the API doesn't want them. We include
+// those other elements in various GET methods for convenience.
 func (o SecurityZoneLoopback) MarshalJSON() ([]byte, error) {
 	ipInfo := make(map[string]*string)
 
@@ -107,6 +136,9 @@ func (o *TwoStageL3ClosClient) SetSecurityZoneLoopbacks(ctx context.Context, szI
 	return nil
 }
 
+// GetSecurityZoneLoopbacks returns a map keyed by loopback interface node ID.
+// This is the format used by the API (PATCH), and by our SetSecurityZoneLoopbacks
+// function.
 func (o *TwoStageL3ClosClient) GetSecurityZoneLoopbacks(ctx context.Context, szId ObjectId) (map[ObjectId]SecurityZoneLoopback, error) {
 	query := new(PathQuery).
 		SetBlueprintId(o.blueprintId).
@@ -127,9 +159,10 @@ func (o *TwoStageL3ClosClient) GetSecurityZoneLoopbacks(ctx context.Context, szI
 	var queryResponse struct {
 		Items []struct {
 			Interface struct {
-				Id       ObjectId `json:"id"`
-				IPv4Addr *string  `json:"ipv4_addr"`
-				IPv6Addr *string  `json:"ipv6_addr"`
+				Id         ObjectId `json:"id"`
+				LoopbackId int      `json:"loopback_id"`
+				IPv4Addr   *string  `json:"ipv4_addr"`
+				IPv6Addr   *string  `json:"ipv6_addr"`
 			} `json:"n_interface"`
 		} `json:"items"`
 	}
@@ -144,64 +177,148 @@ func (o *TwoStageL3ClosClient) GetSecurityZoneLoopbacks(ctx context.Context, szI
 
 	result := make(map[ObjectId]SecurityZoneLoopback, len(queryResponse.Items))
 	for _, item := range queryResponse.Items {
-		var ipv4Addr *netip.Prefix
-		if item.Interface.IPv4Addr != nil {
-			ip, err := netip.ParsePrefix(*item.Interface.IPv4Addr)
-			if err != nil {
-				return nil, fmt.Errorf("failed parsing node %q ipv4_addr value %q - %w", item.Interface.Id, *item.Interface.IPv4Addr, err)
-			}
-			ipv4Addr = &ip
+		szl := SecurityZoneLoopback{
+			Id:             item.Interface.Id,
+			LoopbackId:     item.Interface.LoopbackId,
+			SecurityZoneId: szId,
 		}
 
-		var ipv6Addr *netip.Prefix
-		if item.Interface.IPv6Addr != nil {
-			ip, err := netip.ParsePrefix(*item.Interface.IPv6Addr)
-			if err != nil {
-				return nil, fmt.Errorf("failed parsing node %q ipv6_addr value %q - %w", item.Interface.Id, *item.Interface.IPv6Addr, err)
-			}
-			ipv6Addr = &ip
+		err = szl.loadIpsFromStringPointers(item.Interface.IPv4Addr, item.Interface.IPv6Addr)
+		if err != nil {
+			return nil, fmt.Errorf("failed loading node %q IP info - %w", item.Interface.Id, err)
 		}
 
-		result[item.Interface.Id] = SecurityZoneLoopback{
-			IPv4Addr: ipv4Addr,
-			IPv6Addr: ipv6Addr,
-		}
+		result[item.Interface.Id] = szl
 	}
 
 	return result, nil
 }
 
-func (o *TwoStageL3ClosClient) GetSecurityZoneLoopbackByInterfaceId(ctx context.Context, id ObjectId) (*SecurityZoneLoopback, error) {
-	var target struct {
-		IPv4Addr *string `json:"ipv4_addr"`
-		IPv6Addr *string `json:"ipv6_addr"`
+// GetSecurityZoneLoopbackByInterfaceId returns a single *SecurityZoneLoopback
+// representing the specified loopback graph node ID.
+func (o *TwoStageL3ClosClient) GetSecurityZoneLoopbackByInterfaceId(ctx context.Context, ifId ObjectId) (*SecurityZoneLoopback, error) {
+	query := new(PathQuery).
+		SetBlueprintId(o.blueprintId).
+		SetClient(o.client).
+		Node([]QEEAttribute{
+			NodeTypeInterface.QEEAttribute(),
+			{Key: "id", Value: QEStringVal(ifId)},
+			{Key: "if_type", Value: QEStringVal("loopback")},
+			{Key: "name", Value: QEStringVal("n_interface")},
+		}).
+		In([]QEEAttribute{RelationshipTypeMemberInterfaces.QEEAttribute()}).
+		Node([]QEEAttribute{NodeTypeSecurityZoneInstance.QEEAttribute()}).
+		In([]QEEAttribute{RelationshipTypeInstantiatedBy.QEEAttribute()}).
+		Node([]QEEAttribute{
+			NodeTypeSecurityZone.QEEAttribute(),
+			{Key: "name", Value: QEStringVal("n_security_zone")},
+		})
+
+	var queryResult struct {
+		Items []struct {
+			Interface struct {
+				Id         ObjectId `json:"id"`
+				Ipv4Addr   *string  `json:"ipv4_addr"`
+				Ipv6Addr   *string  `json:"ipv6_addr"`
+				LoopbackId int      `json:"loopback_id"`
+			} `json:"n_interface"`
+			SecurityZone struct {
+				Id ObjectId `json:"id"`
+			} `json:"n_security_zone"`
+		} `json:"items"`
 	}
 
-	err := o.client.GetNode(ctx, o.blueprintId, id, &target)
+	err := query.Do(ctx, &queryResult)
 	if err != nil {
-		return nil, fmt.Errorf("failed fetching ndoe %q from blueprint %q - %w", id, o.blueprintId, err)
+		return nil, fmt.Errorf("failed while querying for loopback interface %q - %w", ifId, err)
 	}
 
-	var ipv4Addr *netip.Prefix
-	if target.IPv4Addr != nil {
-		ip, err := netip.ParsePrefix(*target.IPv4Addr)
-		if err != nil {
-			return nil, fmt.Errorf("failed parsing node %q ipv4_addr value %q - %w", id, *target.IPv4Addr, err)
+	switch len(queryResult.Items) {
+	case 0:
+		return nil, ClientErr{
+			errType: ErrNotfound,
+			err:     fmt.Errorf("loopback interface %q not found with query %q", ifId, query),
 		}
-		ipv4Addr = &ip
-	}
-
-	var ipv6Addr *netip.Prefix
-	if target.IPv6Addr != nil {
-		ip, err := netip.ParsePrefix(*target.IPv6Addr)
-		if err != nil {
-			return nil, fmt.Errorf("failed parsing node %q ipv6_addr value %q - %w", id, *target.IPv6Addr, err)
+	case 1:
+	default:
+		return nil, ClientErr{
+			errType: ErrMultipleMatch,
+			err:     fmt.Errorf("found %d matches while looking for loopback interface %q with query %q", len(queryResult.Items), ifId, query),
 		}
-		ipv6Addr = &ip
 	}
 
-	return &SecurityZoneLoopback{
-		IPv4Addr: ipv4Addr,
-		IPv6Addr: ipv6Addr,
-	}, nil
+	szl := SecurityZoneLoopback{
+		Id:             queryResult.Items[0].Interface.Id,
+		LoopbackId:     queryResult.Items[0].Interface.LoopbackId,
+		SecurityZoneId: queryResult.Items[0].SecurityZone.Id,
+	}
+
+	err = szl.loadIpsFromStringPointers(queryResult.Items[0].Interface.Ipv4Addr, queryResult.Items[0].Interface.Ipv6Addr)
+	if err != nil {
+		return nil, fmt.Errorf("failed loading node %q IP info - %w", queryResult.Items[0].Interface.Id, err)
+	}
+
+	return &szl, nil
+}
+
+// GetSecurityZoneLoopbacksBySystemId returns []SecurityZoneLoopback representing
+// all of the loopback interfaces belonging to the specified system node.
+func (o *TwoStageL3ClosClient) GetSecurityZoneLoopbacksBySystemId(ctx context.Context, sysId ObjectId) ([]SecurityZoneLoopback, error) {
+	query := new(PathQuery).
+		SetBlueprintId(o.blueprintId).
+		SetClient(o.client).
+		Node([]QEEAttribute{
+			NodeTypeSystem.QEEAttribute(),
+			{Key: "id", Value: QEStringVal(sysId)},
+		}).
+		Out([]QEEAttribute{RelationshipTypeHostedInterfaces.QEEAttribute()}).
+		Node([]QEEAttribute{
+			NodeTypeInterface.QEEAttribute(),
+			{Key: "if_type", Value: QEStringVal("loopback")},
+			{Key: "name", Value: QEStringVal("n_interface")},
+		}).
+		In([]QEEAttribute{RelationshipTypeMemberInterfaces.QEEAttribute()}).
+		Node([]QEEAttribute{NodeTypeSecurityZoneInstance.QEEAttribute()}).
+		In([]QEEAttribute{RelationshipTypeInstantiatedBy.QEEAttribute()}).
+		Node([]QEEAttribute{
+			NodeTypeSecurityZone.QEEAttribute(),
+			{Key: "name", Value: QEStringVal("n_security_zone")},
+		})
+
+	var queryResult struct {
+		Items []struct {
+			Interface struct {
+				Id         ObjectId `json:"id"`
+				Ipv4Addr   *string  `json:"ipv4_addr"`
+				Ipv6Addr   *string  `json:"ipv6_addr"`
+				LoopbackId int      `json:"loopback_id"`
+			} `json:"n_interface"`
+			SecurityZone struct {
+				Id ObjectId `json:"id"`
+			} `json:"n_security_zone"`
+		} `json:"items"`
+	}
+
+	err := query.Do(ctx, &queryResult)
+	if err != nil {
+		return nil, fmt.Errorf("failed while querying for system %q loopback", sysId)
+	}
+
+	result := make([]SecurityZoneLoopback, len(queryResult.Items))
+	for i, item := range queryResult.Items {
+		szl := SecurityZoneLoopback{
+			Id:             item.Interface.Id,
+			LoopbackId:     item.Interface.LoopbackId,
+			SecurityZoneId: item.SecurityZone.Id,
+		}
+
+		err = szl.loadIpsFromStringPointers(item.Interface.Ipv4Addr, item.Interface.Ipv6Addr)
+		if err != nil {
+			return nil, fmt.Errorf("failed loading node %q IP info - %w", item.Interface.Id, err)
+		}
+
+		result[i] = szl
+	}
+
+	return result, nil
 }

--- a/apstra/two_stage_l3_clos_security_zones_loopbacks.go
+++ b/apstra/two_stage_l3_clos_security_zones_loopbacks.go
@@ -104,6 +104,9 @@ func (o SecurityZoneLoopback) MarshalJSON() ([]byte, error) {
 }
 
 // SetSecurityZoneLoopbacks takes a map of SecurityZoneLoopback keyed by the loopback interface graph node ID.
+// Only IP information is required in the `SecurityZoneLoopback` objects passed to this function. The other
+// elements will not be rendered to JSON and would be ignored by the API. See the SecurityZoneLoopback for an
+// explanation of how to set and clear addresses (Go nil vs. JSON null, etc...)
 func (o *TwoStageL3ClosClient) SetSecurityZoneLoopbacks(ctx context.Context, szId ObjectId, loopbacks map[ObjectId]SecurityZoneLoopback) error {
 	if !compatibility.SecurityZoneLoopbackApiSupported.Check(o.client.apiVersion) {
 		return fmt.Errorf("SetSecurityZoneLoopbacks requires Apstra version %s, have version %s",


### PR DESCRIPTION
This PR does two things:
- Introduces the `GetSecurityZoneLoopbacksBySystemId()` method for returning loopback details based on a system ID.
- Enhances the `SecurityZoneLoopbacks` object to include additional info:
  ```
  Id             ObjectId // ID of the graph interface node
  LoopbackId     int      // loopback interface instance number
  SecurityZoneId ObjectId // the security zone to which the interface belongs
  ```

The new fields are not required by `SetSecurityZoneLoopbacks()` and they are not rendered into JSON because the API will ignore them.

Including the additional fields required re-work to the `GetSecurityZoneLoopbackByInterfaceId()` method. It was a simple `GetNode()`, but now it's a graph query so that it can retrieve the security zone ID from an entirely different graph node.

All of the old tests are passing, and have been extended to include the new method and attributes.
 
Closes #421