### PR TITLE
Introduce `compatibility.HasDeviceOsImageDownloadTimeout`

### DIFF
--- a/apstra/api_system_agent.go
+++ b/apstra/api_system_agent.go
@@ -12,6 +12,7 @@ import (
 const apiUrlSystemAgentManagerConfig = "/api/system-agent/manager-config"
 
 type SystemAgentManagerConfig struct {
+	DeviceOsImageDownloadTimeout    *int `json:"device_os_image_download_timeout"` // introduced in and required by 5.1.0 (1-2700)
 	SkipRevertToPristineOnUninstall bool `json:"skip_revert_to_pristine_on_uninstall"`
 	SkipPristineValidation          bool `json:"skip_pristine_validation"`
 	SkipInterfaceShutdownOnUpgrade  bool `json:"skip_interface_shutdown_on_upgrade"`

--- a/apstra/api_system_agent.go
+++ b/apstra/api_system_agent.go
@@ -12,7 +12,7 @@ import (
 const apiUrlSystemAgentManagerConfig = "/api/system-agent/manager-config"
 
 type SystemAgentManagerConfig struct {
-	DeviceOsImageDownloadTimeout    *int `json:"device_os_image_download_timeout"` // introduced in and required by 5.1.0 (1-2700)
+	DeviceOsImageDownloadTimeout    *int `json:"device_os_image_download_timeout,omitempty"` // introduced in and required by 5.1.0 (1-2700)
 	SkipRevertToPristineOnUninstall bool `json:"skip_revert_to_pristine_on_uninstall"`
 	SkipPristineValidation          bool `json:"skip_pristine_validation"`
 	SkipInterfaceShutdownOnUpgrade  bool `json:"skip_interface_shutdown_on_upgrade"`

--- a/apstra/api_system_agent_test.go
+++ b/apstra/api_system_agent_test.go
@@ -10,6 +10,7 @@ package apstra
 import (
 	"context"
 	"log"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra/compatibility"
@@ -34,6 +35,9 @@ func TestGetSetSystemAgentManagerConfiguration(t *testing.T) {
 				SkipRevertToPristineOnUninstall: !mgrCfg.SkipRevertToPristineOnUninstall,
 				SkipPristineValidation:          !mgrCfg.SkipPristineValidation,
 				SkipInterfaceShutdownOnUpgrade:  !mgrCfg.SkipInterfaceShutdownOnUpgrade,
+			}
+			if compatibility.HasDeviceOsImageDownloadTimeout.Check(client.client.apiVersion) {
+				testCfg.DeviceOsImageDownloadTimeout = toPtr(rand.IntN(2700) + 1)
 			}
 
 			// set new config

--- a/apstra/client.go
+++ b/apstra/client.go
@@ -1674,6 +1674,9 @@ func (o *Client) GetSystemAgentManagerConfig(ctx context.Context) (*SystemAgentM
 // SetSystemAgentManagerConfig uses a *SystemAgentManagerConfig object to configure the Advanced Settings
 // found on the Managed Devices page of the Web UI.
 func (o *Client) SetSystemAgentManagerConfig(ctx context.Context, cfg *SystemAgentManagerConfig) error {
+	if compatibility.HasDeviceOsImageDownloadTimeout.Check(o.apiVersion) != (cfg.DeviceOsImageDownloadTimeout != nil) {
+		return fmt.Errorf("DeviceOsImageDownloadTimeout is required with apstra %s, and must not be used with other versions", compatibility.HasDeviceOsImageDownloadTimeout)
+	}
 	if !compatibility.SystemManagerHasSkipInterfaceShutdownOnUpgrade.Check(o.apiVersion) && cfg.SkipInterfaceShutdownOnUpgrade {
 		return fmt.Errorf("SkipInterfaceShutdownOnUpgrade may only be used with apstra %s", compatibility.SystemManagerHasSkipInterfaceShutdownOnUpgrade)
 	}

--- a/apstra/compatibility/compatibility.go
+++ b/apstra/compatibility/compatibility.go
@@ -15,6 +15,7 @@ const (
 	apstra422  = "4.2.2"
 	apstra500  = "5.0.0"
 	apstra501  = "5.0.1"
+	apstra510  = "5.1.0"
 )
 
 var (

--- a/apstra/compatibility/constraints.go
+++ b/apstra/compatibility/constraints.go
@@ -17,11 +17,14 @@ var (
 	BpHasVirtualNetworkPolicyNode = Constraint{
 		constraints: version.MustConstraints(version.NewConstraint("<=" + apstra420)),
 	}
+	EmptyVnBindingsOk = Constraint{
+		constraints: version.MustConstraints(version.NewConstraint(">=" + apstra500)),
+	}
 	FabricSettingsApiOk = Constraint{
 		constraints: version.MustConstraints(version.NewConstraint(">=" + apstra421)),
 	}
-	EmptyVnBindingsOk = Constraint{
-		constraints: version.MustConstraints(version.NewConstraint(">=" + apstra500)),
+	HasDeviceOsImageDownloadTimeout = Constraint{
+		constraints: version.MustConstraints(version.NewConstraint(">=" + apstra510)),
 	}
 	IbaDashboardSupported = Constraint{
 		constraints: version.MustConstraints(version.NewConstraint(">=" + apstra500)),


### PR DESCRIPTION
Apstra 5.1.0 added a new field `device_os_image_download_timeout` to the payload for `/api/system-agent/manager-config`.

This PR adds the attribute to our `SystemAgentManagerConfig` and adds version constraints and test code required to support pre-change and post-change versions of Apstra.

I was on the fence about naming the constraint. Apstra < 5.1.0 doesn't support this attribute at all, while >= 5.1.0 require setting this parameter. `HasThing`, `RequiresThing`, `SupportsThing`... None of these tell the whole story. I settled with `Has` and error if the field is missing on a platform which requires it.

Tested with:
- 4.2.0-236
- 4.2.1-207
- 4.2.1.1-10
- 4.2.2-2
- 5.0.0-63
- 5.0.1-1
- 5.1.0-117

Closes #476