### PR TITLE
Change `LogicalDevicePortRoles` `SetAll()` to `IncludeAllUses()`

### DIFF
--- a/apstra/api_design_interface_maps_integration_test.go
+++ b/apstra/api_design_interface_maps_integration_test.go
@@ -123,9 +123,6 @@ func TestCreateInterfaceMap(t *testing.T) {
 		require.Equal(t, asCreated.Data.Interfaces, newMapInfo.Interfaces)
 
 		for i := range asCreated.Data.Interfaces {
-			newMapInfo.Interfaces[i].Roles.Sort()
-			asCreated.Data.Interfaces[i].Roles.Sort()
-
 			require.Equal(t, newMapInfo.Interfaces[i].Name, asCreated.Data.Interfaces[i].Name)
 			require.Equal(t, newMapInfo.Interfaces[i].Roles, asCreated.Data.Interfaces[i].Roles)
 			require.Equal(t, newMapInfo.Interfaces[i].ActiveState, asCreated.Data.Interfaces[i].ActiveState)

--- a/apstra/enum/enum.go
+++ b/apstra/enum/enum.go
@@ -247,9 +247,8 @@ var (
 		PortRoleAccess,
 		PortRoleGeneric,
 		// todo: remove PortRoleL3Server. Then:
-		//  - remove TestLogicalDevicePortRoles_SetAll()
 		//  - remove LogicalDevicePortRoles.Validate()
-		//  - simplify LogicalDevicePortRoles.SetAll()
+		//  - simplify LogicalDevicePortRoles.IncludeAllUses()
 		PortRoleL3Server,
 		PortRoleLeaf,
 		PortRolePeer,

--- a/apstra/logical_device_port_roles.go
+++ b/apstra/logical_device_port_roles.go
@@ -6,8 +6,6 @@ package apstra
 
 import (
 	"fmt"
-	"sort"
-
 	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 )
 
@@ -39,29 +37,21 @@ func (o *LogicalDevicePortRoles) FromStrings(in []string) error {
 	return nil
 }
 
-func (o *LogicalDevicePortRoles) SetAll() {
-	members := enum.PortRoles.Members()
-	for i, member := range members {
-		if member == enum.PortRoleL3Server {
-			members[i] = members[len(members)-1]
-			members = members[:len(members)-1]
+// IncludeAllUses ensures that the LogicalDevicePortRoles contains the entire
+// set of "available for use" port roles: All roles excluding "l3_server"
+// (deprecated) and "unused".
+func (o *LogicalDevicePortRoles) IncludeAllUses() {
+	// wipe out any existing values
+	*o = nil
+
+	for _, member := range enum.PortRoles.Members() {
+		switch member {
+		case enum.PortRoleL3Server: // don't add this one
+		case enum.PortRoleUnused: //   don't add this one
+		default:
+			*o = append(*o, member) // this one's a keeper
 		}
 	}
-
-	*o = members
-	o.Sort()
-}
-
-func (o *LogicalDevicePortRoles) Sort() {
-	if o == nil || *o == nil {
-		return
-	}
-
-	clone := *o
-
-	sort.Slice(*o, func(i, j int) bool {
-		return clone[i].Value < clone[j].Value
-	})
 }
 
 func (o *LogicalDevicePortRoles) Validate() error {

--- a/apstra/logical_device_port_roles.go
+++ b/apstra/logical_device_port_roles.go
@@ -6,6 +6,7 @@ package apstra
 
 import (
 	"fmt"
+
 	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 )
 

--- a/apstra/logical_device_port_roles_unit_test.go
+++ b/apstra/logical_device_port_roles_unit_test.go
@@ -20,7 +20,7 @@ func TestLogicalDevicePortRoles_Strings(t *testing.T) {
 	}
 
 	var all apstra.LogicalDevicePortRoles
-	all.SetAll()
+	all.IncludeAllUses()
 
 	testCases := map[string]testCase{
 		"none": {},
@@ -53,7 +53,7 @@ func TestLogicalDevicePortRoles_FromStrings(t *testing.T) {
 	}
 
 	var all apstra.LogicalDevicePortRoles
-	all.SetAll()
+	all.IncludeAllUses()
 
 	testCases := map[string]testCase{
 		"none": {},
@@ -81,37 +81,9 @@ func TestLogicalDevicePortRoles_FromStrings(t *testing.T) {
 	}
 }
 
-func TestLogicalDevicePortRoles_Sort(t *testing.T) {
-	type testCase struct {
-		data     apstra.LogicalDevicePortRoles
-		expected apstra.LogicalDevicePortRoles
-	}
-
-	testCases := map[string]testCase{
-		"empty": {},
-		"presorted": {
-			data:     apstra.LogicalDevicePortRoles{enum.PortRoleAccess, enum.PortRoleGeneric, enum.PortRoleSpine},
-			expected: apstra.LogicalDevicePortRoles{enum.PortRoleAccess, enum.PortRoleGeneric, enum.PortRoleSpine},
-		},
-		"unsorted": {
-			data:     apstra.LogicalDevicePortRoles{enum.PortRoleSpine, enum.PortRoleGeneric, enum.PortRoleAccess},
-			expected: apstra.LogicalDevicePortRoles{enum.PortRoleAccess, enum.PortRoleGeneric, enum.PortRoleSpine},
-		},
-	}
-
-	for tName, tCase := range testCases {
-		t.Run(tName, func(t *testing.T) {
-			t.Parallel()
-
-			tCase.data.Sort()
-			require.Equal(t, tCase.expected, tCase.data)
-		})
-	}
-}
-
-func TestLogicalDevicePortRoles_SetAll(t *testing.T) {
+func TestLogicalDevicePortRoles_IncludeAllUses(t *testing.T) {
 	var data apstra.LogicalDevicePortRoles
-	data.SetAll()
+	data.IncludeAllUses()
 
 	expected := apstra.LogicalDevicePortRoles{
 		enum.PortRoleAccess,
@@ -121,7 +93,7 @@ func TestLogicalDevicePortRoles_SetAll(t *testing.T) {
 		enum.PortRolePeer,
 		enum.PortRoleSpine,
 		enum.PortRoleSuperspine,
-		enum.PortRoleUnused,
+		// enum.PortRoleUnused,  <---- TEST VALIDATES THAT THIS ONE IS OMITTED
 	}
 
 	require.Equal(t, expected, data)


### PR DESCRIPTION
The `SetAll()` method had a bug which damaged the values map inside our enum type.

Also, "Set All" doesn't really describe the use case for this function, which should check every "use" box in a logical device port group: spine, leaf, access, etc...

But:
- `l3_server` is deprecated - we should stop including it
- `unused` doesn't make sense to mix in with `leaf`, `spine`, etc... This value probably shouldn't exist at all, but it's what we've got.

So, changes in this PR:
- Rename `SetAll()` to `IncludeAllUses()`
- Change the strategy from "delete undesirable slice elements" (which broke things due to unexpected "by reference" behavior) to "only copy desirable elements"
- Eliminate the `Sort()` method because we're no longer swapping values around while deleting them, so the sort order shouldn't become a problem.