### PR TITLE
Add support for blueprint rendered config and rendered config diffs

### DIFF
--- a/apstra/api_blueprints.go
+++ b/apstra/api_blueprints.go
@@ -16,13 +16,14 @@ import (
 )
 
 const (
-	apiUrlBlueprints          = "/api/blueprints"
-	apiUrlPathDelim           = "/"
-	apiUrlBlueprintsPrefix    = apiUrlBlueprints + apiUrlPathDelim
-	apiUrlBlueprintById       = apiUrlBlueprintsPrefix + "%s"
-	apiUrlBlueprintByIdPrefix = apiUrlBlueprintById + apiUrlPathDelim
-	apiUrlBlueprintNodes      = apiUrlBlueprintById + apiUrlPathDelim + "nodes"
-	apiUrlBlueprintNodeById   = apiUrlBlueprintNodes + apiUrlPathDelim + "%s"
+	apiUrlBlueprints              = "/api/blueprints"
+	apiUrlPathDelim               = "/"
+	apiUrlBlueprintsPrefix        = apiUrlBlueprints + apiUrlPathDelim
+	apiUrlBlueprintById           = apiUrlBlueprintsPrefix + "%s"
+	apiUrlBlueprintByIdPrefix     = apiUrlBlueprintById + apiUrlPathDelim
+	apiUrlBlueprintNodes          = apiUrlBlueprintById + apiUrlPathDelim + "nodes"
+	apiUrlBlueprintNodeById       = apiUrlBlueprintNodes + apiUrlPathDelim + "%s"
+	apiUrlBlueprintNodeByIdPrefix = apiUrlBlueprintNodeById + apiUrlPathDelim
 
 	initTypeFromTemplate   = "template_reference"
 	initTypeTemplateInline = "rack_based_template_inline"

--- a/apstra/enum/enum.go
+++ b/apstra/enum/enum.go
@@ -256,6 +256,14 @@ var (
 		PortRoleSuperspine,
 		PortRoleUnused,
 	)
+
+	_                          enum = new(RenderedConfigType)
+	RenderedConfigTypeStaging       = RenderedConfigType{Value: "staging"}
+	RenderedConfigTypeDeployed      = RenderedConfigType{Value: "deployed"}
+	RenderedConfigTypes             = oenum.New(
+		RenderedConfigTypeStaging,
+		RenderedConfigTypeDeployed,
+	)
 )
 
 type DeployMode oenum.Member[string]
@@ -519,6 +527,21 @@ func (o PortRole) String() string {
 }
 
 func (o *PortRole) FromString(s string) error {
+	t := PortRoles.Parse(s)
+	if t == nil {
+		return newEnumParseError(o, s)
+	}
+	o.Value = t.Value
+	return nil
+}
+
+type RenderedConfigType oenum.Member[string]
+
+func (o RenderedConfigType) String() string {
+	return o.Value
+}
+
+func (o *RenderedConfigType) FromString(s string) error {
 	t := PortRoles.Parse(s)
 	if t == nil {
 		return newEnumParseError(o, s)

--- a/apstra/two_stage_l3_clos_generic_system_loopback.go
+++ b/apstra/two_stage_l3_clos_generic_system_loopback.go
@@ -12,10 +12,11 @@ import (
 )
 
 const (
-	apiUrlGenericSystemSystems            = apiUrlBlueprintById + apiUrlPathDelim + "systems"
-	apiUrlGenericSystemSystemsById        = apiUrlGenericSystemSystems + apiUrlPathDelim + "%s"
-	apiUrlGenericSystemSystemLoopback     = apiUrlGenericSystemSystemsById + apiUrlPathDelim + "loopback"
-	apiUrlGenericSystemSystemLoopbackById = apiUrlGenericSystemSystemLoopback + apiUrlPathDelim + "%d"
+	apiUrlBlueprintSystems          = apiUrlBlueprintById + apiUrlPathDelim + "systems"
+	apiUrlBlueprintSystemById       = apiUrlBlueprintSystems + apiUrlPathDelim + "%s"
+	apiUrlBlueprintSystemByIdPrefix = apiUrlBlueprintSystemById + apiUrlPathDelim
+	apiUrlGenericSystemLoopback     = apiUrlBlueprintSystemById + apiUrlPathDelim + "loopback"
+	apiUrlGenericSystemLoopbackById = apiUrlGenericSystemLoopback + apiUrlPathDelim + "%d"
 )
 
 type GenericSystemLoopback struct {
@@ -91,7 +92,7 @@ func (o *TwoStageL3ClosClient) getGenericSystemLoopback(ctx context.Context, nod
 	var response rawGenericSystemLoopback
 	err := o.client.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodGet,
-		urlStr:      fmt.Sprintf(apiUrlGenericSystemSystemLoopbackById, o.blueprintId, nodeId, loopbackId),
+		urlStr:      fmt.Sprintf(apiUrlGenericSystemLoopbackById, o.blueprintId, nodeId, loopbackId),
 		apiResponse: &response,
 	})
 	if err != nil {
@@ -173,7 +174,7 @@ func (o *TwoStageL3ClosClient) SetGenericSystemLoopback(ctx context.Context, nod
 func (o *TwoStageL3ClosClient) setGenericSystemLoopback(ctx context.Context, nodeId ObjectId, loopbackId int, in *rawGenericSystemLoopback) error {
 	err := o.client.talkToApstra(ctx, &talkToApstraIn{
 		method:   http.MethodPatch,
-		urlStr:   fmt.Sprintf(apiUrlGenericSystemSystemLoopbackById, o.blueprintId, nodeId, loopbackId),
+		urlStr:   fmt.Sprintf(apiUrlGenericSystemLoopbackById, o.blueprintId, nodeId, loopbackId),
 		apiInput: in,
 	})
 	if err != nil {

--- a/apstra/two_stage_l3_clos_rendered_config.go
+++ b/apstra/two_stage_l3_clos_rendered_config.go
@@ -1,0 +1,51 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package apstra
+
+import (
+	"context"
+	"fmt"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"net/http"
+)
+
+const (
+	apiUrlBlueprintNodeConfigRender   = apiUrlBlueprintNodeByIdPrefix + "config-rendering?type=%s"
+	apiUrlBlueprintSystemConfigRender = apiUrlBlueprintSystemByIdPrefix + "config-rendering?type=%s"
+)
+
+func (o *TwoStageL3ClosClient) GetNodeRenderedConfig(ctx context.Context, id ObjectId, rcType enum.RenderedConfigType) (string, error) {
+	var apiResponse struct {
+		Config string `json:"config"`
+	}
+
+	err := o.client.talkToApstra(ctx, &talkToApstraIn{
+		method:      http.MethodGet,
+		urlStr:      fmt.Sprintf(apiUrlBlueprintNodeConfigRender, o.blueprintId, id, rcType.String()),
+		apiResponse: &apiResponse,
+	})
+	if err != nil {
+		return "", convertTtaeToAceWherePossible(err)
+	}
+
+	return apiResponse.Config, nil
+}
+
+func (o *TwoStageL3ClosClient) GetSystemRenderedConfig(ctx context.Context, id ObjectId, rcType enum.RenderedConfigType) (string, error) {
+	var apiResponse struct {
+		Config string `json:"config"`
+	}
+
+	err := o.client.talkToApstra(ctx, &talkToApstraIn{
+		method:      http.MethodGet,
+		urlStr:      fmt.Sprintf(apiUrlBlueprintSystemConfigRender, o.blueprintId, id, rcType.String()),
+		apiResponse: &apiResponse,
+	})
+	if err != nil {
+		return "", convertTtaeToAceWherePossible(err)
+	}
+
+	return apiResponse.Config, nil
+}

--- a/apstra/two_stage_l3_clos_rendered_config.go
+++ b/apstra/two_stage_l3_clos_rendered_config.go
@@ -7,8 +7,9 @@ package apstra
 import (
 	"context"
 	"fmt"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"net/http"
+
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 )
 
 const (

--- a/apstra/two_stage_l3_clos_rendered_config_integration_test.go
+++ b/apstra/two_stage_l3_clos_rendered_config_integration_test.go
@@ -10,10 +10,11 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
-	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
+
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetNodeRenderedConfig(t *testing.T) {
@@ -59,7 +60,6 @@ func TestGetNodeRenderedConfig(t *testing.T) {
 					require.Greaterf(t, lineCount, 100, "deployed config less than 100 lines is sus")
 				})
 			}
-
 		})
 	}
 }

--- a/apstra/two_stage_l3_clos_rendered_config_integration_test.go
+++ b/apstra/two_stage_l3_clos_rendered_config_integration_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package apstra
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+)
+
+func TestGetNodeRenderedConfig(t *testing.T) {
+	ctx := context.Background()
+
+	clients, err := getTestClients(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for clientName, client := range clients {
+		t.Run(fmt.Sprintf("%s_%s", client.client.apiVersion, clientName), func(t *testing.T) {
+			t.Parallel()
+
+			bp := testBlueprintI(ctx, t, client.client)
+			leafIds, err := getSystemIdsByRole(ctx, bp, "leaf")
+			require.NoError(t, err)
+
+			for _, leafId := range leafIds {
+				t.Run("leaf_"+leafId.String()+"_staging", func(t *testing.T) {
+					t.Parallel()
+
+					stagingConfig, err := bp.GetNodeRenderedConfig(ctx, leafId, enum.RenderedConfigTypeStaging)
+					require.NoError(t, err)
+					lineCount := 0
+					scanner := bufio.NewScanner(strings.NewReader(stagingConfig))
+					for scanner.Scan() {
+						lineCount++
+					}
+					require.Greaterf(t, lineCount, 100, "staging config less than 100 lines is sus")
+				})
+
+				t.Run("leaf_"+leafId.String()+"_deployed", func(t *testing.T) {
+					t.Parallel()
+
+					deployedConfig, err := bp.GetNodeRenderedConfig(ctx, leafId, enum.RenderedConfigTypeDeployed)
+					require.NoError(t, err)
+					lineCount := 0
+					scanner := bufio.NewScanner(strings.NewReader(deployedConfig))
+					for scanner.Scan() {
+						lineCount++
+					}
+					require.Greaterf(t, lineCount, 100, "deployed config less than 100 lines is sus")
+				})
+			}
+
+		})
+	}
+}

--- a/apstra/two_stage_l3_clos_rendered_diff.go
+++ b/apstra/two_stage_l3_clos_rendered_diff.go
@@ -1,0 +1,55 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package apstra
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"net/http"
+)
+
+const (
+	apiUrlBlueprintNodeConfigRenderDiff   = apiUrlBlueprintNodeByIdPrefix + "config-incremental?type=%s"
+	apiUrlBlueprintSystemConfigRenderDiff = apiUrlBlueprintSystemByIdPrefix + "config-incremental?type=%s"
+)
+
+type RenderDiff struct {
+	Config             string          `json:"config"`
+	PristineConfig     json.RawMessage `json:"pristine_config"`
+	Context            json.RawMessage `json:"context"`
+	SupportsDiffConfig bool            `json:"supports_diff_config"`
+}
+
+func (o *TwoStageL3ClosClient) GetNodeRenderedConfigDiff(ctx context.Context, id ObjectId, rcType enum.RenderedConfigType) (*RenderDiff, error) {
+	var apiResponse RenderDiff
+
+	err := o.client.talkToApstra(ctx, &talkToApstraIn{
+		method:      http.MethodGet,
+		urlStr:      fmt.Sprintf(apiUrlBlueprintNodeConfigRenderDiff, o.blueprintId, id, rcType.String()),
+		apiResponse: &apiResponse,
+	})
+	if err != nil {
+		return nil, convertTtaeToAceWherePossible(err)
+	}
+
+	return &apiResponse, nil
+}
+
+func (o *TwoStageL3ClosClient) GetSystemRenderedConfigDiff(ctx context.Context, id ObjectId, rcType enum.RenderedConfigType) (*RenderDiff, error) {
+	var apiResponse RenderDiff
+
+	err := o.client.talkToApstra(ctx, &talkToApstraIn{
+		method:      http.MethodGet,
+		urlStr:      fmt.Sprintf(apiUrlBlueprintSystemConfigRenderDiff, o.blueprintId, id, rcType.String()),
+		apiResponse: &apiResponse,
+	})
+	if err != nil {
+		return nil, convertTtaeToAceWherePossible(err)
+	}
+
+	return &apiResponse, nil
+}

--- a/apstra/two_stage_l3_clos_rendered_diff.go
+++ b/apstra/two_stage_l3_clos_rendered_diff.go
@@ -9,13 +9,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 )
 
 const (
-	apiUrlBlueprintNodeConfigRenderDiff   = apiUrlBlueprintNodeByIdPrefix + "config-incremental?type=%s"
-	apiUrlBlueprintSystemConfigRenderDiff = apiUrlBlueprintSystemByIdPrefix + "config-incremental?type=%s"
+	apiUrlBlueprintNodeConfigRenderDiff   = apiUrlBlueprintNodeByIdPrefix + "config-incremental"
+	apiUrlBlueprintSystemConfigRenderDiff = apiUrlBlueprintSystemByIdPrefix + "config-incremental"
 )
 
 type RenderDiff struct {
@@ -25,12 +23,12 @@ type RenderDiff struct {
 	SupportsDiffConfig bool            `json:"supports_diff_config"`
 }
 
-func (o *TwoStageL3ClosClient) GetNodeRenderedConfigDiff(ctx context.Context, id ObjectId, rcType enum.RenderedConfigType) (*RenderDiff, error) {
+func (o *TwoStageL3ClosClient) GetNodeRenderedConfigDiff(ctx context.Context, id ObjectId) (*RenderDiff, error) {
 	var apiResponse RenderDiff
 
 	err := o.client.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodGet,
-		urlStr:      fmt.Sprintf(apiUrlBlueprintNodeConfigRenderDiff, o.blueprintId, id, rcType.String()),
+		urlStr:      fmt.Sprintf(apiUrlBlueprintNodeConfigRenderDiff, o.blueprintId, id),
 		apiResponse: &apiResponse,
 	})
 	if err != nil {
@@ -40,12 +38,12 @@ func (o *TwoStageL3ClosClient) GetNodeRenderedConfigDiff(ctx context.Context, id
 	return &apiResponse, nil
 }
 
-func (o *TwoStageL3ClosClient) GetSystemRenderedConfigDiff(ctx context.Context, id ObjectId, rcType enum.RenderedConfigType) (*RenderDiff, error) {
+func (o *TwoStageL3ClosClient) GetSystemRenderedConfigDiff(ctx context.Context, id ObjectId) (*RenderDiff, error) {
 	var apiResponse RenderDiff
 
 	err := o.client.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodGet,
-		urlStr:      fmt.Sprintf(apiUrlBlueprintSystemConfigRenderDiff, o.blueprintId, id, rcType.String()),
+		urlStr:      fmt.Sprintf(apiUrlBlueprintSystemConfigRenderDiff, o.blueprintId, id),
 		apiResponse: &apiResponse,
 	})
 	if err != nil {

--- a/apstra/two_stage_l3_clos_rendered_diff.go
+++ b/apstra/two_stage_l3_clos_rendered_diff.go
@@ -8,8 +8,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"net/http"
+
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 )
 
 const (

--- a/apstra/two_stage_l3_clos_rendered_diff_integration_test.go
+++ b/apstra/two_stage_l3_clos_rendered_diff_integration_test.go
@@ -1,0 +1,205 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package apstra
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/stretchr/testify/require"
+	"math/rand/v2"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestGetNodeRenderedDiff(t *testing.T) {
+	ctx := context.Background()
+
+	clients, err := getTestClients(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for clientName, client := range clients {
+		t.Run(fmt.Sprintf("%s_%s", client.client.apiVersion, clientName), func(t *testing.T) {
+			t.Parallel()
+
+			bp := testBlueprintI(ctx, t, client.client)
+
+			leafIds, err := getSystemIdsByRole(ctx, bp, "leaf")
+			require.NoError(t, err)
+
+			leafWg := new(sync.WaitGroup)
+			leafWg.Add(len(leafIds))
+			for _, leafId := range leafIds {
+				t.Run("leaf_"+leafId.String()+"_without_diff", func(t *testing.T) {
+					t.Parallel()
+
+					// staging config should have no diffs at this point
+					stagingConfigDiff, err := bp.GetNodeRenderedConfigDiff(ctx, leafId, enum.RenderedConfigTypeStaging)
+					require.NoError(t, err)
+					require.NotNil(t, stagingConfigDiff)
+					require.Equal(t, "null", string(stagingConfigDiff.PristineConfig)) // no pristine config, i guess
+					require.Empty(t, stagingConfigDiff.Config)                         // no diff
+					require.False(t, stagingConfigDiff.SupportsDiffConfig)             // whatever this is
+					require.Greater(t, len(stagingConfigDiff.Context), 4000)           // 4KB-ish of context?
+
+					// deployed config should have no diffs at this point
+					deployedConfigDiff, err := bp.GetNodeRenderedConfigDiff(ctx, leafId, enum.RenderedConfigTypeStaging)
+					require.NoError(t, err)
+					require.NotNil(t, deployedConfigDiff)
+					require.Equal(t, "null", string(deployedConfigDiff.PristineConfig)) // no pristine config, i guess
+					require.Empty(t, deployedConfigDiff.Config)                         // no diff
+					require.False(t, deployedConfigDiff.SupportsDiffConfig)             // whatever this is
+					require.Greater(t, len(deployedConfigDiff.Context), 4000)           // 4KB-ish of context?
+
+					leafWg.Done()
+				})
+			}
+
+			// make changes to the rendered config by deploying a virtual network to the switches
+			t.Run("leafs_with_diffs", func(t *testing.T) {
+				t.Parallel()
+				leafWg.Wait() // wait for leafs to be verified diff-free
+
+				// create a security zone
+				szLabel := randString(6, "hex")
+				szId, err := bp.CreateSecurityZone(ctx, &SecurityZoneData{
+					Label:   szLabel,
+					SzType:  SecurityZoneTypeEVPN,
+					VrfName: szLabel,
+				})
+				require.NoError(t, err)
+
+				err = bp.SetResourceAllocation(ctx, &ResourceGroupAllocation{
+					ResourceGroup: ResourceGroup{
+						Type:           ResourceTypeIp4Pool,
+						Name:           ResourceGroupNameLeafIp4,
+						SecurityZoneId: &szId,
+					},
+					PoolIds: []ObjectId{"Private-10_0_0_0-8"},
+				})
+				require.NoError(t, err)
+
+				// prep VN bindings
+				vlanId := Vlan(rand.IntN(vlanMax-2) + 2) // 2-4094
+				vnBindings := make([]VnBinding, len(leafIds))
+				for i, leafId := range leafIds {
+					vnBindings[i] = VnBinding{
+						SystemId: leafId,
+						VlanId:   &vlanId,
+					}
+				}
+
+				// create a VN within the security zone
+				rip := randomPrefix(t, "172.16.0.0/12", 24)
+				vnId, err := bp.CreateVirtualNetwork(ctx, &VirtualNetworkData{
+					VirtualGatewayIpv4Enabled: true,
+					Ipv4Enabled:               true,
+					Ipv4Subnet:                &rip,
+					Label:                     randString(6, "hex"),
+					SecurityZoneId:            szId,
+					VnBindings:                vnBindings,
+					VnType:                    VnTypeVxlan,
+				})
+				require.NoError(t, err)
+				t.Logf(vnId.String())
+
+				leafWg.Add(len(leafIds))
+				for _, leafId := range leafIds {
+					t.Run("leaf_"+leafId.String(), func(t *testing.T) {
+						t.Parallel()
+
+						// staging config should have diffs at this point
+						stagingConfigDiff, err := bp.GetNodeRenderedConfigDiff(ctx, leafId, enum.RenderedConfigTypeStaging)
+						require.NoError(t, err)
+						require.NotNil(t, stagingConfigDiff)
+						require.Equal(t, "null", string(stagingConfigDiff.PristineConfig)) // no pristine config, i guess
+						require.False(t, stagingConfigDiff.SupportsDiffConfig)             // whatever this is
+						require.Greater(t, len(stagingConfigDiff.Context), 4000)           // 4KB-ish of context?
+						adds, dels := 0, 0
+						scanner := bufio.NewScanner(strings.NewReader(stagingConfigDiff.Config))
+						for scanner.Scan() {
+							switch {
+							case strings.HasPrefix(scanner.Text(), "+"):
+								adds++
+							case strings.HasPrefix(scanner.Text(), "-"):
+								dels++
+							}
+						}
+						require.Greater(t, adds, 40)
+						require.Equal(t, dels, 0)
+
+						// deployed config should still have no diffs at this point
+						deployedConfigDiff, err := bp.GetNodeRenderedConfigDiff(ctx, leafId, enum.RenderedConfigTypeDeployed)
+						require.NoError(t, err)
+						require.NotNil(t, deployedConfigDiff)
+						require.Equal(t, "null", string(deployedConfigDiff.PristineConfig)) // no pristine config, i guess
+						require.Empty(t, deployedConfigDiff.Config)                         // no diff
+						require.False(t, deployedConfigDiff.SupportsDiffConfig)             // whatever this is
+						require.Greater(t, len(deployedConfigDiff.Context), 4000)           // 4KB-ish of context?
+
+						leafWg.Done()
+					})
+				}
+
+				t.Run("test_config_withdrawal_diff", func(t *testing.T) {
+					t.Parallel()
+
+					leafWg.Wait()
+
+					// commit the blueprint so our new VN shows up in deployed config
+					status, err := bp.Client().GetBlueprintStatus(ctx, bp.Id())
+					require.NoError(t, err)
+					_, err = bp.Client().DeployBlueprint(ctx, &BlueprintDeployRequest{
+						Id:          bp.Id(),
+						Description: `commit so that we can generate "delete" diffs`,
+						Version:     status.Version,
+					})
+					require.NoError(t, err)
+
+					// delete the VN to generate config withdrawals
+					err = bp.DeleteVirtualNetwork(ctx, vnId)
+					require.NoError(t, err)
+
+					for _, leafId := range leafIds {
+						// staging config should have diffs at this point
+						stagingConfigDiff, err := bp.GetNodeRenderedConfigDiff(ctx, leafId, enum.RenderedConfigTypeStaging)
+						require.NoError(t, err)
+						require.NotNil(t, stagingConfigDiff)
+						require.Equal(t, "null", string(stagingConfigDiff.PristineConfig)) // no pristine config, i guess
+						require.False(t, stagingConfigDiff.SupportsDiffConfig)             // whatever this is
+						require.Greater(t, len(stagingConfigDiff.Context), 4000)           // 4KB-ish of context?
+						adds, dels := 0, 0
+						scanner := bufio.NewScanner(strings.NewReader(stagingConfigDiff.Config))
+						for scanner.Scan() {
+							switch {
+							case strings.HasPrefix(scanner.Text(), "+"):
+								adds++
+							case strings.HasPrefix(scanner.Text(), "-"):
+								dels++
+							}
+						}
+						require.Equal(t, adds, 0)
+						require.Greater(t, dels, 40)
+
+						// deployed config should still have no diffs at this point
+						deployedConfigDiff, err := bp.GetNodeRenderedConfigDiff(ctx, leafId, enum.RenderedConfigTypeDeployed)
+						require.NoError(t, err)
+						require.NotNil(t, deployedConfigDiff)
+						require.Equal(t, "null", string(deployedConfigDiff.PristineConfig)) // no pristine config, i guess
+						require.Empty(t, deployedConfigDiff.Config)                         // no diff
+						require.False(t, deployedConfigDiff.SupportsDiffConfig)             // whatever this is
+						require.Greater(t, len(deployedConfigDiff.Context), 4000)           // 4KB-ish of context?
+					}
+				})
+			})
+		})
+	}
+}

--- a/apstra/two_stage_l3_clos_rendered_diff_integration_test.go
+++ b/apstra/two_stage_l3_clos_rendered_diff_integration_test.go
@@ -10,12 +10,13 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
-	"github.com/stretchr/testify/require"
 	"math/rand/v2"
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetNodeRenderedDiff(t *testing.T) {

--- a/apstra/two_stage_l3_clos_rendered_diff_integration_test.go
+++ b/apstra/two_stage_l3_clos_rendered_diff_integration_test.go
@@ -15,7 +15,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,22 +42,13 @@ func TestGetNodeRenderedDiff(t *testing.T) {
 					t.Parallel()
 
 					// staging config should have no diffs at this point
-					stagingConfigDiff, err := bp.GetNodeRenderedConfigDiff(ctx, leafId, enum.RenderedConfigTypeStaging)
+					diff, err := bp.GetNodeRenderedConfigDiff(ctx, leafId)
 					require.NoError(t, err)
-					require.NotNil(t, stagingConfigDiff)
-					require.Equal(t, "null", string(stagingConfigDiff.PristineConfig)) // no pristine config, i guess
-					require.Empty(t, stagingConfigDiff.Config)                         // no diff
-					require.False(t, stagingConfigDiff.SupportsDiffConfig)             // whatever this is
-					require.Greater(t, len(stagingConfigDiff.Context), 4000)           // 4KB-ish of context?
-
-					// deployed config should have no diffs at this point
-					deployedConfigDiff, err := bp.GetNodeRenderedConfigDiff(ctx, leafId, enum.RenderedConfigTypeStaging)
-					require.NoError(t, err)
-					require.NotNil(t, deployedConfigDiff)
-					require.Equal(t, "null", string(deployedConfigDiff.PristineConfig)) // no pristine config, i guess
-					require.Empty(t, deployedConfigDiff.Config)                         // no diff
-					require.False(t, deployedConfigDiff.SupportsDiffConfig)             // whatever this is
-					require.Greater(t, len(deployedConfigDiff.Context), 4000)           // 4KB-ish of context?
+					require.NotNil(t, diff)
+					require.Equal(t, "null", string(diff.PristineConfig)) // no pristine config, i guess
+					require.Empty(t, diff.Config)                         // no diff
+					require.False(t, diff.SupportsDiffConfig)             // whatever this is
+					require.Greater(t, len(diff.Context), 4000)           // 4KB-ish of context?
 
 					leafWg.Done()
 				})
@@ -118,14 +108,14 @@ func TestGetNodeRenderedDiff(t *testing.T) {
 						t.Parallel()
 
 						// staging config should have diffs at this point
-						stagingConfigDiff, err := bp.GetNodeRenderedConfigDiff(ctx, leafId, enum.RenderedConfigTypeStaging)
+						diff, err := bp.GetNodeRenderedConfigDiff(ctx, leafId)
 						require.NoError(t, err)
-						require.NotNil(t, stagingConfigDiff)
-						require.Equal(t, "null", string(stagingConfigDiff.PristineConfig)) // no pristine config, i guess
-						require.False(t, stagingConfigDiff.SupportsDiffConfig)             // whatever this is
-						require.Greater(t, len(stagingConfigDiff.Context), 4000)           // 4KB-ish of context?
+						require.NotNil(t, diff)
+						require.Equal(t, "null", string(diff.PristineConfig)) // no pristine config, i guess
+						require.False(t, diff.SupportsDiffConfig)             // whatever this is
+						require.Greater(t, len(diff.Context), 4000)           // 4KB-ish of context?
 						adds, dels := 0, 0
-						scanner := bufio.NewScanner(strings.NewReader(stagingConfigDiff.Config))
+						scanner := bufio.NewScanner(strings.NewReader(diff.Config))
 						for scanner.Scan() {
 							switch {
 							case strings.HasPrefix(scanner.Text(), "+"):
@@ -136,15 +126,6 @@ func TestGetNodeRenderedDiff(t *testing.T) {
 						}
 						require.Greater(t, adds, 40)
 						require.Equal(t, dels, 0)
-
-						// deployed config should still have no diffs at this point
-						deployedConfigDiff, err := bp.GetNodeRenderedConfigDiff(ctx, leafId, enum.RenderedConfigTypeDeployed)
-						require.NoError(t, err)
-						require.NotNil(t, deployedConfigDiff)
-						require.Equal(t, "null", string(deployedConfigDiff.PristineConfig)) // no pristine config, i guess
-						require.Empty(t, deployedConfigDiff.Config)                         // no diff
-						require.False(t, deployedConfigDiff.SupportsDiffConfig)             // whatever this is
-						require.Greater(t, len(deployedConfigDiff.Context), 4000)           // 4KB-ish of context?
 
 						leafWg.Done()
 					})
@@ -171,14 +152,14 @@ func TestGetNodeRenderedDiff(t *testing.T) {
 
 					for _, leafId := range leafIds {
 						// staging config should have diffs at this point
-						stagingConfigDiff, err := bp.GetNodeRenderedConfigDiff(ctx, leafId, enum.RenderedConfigTypeStaging)
+						diff, err := bp.GetNodeRenderedConfigDiff(ctx, leafId)
 						require.NoError(t, err)
-						require.NotNil(t, stagingConfigDiff)
-						require.Equal(t, "null", string(stagingConfigDiff.PristineConfig)) // no pristine config, i guess
-						require.False(t, stagingConfigDiff.SupportsDiffConfig)             // whatever this is
-						require.Greater(t, len(stagingConfigDiff.Context), 4000)           // 4KB-ish of context?
+						require.NotNil(t, diff)
+						require.Equal(t, "null", string(diff.PristineConfig)) // no pristine config, i guess
+						require.False(t, diff.SupportsDiffConfig)             // whatever this is
+						require.Greater(t, len(diff.Context), 4000)           // 4KB-ish of context?
 						adds, dels := 0, 0
-						scanner := bufio.NewScanner(strings.NewReader(stagingConfigDiff.Config))
+						scanner := bufio.NewScanner(strings.NewReader(diff.Config))
 						for scanner.Scan() {
 							switch {
 							case strings.HasPrefix(scanner.Text(), "+"):
@@ -189,15 +170,6 @@ func TestGetNodeRenderedDiff(t *testing.T) {
 						}
 						require.Equal(t, adds, 0)
 						require.Greater(t, dels, 40)
-
-						// deployed config should still have no diffs at this point
-						deployedConfigDiff, err := bp.GetNodeRenderedConfigDiff(ctx, leafId, enum.RenderedConfigTypeDeployed)
-						require.NoError(t, err)
-						require.NotNil(t, deployedConfigDiff)
-						require.Equal(t, "null", string(deployedConfigDiff.PristineConfig)) // no pristine config, i guess
-						require.Empty(t, deployedConfigDiff.Config)                         // no diff
-						require.False(t, deployedConfigDiff.SupportsDiffConfig)             // whatever this is
-						require.Greater(t, len(deployedConfigDiff.Context), 4000)           // 4KB-ish of context?
 					}
 				})
 			})


### PR DESCRIPTION
This PR:
- renames some URL constants which *seemed at the time* like they were unique to generic systems. Turns out this API path is used for both generic systems and switches.
- introduces `TwoStageL3ClosClient.GetNodeRenderedConfig()` with related enum values and tests
- introduces `TwoStageL3ClosClient.GetSystemRenderedConfig()` with related enum values and tests
- introduces `TwoStageL3ClosClient.GetNodeRenderedConfigDiff()` with related struct and tests
- introduces `TwoStageL3ClosClient.GetSystemRenderedConfigDiff()` with related struct and tests

Closes #440