### PR TITLE
Update `TestIbaProbes()` for 5.1.0

### DIFF
--- a/apstra/api_iba_probes_test.go
+++ b/apstra/api_iba_probes_test.go
@@ -14,6 +14,7 @@ import (
 	"log"
 	"testing"
 
+	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/require"
 )
 
@@ -369,10 +370,12 @@ func TestIbaProbes(t *testing.T) {
 				"eastwest_traffic":                   true,
 				"vxlan_floodlist":                    true,
 				"fabric_hotcold_ifcounter":           true,
-				"specific_interface_flapping":        true,
 				"evpn_vxlan_type3":                   true,
 				"specific_hotcold_ifcounter":         true,
 				"spine_superspine_hotcold_ifcounter": true,
+			}
+			if version.MustConstraints(version.NewConstraint("<5.1.0")).Check(client.client.apiVersion) {
+				expectedToFail["specific_interface_flapping"] = true
 			}
 
 			for _, predefinedProbe := range predefinedProbes {


### PR DESCRIPTION
The `TestIbaProbes()` function includes a list of probes which are expected to fail instantiation.

One of those probes (`specific_interface_flapping`) does not fail with version 5.1.0.

This PR adds a version check when preparing the `expectedToFail` map in the test.

Tested with:
- 4.2.0-236
- 4.2.1-207
- 4.2.1.1-10
- 4.2.2-2
- 5.0.0-63
- 5.0.1-1
- 5.1.0-117

Closes #475