### PR TITLE
Add node and relationship types for routing zone constraints

### DIFF
--- a/apstra/query_node.go
+++ b/apstra/query_node.go
@@ -27,6 +27,7 @@ const (
 	NodeTypeRedundancyGroup
 	NodeTypeRouteTargetPolicy
 	NodeTypeRoutingPolicy
+	NodeTypeRoutingZoneConstraint
 	NodeTypeSecurityZone
 	NodeTypeSecurityZoneInstance
 	NodeTypeSecurityZonePolicy
@@ -57,6 +58,7 @@ const (
 	nodeTypeRedundancyGroup        = nodeType("redundancy_group")
 	nodeTypeRouteTargetPolicy      = nodeType("route_target_policy")
 	nodeTypeRoutingPolicy          = nodeType("routing_policy")
+	nodeTypeRoutingZoneConstraint  = nodeType("routing_zone_constraint")
 	nodeTypeSecurityZone           = nodeType("security_zone")
 	nodeTypeSecurityZoneInstance   = nodeType("sz_instance")
 	nodeTypeSecurityZonePolicy     = nodeType("security_zone_policy")
@@ -115,6 +117,8 @@ func (o NodeType) String() string {
 		return string(nodeTypeRouteTargetPolicy)
 	case NodeTypeRoutingPolicy:
 		return string(nodeTypeRoutingPolicy)
+	case NodeTypeRoutingZoneConstraint:
+		return string(nodeTypeRoutingZoneConstraint)
 	case NodeTypeSecurityZone:
 		return string(nodeTypeSecurityZone)
 	case NodeTypeSecurityZoneInstance:

--- a/apstra/query_relationship.go
+++ b/apstra/query_relationship.go
@@ -10,6 +10,7 @@ const (
 	RelationshipTypeNone = RelationshipType(iota)
 	RelationshipTypeComposedOf
 	RelationshipTypeComposedOfSystems
+	RelationshipTypeConstraint
 	RelationshipTypeDeviceProfile
 	RelationshipTypeEpAffectedBy
 	RelationshipTypeEpFirstSubpolicy
@@ -37,6 +38,7 @@ const (
 	relationshipTypeNone              = relationshipType("")
 	relationshipTypeComposedOf        = relationshipType("composed_of")
 	relationshipTypeComposedOfSystems = relationshipType("composed_of_systems")
+	relationshipTypeConstraint        = relationshipType("constraint")
 	relationshipTypeDeviceProfile     = relationshipType("device_profile")
 	relationshipTypeEpAffectedBy      = relationshipType("ep_affected_by")
 	relationshipTypeEpFirstSubpolicy  = relationshipType("ep_first_subpolicy")
@@ -75,6 +77,8 @@ func (o RelationshipType) String() string {
 		return string(relationshipTypeComposedOf)
 	case RelationshipTypeComposedOfSystems:
 		return string(relationshipTypeComposedOfSystems)
+	case RelationshipTypeConstraint:
+		return string(relationshipTypeConstraint)
 	case RelationshipTypeDeviceProfile:
 		return string(relationshipTypeDeviceProfile)
 	case RelationshipTypeEpAffectedBy:


### PR DESCRIPTION
This PR introduces `NodeTypeRoutingZoneConstraint` and `RelationshipTypeConstraint`