### PR TITLE
Introduce `Client{}` methods to support Terraform API key ephemeral resource

### DIFF
--- a/apstra/api_user.go
+++ b/apstra/api_user.go
@@ -48,6 +48,12 @@ func (o *Client) Config() ClientCfg {
 	return o.cfg
 }
 
+func (o *Client) ApiToken() string {
+	o.lock(mutexKeyHttpHeaders)
+	defer o.unlock(mutexKeyHttpHeaders)
+	return o.httpHeaders[apstraAuthHeader]
+}
+
 func (o *Client) login(ctx context.Context) error {
 	response := &userLoginResponse{}
 	err := o.talkToApstra(ctx, &talkToApstraIn{

--- a/apstra/api_user.go
+++ b/apstra/api_user.go
@@ -57,7 +57,7 @@ func (o *Client) GetApiToken() string {
 func (o *Client) SetApiToken(in string) {
 	o.lock(mutexKeyHttpHeaders)
 	o.httpHeaders[apstraAuthHeader] = in
-	defer o.unlock(mutexKeyHttpHeaders)
+	o.unlock(mutexKeyHttpHeaders)
 }
 
 func (o *Client) login(ctx context.Context) error {

--- a/apstra/api_user.go
+++ b/apstra/api_user.go
@@ -93,7 +93,7 @@ func (o *Client) logout(ctx context.Context) error {
 	// - "logged in" state and
 	// - operation of a task monitor routine
 	o.lock(mutexKeyHttpHeaders)
-	if _, tokenFound := o.httpHeaders[apstraAuthHeader]; !tokenFound {
+	if token := o.httpHeaders[apstraAuthHeader]; token == "" {
 		o.unlock(mutexKeyHttpHeaders)
 		return nil
 	}

--- a/apstra/api_user.go
+++ b/apstra/api_user.go
@@ -100,7 +100,7 @@ func (o *Client) logout(ctx context.Context) error {
 	}()
 
 	o.lock(mutexKeyHttpHeaders)
-	if token := o.httpHeaders[apstraAuthHeader]; token == "" {
+	if token := o.httpHeaders[apstraAuthHeader]; token == "" { // doesn't exist OR is empty string?
 		o.unlock(mutexKeyHttpHeaders)
 		return nil // don't need to call the logout API if we have no token
 	}

--- a/apstra/api_user.go
+++ b/apstra/api_user.go
@@ -48,10 +48,16 @@ func (o *Client) Config() ClientCfg {
 	return o.cfg
 }
 
-func (o *Client) ApiToken() string {
+func (o *Client) GetApiToken() string {
 	o.lock(mutexKeyHttpHeaders)
 	defer o.unlock(mutexKeyHttpHeaders)
 	return o.httpHeaders[apstraAuthHeader]
+}
+
+func (o *Client) SetApiToken(in string) {
+	o.lock(mutexKeyHttpHeaders)
+	o.httpHeaders[apstraAuthHeader] = in
+	defer o.unlock(mutexKeyHttpHeaders)
 }
 
 func (o *Client) login(ctx context.Context) error {

--- a/apstra/api_user.go
+++ b/apstra/api_user.go
@@ -114,7 +114,7 @@ func (o *Client) logout(ctx context.Context) error {
 		doNotLogin: true,
 	})
 	if err != nil {
-		return fmt.Errorf("error calling '%s' - %w", apiUrlUserLogout, err)
+		return fmt.Errorf("error calling '%s' - %w", apiUrlUserLogout, convertTtaeToAceWherePossible(err))
 	}
 	return nil
 }

--- a/apstra/api_user.go
+++ b/apstra/api_user.go
@@ -44,6 +44,10 @@ func (o *Client) stopTaskMonitor() {
 	}
 }
 
+func (o *Client) Config() ClientCfg {
+	return o.cfg
+}
+
 func (o *Client) login(ctx context.Context) error {
 	response := &userLoginResponse{}
 	err := o.talkToApstra(ctx, &talkToApstraIn{

--- a/apstra/api_user.go
+++ b/apstra/api_user.go
@@ -89,17 +89,8 @@ func (o *Client) login(ctx context.Context) error {
 
 func (o *Client) logout(ctx context.Context) error {
 	o.Log(1, "client logging out")
-	// presence of an auth token is proxy for both
-	// - "logged in" state and
-	// - operation of a task monitor routine
-	o.lock(mutexKeyHttpHeaders)
-	if token := o.httpHeaders[apstraAuthHeader]; token == "" {
-		o.unlock(mutexKeyHttpHeaders)
-		return nil
-	}
-	o.unlock(mutexKeyHttpHeaders)
 
-	defer func() {
+	defer func() { // clear the auth token and stop the task monitor
 		o.Log(1, "deleting auth token")
 		o.lock(mutexKeyHttpHeaders)
 		delete(o.httpHeaders, apstraAuthHeader)
@@ -107,6 +98,13 @@ func (o *Client) logout(ctx context.Context) error {
 		o.Log(1, "shutting down the task monitor")
 		o.stopTaskMonitor()
 	}()
+
+	o.lock(mutexKeyHttpHeaders)
+	if token := o.httpHeaders[apstraAuthHeader]; token == "" {
+		o.unlock(mutexKeyHttpHeaders)
+		return nil // don't need to call the logout API if we have no token
+	}
+	o.unlock(mutexKeyHttpHeaders)
 
 	err := o.talkToApstra(ctx, &talkToApstraIn{
 		method:     http.MethodPost,

--- a/apstra/talk_to_apstra.go
+++ b/apstra/talk_to_apstra.go
@@ -77,6 +77,8 @@ func convertTtaeToAceWherePossible(err error) error {
 	var ttae TalkToApstraErr
 	if errors.As(err, &ttae) {
 		switch ttae.Response.StatusCode {
+		case http.StatusUnauthorized:
+			return ClientErr{errType: ErrAuthFail, err: err}
 		case http.StatusNotFound:
 			if ttae.Request.URL.Path == apiUrlBlueprints {
 				return ClientErr{errType: ErrNotfound, retryable: true, err: err}


### PR DESCRIPTION
The biggest/riskiest change in here is the new order of operations in `logout()`.

We now *always* kick off the deferred function to clear the API token and stop the task monitor, rather than doing that *only* if we find an API token. 