### PR TITLE
Create methods and structs to modify VN bindings

### DIFF
--- a/apstra/compatibility/constraints.go
+++ b/apstra/compatibility/constraints.go
@@ -20,6 +20,9 @@ var (
 	FabricSettingsApiOk = Constraint{
 		constraints: version.MustConstraints(version.NewConstraint(">=" + apstra421)),
 	}
+	EmptyVnBindingsOk = Constraint{
+		constraints: version.MustConstraints(version.NewConstraint(">=" + apstra500)),
+	}
 	IbaDashboardSupported = Constraint{
 		constraints: version.MustConstraints(version.NewConstraint(">=" + apstra500)),
 	}

--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -88,6 +88,20 @@ func randomIpv6() net.IP {
 	}
 }
 
+func randomIntsN(s []int, n int) {
+	l := len(s)
+	m := make(map[int]struct{}, l)
+	for len(m) < l {
+		m[rand.Intn(n)] = struct{}{}
+	}
+
+	i := 0
+	for k := range m {
+		s[i] = k
+		i++
+	}
+}
+
 func randomPrefix(t testing.TB, cidrBlock string, bits int) net.IPNet {
 	t.Helper()
 
@@ -1123,4 +1137,8 @@ func wrapCtxWithTestId(t testing.TB, ctx context.Context) context.Context {
 	}
 
 	return context.WithValue(ctx, CtxKeyTestID, UUID.String()+"/"+t.Name())
+}
+
+func oneOf[A interface{}](i A, s ...A) A {
+	return append([]A{i}, s...)[rand.Intn(len(s)+1)]
 }

--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -88,6 +88,7 @@ func randomIpv6() net.IP {
 	}
 }
 
+// randomIntsN fills the supplied slice with non-negative pseudo-random values in the half-open interval [0,n)
 func randomIntsN(s []int, n int) {
 	l := len(s)
 	m := make(map[int]struct{}, l)

--- a/apstra/test_clients_slicer_test.go
+++ b/apstra/test_clients_slicer_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	slicerTopologyUrlById   = "http://slicer-topology-management-ui.k8s-ci.dc1.apstra.com/v1_1/systest/%s"
+	slicerTopologyUrlById   = "http://slicer-topology-management-ui.k8s-autobuild.dc1.apstra.com/v1_1/systest/%s"
 	envSlicerTopologyIdList = "SLICER_TOPOLOGIES"
 )
 

--- a/apstra/test_clients_test.go
+++ b/apstra/test_clients_test.go
@@ -122,6 +122,10 @@ func getTestClientCfgs(ctx context.Context) (map[string]testClientCfg, error) {
 
 	// add slicer to testClients slice here
 	slicerTestClientCfgs, err := getSlicerTestClientCfgs(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	for k, v := range slicerTestClientCfgs {
 		testClientCfgs[k] = v
 	}

--- a/apstra/two_stage_l3_clos_virtual_network_bindings.go
+++ b/apstra/two_stage_l3_clos_virtual_network_bindings.go
@@ -47,7 +47,7 @@ func (o *TwoStageL3ClosClient) SetVirtualNetworkLeafBindings(ctx context.Context
 			return fmt.Errorf("siMap[%s] has system ID (%s)", k, v.SystemId) // map key should match payload
 		}
 		if _, ok := req.VnBindings[k]; !ok {
-			// this is the big one - check for SVI info
+			// this is the big one - check that SVI info represents an active VN binding
 			return fmt.Errorf("SVI requested for system %[1]s but %[1]s not among bound leaf IDs", k)
 		}
 		sviIps[i] = *v

--- a/apstra/two_stage_l3_clos_virtual_network_bindings.go
+++ b/apstra/two_stage_l3_clos_virtual_network_bindings.go
@@ -1,0 +1,166 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package apstra
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+type VirtualNetworkBindingsRequest struct {
+	VnId               ObjectId
+	VnBindings         map[ObjectId]*VnBinding
+	SviIps             map[ObjectId]*SviIp
+	DhcpServiceEnabled *DhcpServiceEnabled
+}
+
+// SetVirtualNetworkLeafBindings replaces the current set of SVI and
+// Binding info on the Virtual Network identified by vnId.
+func (o *TwoStageL3ClosClient) SetVirtualNetworkLeafBindings(ctx context.Context, req VirtualNetworkBindingsRequest) error {
+	var i int
+
+	// turn the supplied map into a slice for the API, with some sanity checking along the way
+	i = 0
+	boundTo := make([]VnBinding, len(req.VnBindings))
+	for k, v := range req.VnBindings {
+		if v == nil {
+			return fmt.Errorf("vbMap[%s] is nil", k) // map entries should not be nil
+		}
+		if k != v.SystemId {
+			return fmt.Errorf("vbMap[%s] has system ID (%s)", k, v.SystemId) // map key should match payload
+		}
+		boundTo[i] = *v
+		i++
+	}
+
+	// turn the supplied map into a slice for the API, with some sanity checking along the way
+	i = 0
+	sviIps := make([]SviIp, len(req.SviIps))
+	for k, v := range req.SviIps {
+		if v == nil {
+			return fmt.Errorf("siMap[%s] is nil", k) // map entries should not be nil
+		}
+		if k != v.SystemId {
+			return fmt.Errorf("siMap[%s] has system ID (%s)", k, v.SystemId) // map key should match payload
+		}
+		if _, ok := req.VnBindings[k]; !ok {
+			// this is the big one - check for SVI info
+			return fmt.Errorf("SVI requested for system %[1]s but %[1]s not among bound leaf IDs", k)
+		}
+		sviIps[i] = *v
+		i++
+	}
+
+	o.client.lock(o.blueprintId.String() + "_" + req.VnId.String())
+	defer o.client.unlock(o.blueprintId.String() + "_" + req.VnId.String())
+
+	err := o.client.talkToApstra(ctx, &talkToApstraIn{
+		method: http.MethodPatch,
+		urlStr: fmt.Sprintf(apiUrlVirtualNetworkById, o.blueprintId, req.VnId),
+		apiInput: struct {
+			SviIps             []SviIp             `json:"svi_ips"`
+			BoundTo            []VnBinding         `json:"bound_to"`
+			DhcpServiceEnabled *DhcpServiceEnabled `json:"dhcp_service,omitempty"`
+		}{
+			SviIps:             sviIps,
+			BoundTo:            boundTo,
+			DhcpServiceEnabled: req.DhcpServiceEnabled,
+		},
+	})
+	if err != nil {
+		return convertTtaeToAceWherePossible(err)
+	}
+
+	return nil
+}
+
+// UpdateVirtualNetworkLeafBindings updates the supplied SVI and Binding info on
+// the Virtual Network identified by vnId. The update requires two API calls:
+// The current set of SVI and Binding info is fetched, the supplied data is
+// merged, and then the combined set is sent back to the API. Binding and SVI
+// configuration can be removed using a nil map entry.
+func (o *TwoStageL3ClosClient) UpdateVirtualNetworkLeafBindings(ctx context.Context, req VirtualNetworkBindingsRequest) error {
+	for k, v := range req.VnBindings {
+		if v == nil {
+			continue
+		}
+
+		if k != v.SystemId {
+			return fmt.Errorf("vbMap[%s] has system ID (%s)", k, v.SystemId)
+		}
+	}
+
+	for k, v := range req.SviIps {
+		if v == nil {
+			continue
+		}
+
+		if k != v.SystemId {
+			return fmt.Errorf("siMap[%s] has system ID (%s)", k, v.SystemId)
+		}
+		if _, ok := req.VnBindings[v.SystemId]; !ok {
+			return fmt.Errorf("SVI requested for system %[1]s but %[1]s not among bound leaf IDs, or is being removed", k)
+		}
+	}
+
+	o.client.lock(o.blueprintId.String() + "_" + req.VnId.String())
+	defer o.client.unlock(o.blueprintId.String() + "_" + req.VnId.String())
+
+	// collect current VN info (bindings and SVI IPs)
+	vn, err := o.GetVirtualNetwork(ctx, req.VnId)
+	if err != nil {
+		return fmt.Errorf("update VN binding info failed to fetch current bindings - %w", err)
+	}
+
+	// drop any current binding which appears in the caller's binding map
+	for i := len(vn.Data.VnBindings) - 1; i >= 0; i-- { // loop backward over current VN bindings
+		if _, ok := req.VnBindings[vn.Data.VnBindings[i].SystemId]; ok {
+			// current VN passed by caller; delete it; we'll use caller's data instead
+			vn.Data.VnBindings[i] = vn.Data.VnBindings[len(vn.Data.VnBindings)-1] // copy last to index i
+			vn.Data.VnBindings = vn.Data.VnBindings[:len(vn.Data.VnBindings)-1]   // trim last from slice
+		}
+	}
+
+	// drop any current SVI IP referencing a binding mentioned in the caller's binding map
+	for i := len(vn.Data.SviIps) - 1; i >= 0; i-- { // loop backward over current SVI IP info
+		if _, ok := req.VnBindings[vn.Data.SviIps[i].SystemId]; ok {
+			// current SVI IP info relates to VN passed by caller; delete it; we'll use caller's data instead
+			vn.Data.SviIps[i] = vn.Data.SviIps[len(vn.Data.SviIps)-1] // copy last to index i
+			vn.Data.SviIps = vn.Data.SviIps[:len(vn.Data.SviIps)-1]   // trim last from slice
+		}
+	}
+
+	// copy non-nil (non-delete) bindings from the caller's map to the binding slice we'll send back
+	for _, binding := range req.VnBindings {
+		if binding != nil {
+			vn.Data.VnBindings = append(vn.Data.VnBindings, *binding)
+		}
+	}
+
+	// copy non-nil (non-delete) SVI IPs from the caller's map to the binding slice we'll send back
+	for _, sviIp := range req.SviIps {
+		if sviIp != nil {
+			vn.Data.SviIps = append(vn.Data.SviIps, *sviIp)
+		}
+	}
+
+	err = o.client.talkToApstra(ctx, &talkToApstraIn{
+		method: http.MethodPatch,
+		urlStr: fmt.Sprintf(apiUrlVirtualNetworkById, o.blueprintId, req.VnId),
+		apiInput: struct {
+			SviIps  []SviIp     `json:"svi_ips"`
+			BoundTo []VnBinding `json:"bound_to"`
+		}{
+			SviIps:  vn.Data.SviIps,
+			BoundTo: vn.Data.VnBindings,
+		},
+	})
+	if err != nil {
+		return convertTtaeToAceWherePossible(err)
+	}
+
+	return nil
+}

--- a/apstra/two_stage_l3_clos_virtual_network_bindings.go
+++ b/apstra/two_stage_l3_clos_virtual_network_bindings.go
@@ -101,7 +101,7 @@ func (o *TwoStageL3ClosClient) UpdateVirtualNetworkLeafBindings(ctx context.Cont
 		if k != v.SystemId {
 			return fmt.Errorf("siMap[%s] has system ID (%s)", k, v.SystemId)
 		}
-		if _, ok := req.VnBindings[v.SystemId]; !ok {
+		if binding := req.VnBindings[k]; binding == nil {
 			return fmt.Errorf("SVI requested for system %[1]s but %[1]s not among bound leaf IDs, or is being removed", k)
 		}
 	}

--- a/apstra/two_stage_l3_clos_virtual_network_bindings_integration_test.go
+++ b/apstra/two_stage_l3_clos_virtual_network_bindings_integration_test.go
@@ -11,7 +11,6 @@ import (
 	"log"
 	"math/rand"
 	"net"
-	"sort"
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra/compatibility"
@@ -105,7 +104,6 @@ func TestSetVirtualNetworkLeafBindings(t *testing.T) {
 			require.NoError(t, err)
 			require.GreaterOrEqual(t, len(leafIds), 2, "test requires at least 2 leaf switches")
 			require.LessOrEqual(t, len(leafIds), 40, "test requires no more than 40 leaf switches")
-			sort.Slice(leafIds, func(i, j int) bool { return leafIds[i] < leafIds[j] })
 
 			rzLabel := randString(6, "hex")
 			rzId, err := bp.CreateSecurityZone(ctx, &SecurityZoneData{
@@ -171,6 +169,206 @@ func TestSetVirtualNetworkLeafBindings(t *testing.T) {
 				require.NoError(t, err)
 				compareBindingsMaps(t, bindings, bindingSliceToMap(t, vn.Data.VnBindings))
 				compareSviMaps(t, sviIps, sviSliceToMap(t, vn.Data.SviIps))
+			}
+		})
+	}
+}
+
+func TestUpdateVirtualNetworkLeafBindings(t *testing.T) {
+	ctx := context.Background()
+
+	clients, err := getTestClients(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bindingSliceToMap := func(t testing.TB, in []VnBinding) map[ObjectId]*VnBinding {
+		t.Helper()
+
+		result := make(map[ObjectId]*VnBinding, len(in))
+		for _, binding := range in {
+			result[binding.SystemId] = &binding
+		}
+
+		if len(in) != len(result) {
+			t.Fatalf("after converting binding slice to map, had %d bindings, expected %d", len(result), len(in))
+		}
+
+		return result
+	}
+
+	sviSliceToMap := func(t testing.TB, in []SviIp) map[ObjectId]*SviIp {
+		t.Helper()
+
+		result := make(map[ObjectId]*SviIp, len(in))
+		for _, sviIp := range in {
+			result[sviIp.SystemId] = &sviIp
+		}
+
+		if len(in) != len(result) {
+			t.Fatalf("after converting svi slice to map, had %d svis, expected %d", len(result), len(in))
+		}
+
+		return result
+	}
+
+	compareBindingsMaps := func(t testing.TB, a, b map[ObjectId]*VnBinding) {
+		t.Helper()
+
+		if len(a) != len(b) {
+			t.Fatalf("bindings count mismatch: %d vs %d", len(a), len(b))
+		}
+
+		for id, bindingA := range a {
+			bindingB, ok := b[id]
+			if !ok {
+				t.Fatalf("binding %q from 'a' map not found in 'b' map", id)
+			}
+
+			compareVnBindings(t, *bindingA, *bindingB, true)
+		}
+	}
+
+	compareSviMaps := func(t testing.TB, a, b map[ObjectId]*SviIp) {
+		t.Helper()
+
+		if len(a) != len(b) {
+			t.Fatalf("svi count mismatch: %d vs %d", len(a), len(b))
+		}
+
+		for id, sviIpA := range a {
+			sviIpB, ok := b[id]
+			if !ok {
+				t.Fatalf("svi %q from 'a' map not found in 'b' map", id)
+			}
+
+			comapareSviIps(t, *sviIpA, *sviIpB)
+		}
+	}
+
+	for clientName, client := range clients {
+		t.Run(client.name(), func(t *testing.T) {
+			t.Parallel()
+
+			if !compatibility.EmptyVnBindingsOk.Check(client.client.apiVersion) {
+				t.Skipf("test applies only to versions %q", compatibility.EmptyVnBindingsOk)
+			}
+
+			bp := testBlueprintC(ctx, t, client.client)
+
+			leafIds, err := getSystemIdsByRole(ctx, bp, "leaf")
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, len(leafIds), 2, "test requires at least 2 leaf switches")
+			require.LessOrEqual(t, len(leafIds), 40, "test requires no more than 40 leaf switches")
+
+			// drop the first leaf from the slice, since we'll put a fixed binding and IP on it
+			fixedLeafId := leafIds[0]
+			leafIds = leafIds[1:]
+
+			rzLabel := randString(6, "hex")
+			rzId, err := bp.CreateSecurityZone(ctx, &SecurityZoneData{
+				Label:   rzLabel,
+				SzType:  SecurityZoneTypeEVPN,
+				VrfName: rzLabel,
+			})
+			require.NoError(t, err)
+
+			vnPrefix := randomPrefix(t, "10.0.0.0/8", 24)
+			vnBinding := VnBinding{
+				SystemId: fixedLeafId,
+				VlanId:   toPtr(Vlan(rand.Intn(97) + 2)),
+			}
+			sviIp := SviIp{
+				SystemId: fixedLeafId,
+				Ipv4Addr: &net.IPNet{
+					IP:   []byte{vnPrefix.IP[0], vnPrefix.IP[1], vnPrefix.IP[2], 2},
+					Mask: vnPrefix.Mask,
+				},
+				Ipv4Mode: oneOf(enum.SviIpv4ModeEnabled, enum.SviIpv4ModeForced),
+				Ipv6Mode: enum.SviIpv6ModeDisabled,
+			}
+			vnId, err := bp.CreateVirtualNetwork(ctx, &VirtualNetworkData{
+				Ipv4Enabled:    true,
+				Ipv4Subnet:     &vnPrefix,
+				Label:          randString(6, "hex"),
+				SecurityZoneId: rzId,
+				VnType:         enum.VnTypeVxlan,
+				VnBindings:     []VnBinding{vnBinding},
+				SviIps:         []SviIp{sviIp},
+			})
+			require.NoError(t, err)
+
+			// set up an slice with leaf counts we'll test with. Assuming 3 test leafs,
+			// this slice will be: [0,1,2,3,2,1,0]
+			testLeafCounts := make([]int, (2*len(leafIds))+1)
+			for i := range (len(testLeafCounts) + 1) / 2 {
+				testLeafCounts[i] = i
+				testLeafCounts[len(testLeafCounts)-i-1] = i
+			}
+
+			for _, count := range testLeafCounts {
+				requestBindings := make(map[ObjectId]*VnBinding, len(leafIds))
+				for j, leafId := range leafIds {
+					if j < count {
+						requestBindings[leafId] = &VnBinding{
+							AccessSwitchNodeIds: nil,
+							SystemId:            leafIds[j],
+							VlanId:              toPtr(Vlan(100*(count) + rand.Intn(100))),
+						}
+					} else {
+						requestBindings[leafId] = nil
+					}
+				}
+
+				requestSviIps := make(map[ObjectId]*SviIp, count)
+				lastOctets := make([]int, count)
+				randomIntsN(lastOctets, 253) // avoid .0, .1 and .255
+				for j, leafId := range leafIds {
+					if j < count {
+						_, ipNet, err := net.ParseCIDR(vnPrefix.String())
+						require.NoError(t, err)
+						ipNet.IP[3] = byte(lastOctets[j])
+						requestSviIps[leafId] = &SviIp{
+							SystemId: leafIds[j],
+							Ipv4Addr: ipNet,
+							Ipv4Mode: oneOf(enum.SviIpv4ModeForced, enum.SviIpv4ModeEnabled),
+							Ipv6Mode: enum.SviIpv6ModeDisabled,
+						}
+					} else {
+						requestSviIps[leafId] = nil
+					}
+				}
+
+				log.Printf("testing UpdateVirtualNetworkLeafBindings() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+				err = bp.UpdateVirtualNetworkLeafBindings(ctx, VirtualNetworkBindingsRequest{
+					VnId:               vnId,
+					VnBindings:         requestBindings,
+					SviIps:             requestSviIps,
+					DhcpServiceEnabled: toPtr(DhcpServiceEnabled(false)),
+				})
+				require.NoError(t, err)
+
+				vn, err := bp.GetVirtualNetwork(ctx, vnId)
+				require.NoError(t, err)
+
+				actualBindings := bindingSliceToMap(t, vn.Data.VnBindings)
+				delete(actualBindings, fixedLeafId)
+				for k, v := range requestBindings {
+					if v == nil {
+						delete(requestBindings, k)
+					}
+				}
+
+				actualSviIps := sviSliceToMap(t, vn.Data.SviIps)
+				delete(actualSviIps, fixedLeafId)
+				for k, v := range requestSviIps {
+					if v == nil {
+						delete(requestSviIps, k)
+					}
+				}
+
+				compareBindingsMaps(t, requestBindings, actualBindings)
+				compareSviMaps(t, requestSviIps, actualSviIps)
 			}
 		})
 	}

--- a/apstra/two_stage_l3_clos_virtual_network_bindings_integration_test.go
+++ b/apstra/two_stage_l3_clos_virtual_network_bindings_integration_test.go
@@ -1,0 +1,177 @@
+// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package apstra
+
+import (
+	"context"
+	"log"
+	"math/rand"
+	"net"
+	"sort"
+	"testing"
+
+	"github.com/Juniper/apstra-go-sdk/apstra/compatibility"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetVirtualNetworkLeafBindings(t *testing.T) {
+	ctx := context.Background()
+
+	clients, err := getTestClients(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bindingSliceToMap := func(t testing.TB, in []VnBinding) map[ObjectId]*VnBinding {
+		t.Helper()
+
+		result := make(map[ObjectId]*VnBinding, len(in))
+		for _, binding := range in {
+			result[binding.SystemId] = &binding
+		}
+
+		if len(in) != len(result) {
+			t.Fatalf("after converting binding slice to map, had %d bindings, expected %d", len(result), len(in))
+		}
+
+		return result
+	}
+
+	sviSliceToMap := func(t testing.TB, in []SviIp) map[ObjectId]*SviIp {
+		t.Helper()
+
+		result := make(map[ObjectId]*SviIp, len(in))
+		for _, sviIp := range in {
+			result[sviIp.SystemId] = &sviIp
+		}
+
+		if len(in) != len(result) {
+			t.Fatalf("after converting svi slice to map, had %d svis, expected %d", len(result), len(in))
+		}
+
+		return result
+	}
+
+	compareBindingsMaps := func(t testing.TB, a, b map[ObjectId]*VnBinding) {
+		t.Helper()
+
+		if len(a) != len(b) {
+			t.Fatalf("bindings count mismatch: %d vs %d", len(a), len(b))
+		}
+
+		for id, bindingA := range a {
+			bindingB, ok := b[id]
+			if !ok {
+				t.Fatalf("binding %q from 'a' map not found in 'b' map", id)
+			}
+
+			compareVnBindings(t, *bindingA, *bindingB, true)
+		}
+	}
+
+	compareSviMaps := func(t testing.TB, a, b map[ObjectId]*SviIp) {
+		t.Helper()
+
+		if len(a) != len(b) {
+			t.Fatalf("svi count mismatch: %d vs %d", len(a), len(b))
+		}
+
+		for id, sviIpA := range a {
+			sviIpB, ok := b[id]
+			if !ok {
+				t.Fatalf("svi %q from 'a' map not found in 'b' map", id)
+			}
+
+			comapareSviIps(t, *sviIpA, *sviIpB)
+		}
+	}
+
+	for clientName, client := range clients {
+		t.Run(client.name(), func(t *testing.T) {
+			t.Parallel()
+
+			if !compatibility.EmptyVnBindingsOk.Check(client.client.apiVersion) {
+				t.Skipf("test applies only to versions %q", compatibility.EmptyVnBindingsOk)
+			}
+
+			bp := testBlueprintC(ctx, t, client.client)
+
+			leafIds, err := getSystemIdsByRole(ctx, bp, "leaf")
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, len(leafIds), 2, "test requires at least 2 leaf switches")
+			require.LessOrEqual(t, len(leafIds), 40, "test requires no more than 40 leaf switches")
+			sort.Slice(leafIds, func(i, j int) bool { return leafIds[i] < leafIds[j] })
+
+			rzLabel := randString(6, "hex")
+			rzId, err := bp.CreateSecurityZone(ctx, &SecurityZoneData{
+				Label:   rzLabel,
+				SzType:  SecurityZoneTypeEVPN,
+				VrfName: rzLabel,
+			})
+			require.NoError(t, err)
+
+			vnPrefix := randomPrefix(t, "10.0.0.0/8", 24)
+			vnId, err := bp.CreateVirtualNetwork(ctx, &VirtualNetworkData{
+				Ipv4Enabled:    true,
+				Ipv4Subnet:     &vnPrefix,
+				Label:          randString(6, "hex"),
+				SecurityZoneId: rzId,
+				VnType:         enum.VnTypeVxlan,
+			})
+			require.NoError(t, err)
+
+			// set up an slice with leaf counts we'll test with. Assuming 4 leafs in the BP,
+			// this slice will be: [0,1,2,3,4,3,2,1,0]
+			testLeafCounts := make([]int, (2*len(leafIds))+1)
+			for i := range (len(testLeafCounts) + 1) / 2 {
+				testLeafCounts[i] = i
+				testLeafCounts[len(testLeafCounts)-i-1] = i
+			}
+
+			for _, count := range testLeafCounts {
+				bindings := make(map[ObjectId]*VnBinding, count)
+				for j := range count {
+					bindings[leafIds[j]] = &VnBinding{
+						AccessSwitchNodeIds: nil,
+						SystemId:            leafIds[j],
+						VlanId:              toPtr(Vlan(100*(count) + rand.Intn(100))),
+					}
+				}
+
+				sviIps := make(map[ObjectId]*SviIp, count)
+				lastOctets := make([]int, count)
+				randomIntsN(lastOctets, 253) // avoid .0, .1 and .255
+				for j := range count {
+					_, ipNet, err := net.ParseCIDR(vnPrefix.String())
+					require.NoError(t, err)
+					ipNet.IP[3] = byte(lastOctets[j])
+					sviIps[leafIds[j]] = &SviIp{
+						SystemId: leafIds[j],
+						Ipv4Addr: ipNet,
+						Ipv4Mode: oneOf(enum.SviIpv4ModeForced, enum.SviIpv4ModeEnabled),
+						Ipv6Mode: enum.SviIpv6ModeDisabled,
+					}
+				}
+
+				log.Printf("testing SetVirtualNetworkLeafBindings() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+				err = bp.SetVirtualNetworkLeafBindings(ctx, VirtualNetworkBindingsRequest{
+					VnId:               vnId,
+					VnBindings:         bindings,
+					SviIps:             sviIps,
+					DhcpServiceEnabled: toPtr(DhcpServiceEnabled(false)),
+				})
+				require.NoError(t, err)
+
+				vn, err := bp.GetVirtualNetwork(ctx, vnId)
+				require.NoError(t, err)
+				compareBindingsMaps(t, bindings, bindingSliceToMap(t, vn.Data.VnBindings))
+				compareSviMaps(t, sviIps, sviSliceToMap(t, vn.Data.SviIps))
+			}
+		})
+	}
+}

--- a/apstra/two_stage_l3_clos_virtual_networks.go
+++ b/apstra/two_stage_l3_clos_virtual_networks.go
@@ -40,6 +40,10 @@ func (o *DhcpServiceEnabled) FromString(s string) error {
 	return nil
 }
 
+func (o DhcpServiceEnabled) MarshalJSON() ([]byte, error) {
+	return json.Marshal(o.String())
+}
+
 func (o DhcpServiceEnabled) String() string {
 	if o {
 		return enum.DhcpServiceModeEnabled.String()

--- a/apstra/two_stage_l3_clos_virtual_networks.go
+++ b/apstra/two_stage_l3_clos_virtual_networks.go
@@ -23,9 +23,9 @@ const (
 	apiUrlVirtualNetworkById = apiUrlVirtualNetworks + apiUrlPathDelim + "%s"
 )
 
-type (
-	DhcpServiceEnabled bool
-)
+var _ json.Marshaler = (*DhcpServiceEnabled)(nil)
+
+type DhcpServiceEnabled bool
 
 func (o *DhcpServiceEnabled) FromString(s string) error {
 	var dsm enum.DhcpServiceMode

--- a/apstra/two_stage_l3_clos_virtual_networks_integration_test.go
+++ b/apstra/two_stage_l3_clos_virtual_networks_integration_test.go
@@ -17,7 +17,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func compareRtPolicy(t *testing.T, a, b *RtPolicy) {
+func compareRtPolicy(t testing.TB, a, b *RtPolicy) {
+	t.Helper()
+
 	if (a != nil) != (b != nil) { // XOR
 		t.Fatalf("RtPolicy exists mismatch: %t vs %t", a != nil, b != nil)
 	}
@@ -28,7 +30,9 @@ func compareRtPolicy(t *testing.T, a, b *RtPolicy) {
 	}
 }
 
-func comapareSviIps(t *testing.T, a, b SviIp) {
+func comapareSviIps(t testing.TB, a, b SviIp) {
+	t.Helper()
+
 	require.Equal(t, a.SystemId, b.SystemId)
 
 	require.Equal(t, a.Ipv4Mode, b.Ipv4Mode)
@@ -46,7 +50,9 @@ func comapareSviIps(t *testing.T, a, b SviIp) {
 	}
 }
 
-func compareSviIpSlices(t *testing.T, a, b []SviIp) {
+func compareSviIpSlices(t testing.TB, a, b []SviIp) {
+	t.Helper()
+
 	require.Equal(t, len(a), len(b))
 	for i := range a {
 		log.Printf("comparing SviIps at index %d", i)
@@ -54,7 +60,9 @@ func compareSviIpSlices(t *testing.T, a, b []SviIp) {
 	}
 }
 
-func compareVnBindings(t *testing.T, a, b VnBinding, strict bool) {
+func compareVnBindings(t testing.TB, a, b VnBinding, strict bool) {
+	t.Helper()
+
 	if len(a.AccessSwitchNodeIds) != 0 || len(b.AccessSwitchNodeIds) != 0 { // nil and [] slices are equal for our purpose
 		compareSlices(t, a.AccessSwitchNodeIds, b.AccessSwitchNodeIds, "VnBindings.AccessSwitchNodeIds")
 	}
@@ -69,7 +77,9 @@ func compareVnBindings(t *testing.T, a, b VnBinding, strict bool) {
 	}
 }
 
-func compareVnBindingSlices(t *testing.T, a, b []VnBinding, strict bool) {
+func compareVnBindingSlices(t testing.TB, a, b []VnBinding, strict bool) {
+	t.Helper()
+
 	require.Equal(t, len(a), len(b))
 	for i := range a {
 		log.Printf("comparing VnBindings at index %d", i)
@@ -77,7 +87,9 @@ func compareVnBindingSlices(t *testing.T, a, b []VnBinding, strict bool) {
 	}
 }
 
-func compareVirtualNetworkData(t *testing.T, a, b *VirtualNetworkData, strict bool) {
+func compareVirtualNetworkData(t testing.TB, a, b *VirtualNetworkData, strict bool) {
+	t.Helper()
+
 	require.Equal(t, a.DhcpService, b.DhcpService)
 	require.Equal(t, a.Ipv4Enabled, b.Ipv4Enabled)
 	require.Equal(t, a.Ipv4Subnet, b.Ipv4Subnet)


### PR DESCRIPTION
### This PR introduces two new `TwoStageL3ClosClient` functions
- `SetVirtualNetworkLeafBindings(ctx context.Context, req VirtualNetworkBindingsRequest) error`
- `UpdateVirtualNetworkLeafBindings(ctx context.Context, req VirtualNetworkBindingsRequest) error`

`SetVirtualNetworkLeafBindings` sets the current VN bindings and per-switch SVI IP information to match the contents of `req`.

`UpdateVirtualNetworkLeafBindings` updates the current VN bindings and per-switch SVI IP information to match the contents of `req`, without disturbing current bindings or IP info. That process looks like:
1. Set a lock specific to the BP/VN combination
2. Retrieve the current binding and SVI information
3. Merge the requested binding and SVI information with the current information
4. Set the merged value
5. Release the lock

Both functions take the new `VirtualNetworkBindingsRequest{}` struct as input. This struct has the somewhat surprising `DhcpServiceEnabled` attribute. See AOS-51519 for the explanation of that.

### Odds and ends:
- Several existing test helper functions have had their `t *testing.T` changed to `t testing.TB`, and now invoke `t.helper()`
- New constraint `EmptyVnBindingsOk` controls whether the tests run.
- New helper function `randomIntsN(s []int, n int)` fills a slice with non-repeating random values
- New helper function `oneOf[A interface{}](i A, s ...A) A` for random selections
- `DhcpServiceEnabled` now fulfills the `json.Marshaler` interface

Closes #466