### PR TITLE
Update slicer URL; Fix missing error check

### DIFF
--- a/apstra/test_clients_slicer_test.go
+++ b/apstra/test_clients_slicer_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	slicerTopologyUrlById   = "http://slicer-topology-management-ui.k8s-ci.dc1.apstra.com/v1_1/systest/%s"
+	slicerTopologyUrlById   = "http://slicer-topology-management-ui.k8s-autobuild.dc1.apstra.com/v1_1/systest/%s"
 	envSlicerTopologyIdList = "SLICER_TOPOLOGIES"
 )
 

--- a/apstra/test_clients_test.go
+++ b/apstra/test_clients_test.go
@@ -122,6 +122,10 @@ func getTestClientCfgs(ctx context.Context) (map[string]testClientCfg, error) {
 
 	// add slicer to testClients slice here
 	slicerTestClientCfgs, err := getSlicerTestClientCfgs(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	for k, v := range slicerTestClientCfgs {
 		testClientCfgs[k] = v
 	}


### PR DESCRIPTION
Two changes here:

- Slicer API URL has changed. Update it in test client code.
- Add missing error check when collecting slicer test clients.

Closes #467