### PR TITLE
Restore obsolete `l3_server` port role for backward compatibility

### DIFF
--- a/apstra/api_design_interface_maps.go
+++ b/apstra/api_design_interface_maps.go
@@ -369,6 +369,13 @@ func (o *Client) getInterfaceMapByName(ctx context.Context, desired string) (*ra
 }
 
 func (o *Client) createInterfaceMap(ctx context.Context, in *InterfaceMapData) (ObjectId, error) {
+	for _, intf := range in.Interfaces {
+		err := intf.Roles.Validate()
+		if err != nil {
+			return "", err
+		}
+	}
+
 	response := &objectIdResponse{}
 	return response.Id, o.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodPost,
@@ -379,6 +386,13 @@ func (o *Client) createInterfaceMap(ctx context.Context, in *InterfaceMapData) (
 }
 
 func (o *Client) updateInterfaceMap(ctx context.Context, id ObjectId, in *InterfaceMapData) error {
+	for _, intf := range in.Interfaces {
+		err := intf.Roles.Validate()
+		if err != nil {
+			return err
+		}
+	}
+
 	return o.talkToApstra(ctx, &talkToApstraIn{
 		method:   http.MethodPut,
 		urlStr:   fmt.Sprintf(apiUrlDesignInterfaceMapById, id),

--- a/apstra/client.go
+++ b/apstra/client.go
@@ -1054,12 +1054,30 @@ func (o *Client) GetLogicalDeviceByName(ctx context.Context, name string) (*Logi
 
 // CreateLogicalDevice creates a new logical device, returns its ObjectId
 func (o *Client) CreateLogicalDevice(ctx context.Context, in *LogicalDeviceData) (ObjectId, error) {
+	for _, panel := range in.Panels {
+		for _, portGroup := range panel.PortGroups {
+			err := portGroup.Roles.Validate()
+			if err != nil {
+				return "", err
+			}
+		}
+	}
+
 	return o.createLogicalDevice(ctx, in.raw())
 }
 
 // UpdateLogicalDevice replaces the whole logical device configuration specified
 // by id with the supplied details.
 func (o *Client) UpdateLogicalDevice(ctx context.Context, id ObjectId, in *LogicalDeviceData) error {
+	for _, panel := range in.Panels {
+		for _, portGroup := range panel.PortGroups {
+			err := portGroup.Roles.Validate()
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	return o.updateLogicalDevice(ctx, id, in.raw())
 }
 

--- a/apstra/enum/enum.go
+++ b/apstra/enum/enum.go
@@ -237,6 +237,7 @@ var (
 	_                  enum = new(PortRole)
 	PortRoleAccess          = PortRole{Value: "access"}
 	PortRoleGeneric         = PortRole{Value: "generic"}
+	PortRoleL3Server        = PortRole{Value: "l3_server"} // todo: remove this
 	PortRoleLeaf            = PortRole{Value: "leaf"}
 	PortRolePeer            = PortRole{Value: "peer"}
 	PortRoleSpine           = PortRole{Value: "spine"}
@@ -245,6 +246,10 @@ var (
 	PortRoles               = oenum.New(
 		PortRoleAccess,
 		PortRoleGeneric,
+		// todo: remove PortRoleL3Server. Then:
+		//  - remove TestLogicalDevicePortRoles_SetAll
+		//  - simplify LogicalDevicePortRoles.SetAll()
+		PortRoleL3Server,
 		PortRoleLeaf,
 		PortRolePeer,
 		PortRoleSpine,

--- a/apstra/enum/enum.go
+++ b/apstra/enum/enum.go
@@ -247,7 +247,8 @@ var (
 		PortRoleAccess,
 		PortRoleGeneric,
 		// todo: remove PortRoleL3Server. Then:
-		//  - remove TestLogicalDevicePortRoles_SetAll
+		//  - remove TestLogicalDevicePortRoles_SetAll()
+		//  - remove LogicalDevicePortRoles.Validate()
 		//  - simplify LogicalDevicePortRoles.SetAll()
 		PortRoleL3Server,
 		PortRoleLeaf,

--- a/apstra/logical_device_port_roles.go
+++ b/apstra/logical_device_port_roles.go
@@ -39,7 +39,16 @@ func (o *LogicalDevicePortRoles) FromStrings(in []string) error {
 }
 
 func (o *LogicalDevicePortRoles) SetAll() {
-	*o = enum.PortRoles.Members()
+	members := enum.PortRoles.Members()
+	for i, member := range members {
+		if member == enum.PortRoleL3Server {
+			members[i] = members[len(members)-1]
+			members = members[:len(members)-1]
+		}
+	}
+
+	*o = members
+	o.Sort()
 }
 
 func (o *LogicalDevicePortRoles) Sort() {

--- a/apstra/logical_device_port_roles.go
+++ b/apstra/logical_device_port_roles.go
@@ -5,6 +5,7 @@
 package apstra
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/Juniper/apstra-go-sdk/apstra/enum"
@@ -61,4 +62,18 @@ func (o *LogicalDevicePortRoles) Sort() {
 	sort.Slice(*o, func(i, j int) bool {
 		return clone[i].Value < clone[j].Value
 	})
+}
+
+func (o *LogicalDevicePortRoles) Validate() error {
+	if o == nil {
+		return nil
+	}
+
+	for _, ldpr := range *o {
+		if ldpr == enum.PortRoleL3Server {
+			return fmt.Errorf("logical device port role %q is no longer supported", ldpr.String())
+		}
+	}
+
+	return nil
 }

--- a/apstra/logical_device_port_roles_unit_test.go
+++ b/apstra/logical_device_port_roles_unit_test.go
@@ -108,3 +108,21 @@ func TestLogicalDevicePortRoles_Sort(t *testing.T) {
 		})
 	}
 }
+
+func TestLogicalDevicePortRoles_SetAll(t *testing.T) {
+	var data apstra.LogicalDevicePortRoles
+	data.SetAll()
+
+	expected := apstra.LogicalDevicePortRoles{
+		enum.PortRoleAccess,
+		enum.PortRoleGeneric,
+		// enum.PortRoleL3Server, <---- TEST VALIDATES THAT THIS ONE IS OMITTED
+		enum.PortRoleLeaf,
+		enum.PortRolePeer,
+		enum.PortRoleSpine,
+		enum.PortRoleSuperspine,
+		enum.PortRoleUnused,
+	}
+
+	require.Equal(t, expected, data)
+}

--- a/apstra/logical_device_port_roles_unit_test.go
+++ b/apstra/logical_device_port_roles_unit_test.go
@@ -126,3 +126,41 @@ func TestLogicalDevicePortRoles_SetAll(t *testing.T) {
 
 	require.Equal(t, expected, data)
 }
+
+func TestLogicalDevicePortRoles_Validate(t *testing.T) {
+	type testCase struct {
+		roles       []string
+		errContains string
+	}
+
+	testCases := map[string]testCase{
+		"okay": {
+			roles: []string{"access", "leaf", "spine"},
+		},
+		"empty": {},
+		"single_err": {
+			roles:       []string{"l3_server"},
+			errContains: "l3_server",
+		},
+		"multiple_err": {
+			roles:       []string{"access", "l3_server", "spine"},
+			errContains: "l3_server",
+		},
+	}
+
+	for tName, tCase := range testCases {
+		t.Run(tName, func(t *testing.T) {
+			var portRoles apstra.LogicalDevicePortRoles
+			err := portRoles.FromStrings(tCase.roles)
+			require.NoError(t, err)
+
+			err = portRoles.Validate()
+			if tCase.errContains != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tCase.errContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#428 eliminated the `l3_server` Port Role which existed in the API but has been removed from the Apstra GUI ages ago.

As of 4.1.0, none of the baked-in Logical Devices or Interface Maps specify the `l3_server` port role, so it's likely only present if we (mistakenly) added it.

This PR restores that Port Role to the `PortRoles` enum along with:
- omission of `l3_server` in `TestLogicalDevicePortRoles_SetAll()`
- `LogicalDevicePortRoles.Validate()` which errors when `l3_server` is set
- calls to `LogicalDevicePortRoles.Validate()` in Logical Device and Interface Map create/modify functions
- tests

The goal is to ensure we can read/parse `l3_server` if it happens to be set on an existing object while ensuring that we never send (allow the user to set it) in future operations.

Closes #432