### PR TITLE
Error instead of forcing empty value

### DIFF
--- a/apstra/api_iba_dashboards.go
+++ b/apstra/api_iba_dashboards.go
@@ -196,10 +196,11 @@ func (o *Client) getIbaDashboardByLabel(ctx context.Context, blueprintId ObjectI
 func (o *Client) createIbaDashboard(ctx context.Context, blueprintId ObjectId, in *IbaDashboardData) (ObjectId, error) {
 	var response objectIdResponse
 	if in.UpdatedBy != "" {
-		return "", errors.New("UpdatedBy is set by Apstra")
+		return "", errors.New("attempt to create dashboard with non-empty updated_by value - this value can be set only by the server")
 	}
 	if in.PredefinedDashboard != "" {
-		return "", errors.New("to instantiate predefined dashboard, please use InstantiatePredefinedDashboard")
+		return "", errors.New("attempt to create dashboard with non-empty predefined_dashboard value - this value can " +
+			"be set only by the server, and only when a dashboard is instantiated from a predefined template")
 	}
 	err := o.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodPost,
@@ -251,8 +252,14 @@ func (o *Client) createIbaDashboard(ctx context.Context, blueprintId ObjectId, i
 }
 
 func (o *Client) updateIbaDashboard(ctx context.Context, blueprintId ObjectId, id ObjectId, in *IbaDashboardData) error {
-	in.UpdatedBy = ""
-	in.PredefinedDashboard = ""
+	if in.UpdatedBy != "" {
+		return errors.New("attempt to update dashboard with non-empty updated_by value - this value can be set only by the server")
+	}
+	if in.PredefinedDashboard != "" {
+		return errors.New("attempt to update dashboard with non-empty predefined_dashboard value - this value can " +
+			"be set only by the server, and only when a dashboard is instantiated from a predefined template")
+	}
+
 	err := o.talkToApstra(ctx, &talkToApstraIn{
 		method: http.MethodPut, urlStr: fmt.Sprintf(apiUrlIbaDashboardsById, blueprintId, id), apiInput: in,
 	})

--- a/apstra/api_iba_dashboards_test.go
+++ b/apstra/api_iba_dashboards_test.go
@@ -47,9 +47,6 @@ func TestCreateReadUpdateDeleteIbaDashboards(t *testing.T) {
 				}
 
 				id, err := bpClient.InstantiateIbaPredefinedDashboard(ctx, d, d.String())
-				if err != nil {
-					t.Log(err)
-				}
 				require.NoError(t, err)
 
 				t.Logf("Name :%s Created Id :%s", d, id)


### PR DESCRIPTION
Three little things:

1. I verbosed-up the error messages a little
2. Overwriting mandatory-empty values in `updateIbaDashboard()` felt bad because it's a pointer to not-our-struct and this function isn't obviously intended to mutate the offered data. So I changed it to an error if the values are non-empty.
3. Killed off a redundant error check.

We can clone the submitted struct and overwrite the values in the clone if "helpfully" squashing those strings seems important. I'm not sure that it is.

Thoughts?