### PR TITLE
Minor test improvement

### DIFF
--- a/apstra/api_system_agent_test.go
+++ b/apstra/api_system_agent_test.go
@@ -18,58 +18,50 @@ import (
 
 func TestGetSetSystemAgentManagerConfiguration(t *testing.T) {
 	clients, err := getTestClients(context.Background(), t)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	for clientName, client := range clients {
-		err = client.client.Login(context.Background())
-		if err != nil {
-			t.Fatal(err)
-		}
-		// initial fetch
-		log.Printf("testing GetSystemAgentManagerConfig() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		mgrCfg, err := client.client.GetSystemAgentManagerConfig(context.Background())
-		if err != nil {
-			t.Fatal(err)
-		}
+		t.Run(client.name(), func(t *testing.T) {
+			t.Parallel()
 
-		// new config with opposite values
-		testCfg := &SystemAgentManagerConfig{
-			SkipRevertToPristineOnUninstall: !mgrCfg.SkipRevertToPristineOnUninstall,
-			SkipPristineValidation:          !mgrCfg.SkipPristineValidation,
-			SkipInterfaceShutdownOnUpgrade:  !mgrCfg.SkipInterfaceShutdownOnUpgrade,
-		}
+			// initial fetch
+			log.Printf("testing GetSystemAgentManagerConfig() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+			mgrCfg, err := client.client.GetSystemAgentManagerConfig(context.Background())
+			require.NoError(t, err)
 
-		// set new config
-		log.Printf("testing SetSystemAgentManagerConfig() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		err = client.client.SetSystemAgentManagerConfig(context.Background(), testCfg)
-		if !compatibility.SystemManagerHasSkipInterfaceShutdownOnUpgrade.Check(client.client.apiVersion) {
-			require.Error(t, err)
-			log.Printf("apstra %s refused to run with SkipInterfaceShutdownOnUpgrade set to %t", client.client.apiVersion, testCfg.SkipInterfaceShutdownOnUpgrade)
+			// new config with opposite values
+			testCfg := &SystemAgentManagerConfig{
+				SkipRevertToPristineOnUninstall: !mgrCfg.SkipRevertToPristineOnUninstall,
+				SkipPristineValidation:          !mgrCfg.SkipPristineValidation,
+				SkipInterfaceShutdownOnUpgrade:  !mgrCfg.SkipInterfaceShutdownOnUpgrade,
+			}
 
-			testCfg.SkipInterfaceShutdownOnUpgrade = false
+			// set new config
+			log.Printf("testing SetSystemAgentManagerConfig() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 			err = client.client.SetSystemAgentManagerConfig(context.Background(), testCfg)
-		}
-		require.NoError(t, err)
+			if !compatibility.SystemManagerHasSkipInterfaceShutdownOnUpgrade.Check(client.client.apiVersion) {
+				require.Error(t, err)
+				log.Printf("apstra %s refused to run with SkipInterfaceShutdownOnUpgrade set to %t", client.client.apiVersion, testCfg.SkipInterfaceShutdownOnUpgrade)
 
-		// fetch new config
-		log.Printf("testing GetSystemAgentManagerConfig() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		testCfgRetrieved, err := client.client.GetSystemAgentManagerConfig(context.Background())
-		if err != nil {
-			t.Fatal(err)
-		}
+				testCfg.SkipInterfaceShutdownOnUpgrade = false
+				err = client.client.SetSystemAgentManagerConfig(context.Background(), testCfg)
+			}
+			require.NoError(t, err)
 
-		// validate field as expected
-		require.Equal(t, testCfg.SkipPristineValidation, testCfgRetrieved.SkipPristineValidation)
-		require.Equal(t, testCfg.SkipInterfaceShutdownOnUpgrade, testCfgRetrieved.SkipInterfaceShutdownOnUpgrade)
-		require.Equal(t, testCfg.SkipRevertToPristineOnUninstall, testCfgRetrieved.SkipRevertToPristineOnUninstall)
+			// fetch new config
+			log.Printf("testing GetSystemAgentManagerConfig() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+			testCfgRetrieved, err := client.client.GetSystemAgentManagerConfig(context.Background())
+			require.NoError(t, err)
 
-		// reset to original configuration
-		log.Printf("testing SetSystemAgentManagerConfig() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		err = client.client.SetSystemAgentManagerConfig(context.Background(), mgrCfg)
-		if err != nil {
-			t.Fatal(err)
-		}
+			// validate field as expected
+			require.Equal(t, testCfg.SkipPristineValidation, testCfgRetrieved.SkipPristineValidation)
+			require.Equal(t, testCfg.SkipInterfaceShutdownOnUpgrade, testCfgRetrieved.SkipInterfaceShutdownOnUpgrade)
+			require.Equal(t, testCfg.SkipRevertToPristineOnUninstall, testCfgRetrieved.SkipRevertToPristineOnUninstall)
+
+			// reset to original configuration
+			log.Printf("testing SetSystemAgentManagerConfig() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+			err = client.client.SetSystemAgentManagerConfig(context.Background(), mgrCfg)
+			require.NoError(t, err)
+		})
 	}
 }


### PR DESCRIPTION
Minor test rewrite - no logic changes, but introduced `t.Run()` for clarity on which version was causing a problem (it was 5.1.0)