### PR TITLE
Move rendered config stuff from bp client to platform client

### DIFF
--- a/apstra/client_rendered_config.go
+++ b/apstra/client_rendered_config.go
@@ -34,14 +34,14 @@ func (o *Client) GetNodeRenderedConfig(ctx context.Context, bpId, nodeId ObjectI
 	return apiResponse.Config, nil
 }
 
-func (o *Client) GetSystemRenderedConfig(ctx context.Context, bpId, nodeId ObjectId, rcType enum.RenderedConfigType) (string, error) {
+func (o *Client) GetSystemRenderedConfig(ctx context.Context, bpId, sysId ObjectId, rcType enum.RenderedConfigType) (string, error) {
 	var apiResponse struct {
 		Config string `json:"config"`
 	}
 
 	err := o.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodGet,
-		urlStr:      fmt.Sprintf(apiUrlBlueprintSystemConfigRender, bpId, nodeId, rcType.String()),
+		urlStr:      fmt.Sprintf(apiUrlBlueprintSystemConfigRender, bpId, sysId, rcType.String()),
 		apiResponse: &apiResponse,
 	})
 	if err != nil {

--- a/apstra/client_rendered_config.go
+++ b/apstra/client_rendered_config.go
@@ -17,14 +17,14 @@ const (
 	apiUrlBlueprintSystemConfigRender = apiUrlBlueprintSystemByIdPrefix + "config-rendering?type=%s"
 )
 
-func (o *TwoStageL3ClosClient) GetNodeRenderedConfig(ctx context.Context, id ObjectId, rcType enum.RenderedConfigType) (string, error) {
+func (o *Client) GetNodeRenderedConfig(ctx context.Context, bpId, nodeId ObjectId, rcType enum.RenderedConfigType) (string, error) {
 	var apiResponse struct {
 		Config string `json:"config"`
 	}
 
-	err := o.client.talkToApstra(ctx, &talkToApstraIn{
+	err := o.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodGet,
-		urlStr:      fmt.Sprintf(apiUrlBlueprintNodeConfigRender, o.blueprintId, id, rcType.String()),
+		urlStr:      fmt.Sprintf(apiUrlBlueprintNodeConfigRender, bpId, nodeId, rcType.String()),
 		apiResponse: &apiResponse,
 	})
 	if err != nil {
@@ -34,14 +34,14 @@ func (o *TwoStageL3ClosClient) GetNodeRenderedConfig(ctx context.Context, id Obj
 	return apiResponse.Config, nil
 }
 
-func (o *TwoStageL3ClosClient) GetSystemRenderedConfig(ctx context.Context, id ObjectId, rcType enum.RenderedConfigType) (string, error) {
+func (o *Client) GetSystemRenderedConfig(ctx context.Context, bpId, nodeId ObjectId, rcType enum.RenderedConfigType) (string, error) {
 	var apiResponse struct {
 		Config string `json:"config"`
 	}
 
-	err := o.client.talkToApstra(ctx, &talkToApstraIn{
+	err := o.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodGet,
-		urlStr:      fmt.Sprintf(apiUrlBlueprintSystemConfigRender, o.blueprintId, id, rcType.String()),
+		urlStr:      fmt.Sprintf(apiUrlBlueprintSystemConfigRender, bpId, nodeId, rcType.String()),
 		apiResponse: &apiResponse,
 	})
 	if err != nil {

--- a/apstra/client_rendered_config_integration_test.go
+++ b/apstra/client_rendered_config_integration_test.go
@@ -37,7 +37,7 @@ func TestGetNodeRenderedConfig(t *testing.T) {
 				t.Run("leaf_"+leafId.String()+"_staging", func(t *testing.T) {
 					t.Parallel()
 
-					stagingConfig, err := bp.GetNodeRenderedConfig(ctx, leafId, enum.RenderedConfigTypeStaging)
+					stagingConfig, err := bp.Client().GetNodeRenderedConfig(ctx, bp.Id(), leafId, enum.RenderedConfigTypeStaging)
 					require.NoError(t, err)
 					lineCount := 0
 					scanner := bufio.NewScanner(strings.NewReader(stagingConfig))
@@ -50,7 +50,7 @@ func TestGetNodeRenderedConfig(t *testing.T) {
 				t.Run("leaf_"+leafId.String()+"_deployed", func(t *testing.T) {
 					t.Parallel()
 
-					deployedConfig, err := bp.GetNodeRenderedConfig(ctx, leafId, enum.RenderedConfigTypeDeployed)
+					deployedConfig, err := bp.Client().GetNodeRenderedConfig(ctx, bp.Id(), leafId, enum.RenderedConfigTypeDeployed)
 					require.NoError(t, err)
 					lineCount := 0
 					scanner := bufio.NewScanner(strings.NewReader(deployedConfig))

--- a/apstra/client_rendered_diff.go
+++ b/apstra/client_rendered_diff.go
@@ -38,12 +38,12 @@ func (o *Client) GetNodeRenderedConfigDiff(ctx context.Context, bpId, nodeId Obj
 	return &apiResponse, nil
 }
 
-func (o *Client) GetSystemRenderedConfigDiff(ctx context.Context, bpId, nodeId ObjectId) (*RenderDiff, error) {
+func (o *Client) GetSystemRenderedConfigDiff(ctx context.Context, bpId, sysId ObjectId) (*RenderDiff, error) {
 	var apiResponse RenderDiff
 
 	err := o.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodGet,
-		urlStr:      fmt.Sprintf(apiUrlBlueprintSystemConfigRenderDiff, bpId, nodeId),
+		urlStr:      fmt.Sprintf(apiUrlBlueprintSystemConfigRenderDiff, bpId, sysId),
 		apiResponse: &apiResponse,
 	})
 	if err != nil {

--- a/apstra/client_rendered_diff.go
+++ b/apstra/client_rendered_diff.go
@@ -23,12 +23,12 @@ type RenderDiff struct {
 	SupportsDiffConfig bool            `json:"supports_diff_config"`
 }
 
-func (o *TwoStageL3ClosClient) GetNodeRenderedConfigDiff(ctx context.Context, id ObjectId) (*RenderDiff, error) {
+func (o *Client) GetNodeRenderedConfigDiff(ctx context.Context, bpId, nodeId ObjectId) (*RenderDiff, error) {
 	var apiResponse RenderDiff
 
-	err := o.client.talkToApstra(ctx, &talkToApstraIn{
+	err := o.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodGet,
-		urlStr:      fmt.Sprintf(apiUrlBlueprintNodeConfigRenderDiff, o.blueprintId, id),
+		urlStr:      fmt.Sprintf(apiUrlBlueprintNodeConfigRenderDiff, bpId, nodeId),
 		apiResponse: &apiResponse,
 	})
 	if err != nil {
@@ -38,12 +38,12 @@ func (o *TwoStageL3ClosClient) GetNodeRenderedConfigDiff(ctx context.Context, id
 	return &apiResponse, nil
 }
 
-func (o *TwoStageL3ClosClient) GetSystemRenderedConfigDiff(ctx context.Context, id ObjectId) (*RenderDiff, error) {
+func (o *Client) GetSystemRenderedConfigDiff(ctx context.Context, bpId, nodeId ObjectId) (*RenderDiff, error) {
 	var apiResponse RenderDiff
 
-	err := o.client.talkToApstra(ctx, &talkToApstraIn{
+	err := o.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodGet,
-		urlStr:      fmt.Sprintf(apiUrlBlueprintSystemConfigRenderDiff, o.blueprintId, id),
+		urlStr:      fmt.Sprintf(apiUrlBlueprintSystemConfigRenderDiff, bpId, nodeId),
 		apiResponse: &apiResponse,
 	})
 	if err != nil {

--- a/apstra/client_rendered_diff_integration_test.go
+++ b/apstra/client_rendered_diff_integration_test.go
@@ -42,7 +42,7 @@ func TestGetNodeRenderedDiff(t *testing.T) {
 					t.Parallel()
 
 					// staging config should have no diffs at this point
-					diff, err := bp.GetNodeRenderedConfigDiff(ctx, leafId)
+					diff, err := bp.Client().GetNodeRenderedConfigDiff(ctx, bp.Id(), leafId)
 					require.NoError(t, err)
 					require.NotNil(t, diff)
 					require.Equal(t, "null", string(diff.PristineConfig)) // no pristine config, i guess
@@ -108,7 +108,7 @@ func TestGetNodeRenderedDiff(t *testing.T) {
 						t.Parallel()
 
 						// staging config should have diffs at this point
-						diff, err := bp.GetNodeRenderedConfigDiff(ctx, leafId)
+						diff, err := bp.Client().GetNodeRenderedConfigDiff(ctx, bp.Id(), leafId)
 						require.NoError(t, err)
 						require.NotNil(t, diff)
 						require.Equal(t, "null", string(diff.PristineConfig)) // no pristine config, i guess
@@ -152,7 +152,7 @@ func TestGetNodeRenderedDiff(t *testing.T) {
 
 					for _, leafId := range leafIds {
 						// staging config should have diffs at this point
-						diff, err := bp.GetNodeRenderedConfigDiff(ctx, leafId)
+						diff, err := bp.Client().GetNodeRenderedConfigDiff(ctx, bp.Id(), leafId)
 						require.NoError(t, err)
 						require.NotNil(t, diff)
 						require.Equal(t, "null", string(diff.PristineConfig)) // no pristine config, i guess


### PR DESCRIPTION
These functions were initially written as methods on our `TwoStageL3ClosClient` object:
- `GetNodeRenderedConfig()`
- `GetSystemRenderedConfig()`
- `GetNodeRenderedConfigDiff()`
- `GetSystemRenderedConfigDiff()`

But they're not specific to the *datacenter* reference design. They are (appear to be?) equally applicable to *freeform* reference design.

This PR moves those methods from `TwoStageL3ClosClient` to `Client` and requires the blueprint ID to be passed as an argument since it's not embedded in the `Client` object.

No logic changes.