### PR TITLE
436 "all port roles" should include `unused`

### DIFF
--- a/apstra/logical_device_port_roles.go
+++ b/apstra/logical_device_port_roles.go
@@ -48,7 +48,6 @@ func (o *LogicalDevicePortRoles) IncludeAllUses() {
 	for _, member := range enum.PortRoles.Members() {
 		switch member {
 		case enum.PortRoleL3Server: // don't add this one
-		case enum.PortRoleUnused: //   don't add this one
 		default:
 			*o = append(*o, member) // this one's a keeper
 		}

--- a/apstra/logical_device_port_roles_unit_test.go
+++ b/apstra/logical_device_port_roles_unit_test.go
@@ -93,7 +93,7 @@ func TestLogicalDevicePortRoles_IncludeAllUses(t *testing.T) {
 		enum.PortRolePeer,
 		enum.PortRoleSpine,
 		enum.PortRoleSuperspine,
-		// enum.PortRoleUnused,  <---- TEST VALIDATES THAT THIS ONE IS OMITTED
+		enum.PortRoleUnused,
 	}
 
 	require.Equal(t, expected, data)

--- a/apstra/logical_device_port_roles_unit_test.go
+++ b/apstra/logical_device_port_roles_unit_test.go
@@ -52,8 +52,13 @@ func TestLogicalDevicePortRoles_FromStrings(t *testing.T) {
 		e apstra.LogicalDevicePortRoles
 	}
 
+	// prepare a sorted LogicalDevicePortRoles with all possible values
 	var all apstra.LogicalDevicePortRoles
 	all.IncludeAllUses()
+	all = append(all, enum.PortRoleL3Server)
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].Value < all[j].Value
+	})
 
 	testCases := map[string]testCase{
 		"none": {},


### PR DESCRIPTION
Restore the `unused` port role to the set of values returned by `IncludeAllUses()`

Closes #435