### PR TITLE
Introduce `section_condition` attribute to blueprint configlet generator

### DIFF
--- a/apstra/api_design_configlets.go
+++ b/apstra/api_design_configlets.go
@@ -23,6 +23,7 @@ const (
 type ConfigletGenerator struct {
 	ConfigStyle          enum.ConfigletStyle   `json:"config_style"`
 	Section              enum.ConfigletSection `json:"section"`
+	SectionCondition     string                `json:"section_condition,omitempty"`
 	TemplateText         string                `json:"template_text"`
 	NegationTemplateText string                `json:"negation_template_text"`
 	Filename             string                `json:"filename"`

--- a/apstra/api_design_configlets.go
+++ b/apstra/api_design_configlets.go
@@ -130,32 +130,35 @@ func (o *Client) getConfigletByName(ctx context.Context, name string) (*Configle
 }
 
 func (o *Client) getAllConfiglets(ctx context.Context) ([]Configlet, error) {
-	response := &struct {
+	var response struct {
 		Items []Configlet `json:"items"`
-	}{}
+	}
+
 	err := o.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodGet,
 		urlStr:      apiUrlDesignConfiglets,
-		apiResponse: response,
+		apiResponse: &response,
 	})
 	if err != nil {
 		return nil, convertTtaeToAceWherePossible(err)
 	}
+
 	return response.Items, nil
 }
 
 func (o *Client) createConfiglet(ctx context.Context, in *ConfigletData) (ObjectId, error) {
-	response := &objectIdResponse{}
+	var response objectIdResponse
 
 	err := o.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodPost,
 		urlStr:      apiUrlDesignConfiglets,
 		apiInput:    in,
-		apiResponse: response,
+		apiResponse: &response,
 	})
 	if err != nil {
 		return "", convertTtaeToAceWherePossible(err)
 	}
+
 	return response.Id, nil
 }
 
@@ -168,12 +171,18 @@ func (o *Client) updateConfiglet(ctx context.Context, id ObjectId, in *Configlet
 	if err != nil {
 		return convertTtaeToAceWherePossible(err)
 	}
+
 	return nil
 }
 
 func (o *Client) deleteConfiglet(ctx context.Context, id ObjectId) error {
-	return o.talkToApstra(ctx, &talkToApstraIn{
+	err := o.talkToApstra(ctx, &talkToApstraIn{
 		method: http.MethodDelete,
 		urlStr: fmt.Sprintf(apiUrlDesignConfigletsById, id),
 	})
+	if err != nil {
+		return convertTtaeToAceWherePossible(err)
+	}
+
+	return nil
 }

--- a/apstra/api_design_configlets_test.go
+++ b/apstra/api_design_configlets_test.go
@@ -12,82 +12,211 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/hashicorp/go-version"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateUpdateGetDeleteConfiglet(t *testing.T) {
+	ctx := context.Background()
+
+	compareGenerators := func(t *testing.T, a, b ConfigletGenerator) {
+		require.Equal(t, a.ConfigStyle.String(), b.ConfigStyle.String())
+		require.Equal(t, a.Section.String(), b.Section.String())
+		require.Equal(t, a.SectionCondition, b.SectionCondition)
+		require.Equal(t, a.TemplateText, b.TemplateText)
+		require.Equal(t, a.NegationTemplateText, b.NegationTemplateText)
+		require.Equal(t, a.Filename, b.Filename)
+	}
+
+	compare := func(t *testing.T, a, b *ConfigletData) {
+		t.Helper()
+
+		require.NotNil(t, a)
+		require.NotNil(t, b)
+		require.Equal(t, a.DisplayName, b.DisplayName)
+		compareSlicesAsSets(t, a.RefArchs, b.RefArchs, "while comparing configlet refarchs,")
+		require.Equal(t, len(a.Generators), len(b.Generators))
+		for i := range a.Generators {
+			compareGenerators(t, a.Generators[i], b.Generators[i])
+		}
+	}
+
 	clients, err := getTestClients(context.Background(), t)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	Name := randString(10, "hex")
-	for _, client := range clients {
-		var cg []ConfigletGenerator
+	type testStep struct {
+		data ConfigletData
+	}
 
-		cg = append(cg, ConfigletGenerator{
-			ConfigStyle:  enum.ConfigletStyleJunos,
-			Section:      enum.ConfigletSectionSystem,
-			TemplateText: "interfaces {\n   {% if 'leaf1' in hostname %}\n    xe-0/0/3 {\n      disable;\n    }\n   {% endif %}\n   {% if 'leaf2' in hostname %}\n    xe-0/0/2 {\n      disable;\n    }\n   {% endif %}\n}",
+	type testCase struct {
+		versionConstraint version.Constraints
+		steps             []testStep
+	}
+
+	testCases := map[string]testCase{
+		"simple_test": {
+			steps: []testStep{
+				{
+					data: ConfigletData{
+						DisplayName: randString(6, "hex"),
+						RefArchs:    []enum.RefDesign{enum.RefDesignDatacenter},
+						Generators: []ConfigletGenerator{
+							{
+								ConfigStyle:  enum.ConfigletStyleJunos,
+								Section:      enum.ConfigletSectionSystem,
+								TemplateText: "set " + randString(6, "hex"),
+							},
+						},
+					},
+				},
+				{
+					data: ConfigletData{
+						DisplayName: randString(6, "hex"),
+						RefArchs:    []enum.RefDesign{enum.RefDesignDatacenter},
+						Generators: []ConfigletGenerator{
+							{
+								ConfigStyle:          enum.ConfigletStyleNxos,
+								Section:              enum.ConfigletSectionInterface,
+								TemplateText:         "set " + randString(6, "hex"),
+								NegationTemplateText: "no " + randString(6, "hex"),
+							},
+							{
+								ConfigStyle:          enum.ConfigletStyleEos,
+								Section:              enum.ConfigletSectionInterface,
+								TemplateText:         "set " + randString(6, "hex"),
+								NegationTemplateText: "no " + randString(6, "hex"),
+							},
+							{
+								ConfigStyle:  enum.ConfigletStyleSonic,
+								Section:      enum.ConfigletSectionFile,
+								TemplateText: "set " + randString(6, "hex"),
+								Filename:     "/etc/" + randString(6, "hex"),
+							},
+						},
+					},
+				},
+				{
+					data: ConfigletData{
+						DisplayName: randString(6, "hex"),
+						RefArchs:    []enum.RefDesign{enum.RefDesignDatacenter},
+						Generators: []ConfigletGenerator{
+							{
+								ConfigStyle:  enum.ConfigletStyleJunos,
+								Section:      enum.ConfigletSectionSystem,
+								TemplateText: "set " + randString(6, "hex"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for clientName, client := range clients {
+		t.Run(client.name(), func(t *testing.T) {
+			t.Parallel()
+
+			for tName, tCase := range testCases {
+				t.Run(tName, func(t *testing.T) {
+					t.Parallel()
+
+					if tCase.versionConstraint != nil && !tCase.versionConstraint.Check(client.client.apiVersion) {
+						t.Skipf("skipping %q due to version constraints: %q. API version: %q",
+							tName, tCase.versionConstraint, client.client.apiVersion)
+					}
+
+					require.GreaterOrEqualf(t, len(tCase.steps), 1, "test %s has no test steps!", tName)
+
+					log.Printf("testing CreateConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.apiVersion)
+					id, err := client.client.CreateConfiglet(ctx, &tCase.steps[0].data)
+					require.NoError(t, err)
+					require.NotEmpty(t, id)
+
+					log.Printf("testing GetConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.apiVersion)
+					configlet, err := client.client.GetConfiglet(ctx, id)
+					require.NoError(t, err)
+					require.Equal(t, id, configlet.Id)
+					compare(t, &tCase.steps[0].data, configlet.Data)
+
+					log.Printf("testing GetConfigletByName() against %s %s (%s)", client.clientType, clientName, client.client.apiVersion)
+					configlet, err = client.client.GetConfigletByName(ctx, tCase.steps[0].data.DisplayName)
+					require.NoError(t, err)
+					require.Equal(t, id, configlet.Id)
+					compare(t, &tCase.steps[0].data, configlet.Data)
+
+					log.Printf("testing GetAllConfiglets() against %s %s (%s)", client.clientType, clientName, client.client.apiVersion)
+					configlets, err := client.client.GetAllConfiglets(ctx)
+					require.NoError(t, err)
+					configlet = nil
+					for _, c := range configlets {
+						if c.Id == id {
+							configlet = &c
+							break
+						}
+					}
+					require.NotNil(t, configlet)
+					require.Equal(t, id, configlet.Id)
+					compare(t, &tCase.steps[0].data, configlet.Data)
+
+					for _, step := range tCase.steps {
+						log.Printf("testing UpdateConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.apiVersion)
+						err = client.client.UpdateConfiglet(ctx, id, &step.data)
+						require.NoError(t, err)
+
+						log.Printf("testing GetConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.apiVersion)
+						configlet, err = client.client.GetConfiglet(ctx, id)
+						require.NoError(t, err)
+						require.Equal(t, id, configlet.Id)
+						compare(t, &step.data, configlet.Data)
+
+						log.Printf("testing GetConfigletByName() against %s %s (%s)", client.clientType, clientName, client.client.apiVersion)
+						configlet, err = client.client.GetConfigletByName(ctx, step.data.DisplayName)
+						require.NoError(t, err)
+						require.Equal(t, id, configlet.Id)
+						compare(t, &step.data, configlet.Data)
+
+						log.Printf("testing GetAllConfiglets() against %s %s (%s)", client.clientType, clientName, client.client.apiVersion)
+						configlets, err = client.client.GetAllConfiglets(ctx)
+						require.NoError(t, err)
+						configlet = nil
+						for _, c := range configlets {
+							if c.Id == id {
+								configlet = &c
+								break
+							}
+						}
+						require.NotNil(t, configlet)
+						require.Equal(t, id, configlet.Id)
+						compare(t, &step.data, configlet.Data)
+					}
+
+					log.Printf("testing DeleteConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.apiVersion)
+					err = client.client.DeleteConfiglet(ctx, id)
+					require.NoError(t, err)
+
+					var ace ClientErr
+
+					log.Printf("testing GetConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.apiVersion)
+					_, err = client.client.GetConfiglet(ctx, id)
+					require.Error(t, err)
+					require.ErrorAs(t, err, &ace)
+					require.Equal(t, ace.Type(), ErrNotfound)
+
+					log.Printf("testing GetConfigletByName() against %s %s (%s)", client.clientType, clientName, client.client.apiVersion)
+					_, err = client.client.GetConfigletByName(ctx, tCase.steps[len(tCase.steps)-1].data.DisplayName)
+					require.Error(t, err)
+					require.ErrorAs(t, err, &ace)
+					require.Equal(t, ace.Type(), ErrNotfound)
+
+					log.Printf("testing DeleteConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.apiVersion)
+					err = client.client.DeleteConfiglet(ctx, id)
+					require.Error(t, err)
+					require.ErrorAs(t, err, &ace)
+					require.Equal(t, ace.Type(), ErrNotfound)
+				})
+			}
 		})
-
-		id1, err := client.client.CreateConfiglet(context.Background(), &ConfigletData{
-			DisplayName: Name,
-			RefArchs:    []enum.RefDesign{enum.RefDesignDatacenter},
-			Generators:  cg,
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if err != nil {
-			t.Fatal(err)
-		}
-		log.Println(id1)
-		log.Println("Getting now")
-		c, err := client.client.GetConfiglet(context.Background(), id1)
-		if err != nil {
-			t.Fatal(err)
-		}
-		log.Println(c)
-		g1 := len(c.Data.Generators)
-		c.Data.Generators = append(c.Data.Generators, ConfigletGenerator{
-			ConfigStyle:  enum.ConfigletStyleJunos,
-			Section:      enum.ConfigletSectionSystem,
-			TemplateText: "interfaces {\n   {% if 'leaf1' in hostname %}\n    xe-0/0/3 {\n      disable;\n    }\n   {% endif %}\n   {% if 'leaf2' in hostname %}\n    xe-0/0/2 {\n      disable;\n    }\n   {% endif %}\n}",
-		})
-		log.Println("Update Config")
-
-		err = client.client.UpdateConfiglet(context.Background(), id1, &ConfigletData{
-			DisplayName: c.Data.DisplayName,
-			RefArchs:    c.Data.RefArchs,
-			Generators:  c.Data.Generators,
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		log.Println("Get Configlet by Name")
-		c, err = client.client.GetConfigletByName(context.Background(), Name)
-		if err != nil {
-			t.Fatal(err)
-		}
-		g2 := len(c.Data.Generators)
-		log.Println(g1, g2)
-		if g1 == g2 {
-			t.Fatal("append did not work")
-		}
-		log.Println(c)
-		log.Println("Deleting now")
-
-		err = client.client.DeleteConfiglet(context.Background(), id1)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		log.Println("Testing an incorrect delete")
-		err = client.client.DeleteConfiglet(context.Background(), id1)
-		log.Println(err)
-		if err == nil {
-			t.Fatal("Error :: Deleting non-existent item works")
-		}
 	}
 }

--- a/apstra/client.go
+++ b/apstra/client.go
@@ -1164,6 +1164,12 @@ func (o *Client) DeleteTag(ctx context.Context, id ObjectId) error {
 
 // CreateConfiglet creates a Configlet and returns its ObjectId.
 func (o *Client) CreateConfiglet(ctx context.Context, in *ConfigletData) (ObjectId, error) {
+	for i, generator := range in.Generators {
+		if generator.SectionCondition != "" {
+			return "", fmt.Errorf("SectionCondition not supported in Design Catalog - generator[%d] has non-empty SectionCondition", i)
+		}
+	}
+
 	return o.createConfiglet(ctx, in)
 }
 
@@ -1179,6 +1185,12 @@ func (o *Client) GetConfiglet(ctx context.Context, in ObjectId) (*Configlet, err
 
 // UpdateConfiglet updates a configlet
 func (o *Client) UpdateConfiglet(ctx context.Context, id ObjectId, in *ConfigletData) error {
+	for i, generator := range in.Generators {
+		if generator.SectionCondition != "" {
+			return fmt.Errorf("SectionCondition not supported in Design Catalog - generator[%d] has non-empty SectionCondition", i)
+		}
+	}
+
 	return o.updateConfiglet(ctx, id, in)
 }
 

--- a/apstra/two_stage_l3_clos_client.go
+++ b/apstra/two_stage_l3_clos_client.go
@@ -569,11 +569,25 @@ func (o *TwoStageL3ClosClient) ImportConfigletById(ctx context.Context, cid Obje
 // CreateConfiglet creates a configlet described by a TwoStageL3ClosConfigletData structure
 // in a blueprint.
 func (o *TwoStageL3ClosClient) CreateConfiglet(ctx context.Context, c *TwoStageL3ClosConfigletData) (ObjectId, error) {
+	if c.Data == nil {
+		return "", errors.New("cannot create configlet with nil data")
+	}
+	if len(c.Data.RefArchs) != 0 {
+		return "", errors.New("RefArchs not permitted when creating configlet")
+	}
+
 	return o.createConfiglet(ctx, c)
 }
 
 // UpdateConfiglet updates a configlet imported into a blueprint.
 func (o *TwoStageL3ClosClient) UpdateConfiglet(ctx context.Context, id ObjectId, c *TwoStageL3ClosConfigletData) error {
+	if c.Data == nil {
+		return errors.New("cannot update configlet with nil data")
+	}
+	if len(c.Data.RefArchs) != 0 {
+		return errors.New("RefArchs not permitted when updating configlet")
+	}
+
 	return o.updateConfiglet(ctx, id, c)
 }
 

--- a/apstra/two_stage_l3_clos_configlet.go
+++ b/apstra/two_stage_l3_clos_configlet.go
@@ -54,17 +54,19 @@ func (o *TwoStageL3ClosConfiglet) UnmarshalJSON(bytes []byte) error {
 }
 
 func (o *TwoStageL3ClosClient) getAllConfiglets(ctx context.Context) ([]TwoStageL3ClosConfiglet, error) {
-	response := &struct {
+	var response struct {
 		Items []TwoStageL3ClosConfiglet `json:"items"`
-	}{}
+	}
+
 	err := o.client.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodGet,
 		urlStr:      fmt.Sprintf(apiUrlBlueprintConfiglets, o.blueprintId.String()),
-		apiResponse: response,
+		apiResponse: &response,
 	})
 	if err != nil {
 		return nil, convertTtaeToAceWherePossible(err)
 	}
+
 	return response.Items, nil
 }
 
@@ -73,10 +75,12 @@ func (o *TwoStageL3ClosClient) getAllConfigletIds(ctx context.Context) ([]Object
 	if err != nil {
 		return nil, convertTtaeToAceWherePossible(err)
 	}
+
 	ids := make([]ObjectId, len(configlets))
 	for i, c := range configlets {
 		ids[i] = c.Id
 	}
+
 	return ids, nil
 }
 
@@ -90,6 +94,7 @@ func (o *TwoStageL3ClosClient) getConfiglet(ctx context.Context, id ObjectId) (*
 	if err != nil {
 		return nil, convertTtaeToAceWherePossible(err)
 	}
+
 	return &response, nil
 }
 
@@ -135,6 +140,7 @@ func (o *TwoStageL3ClosClient) createConfiglet(ctx context.Context, in *TwoStage
 	if err != nil {
 		return "", convertTtaeToAceWherePossible(err)
 	}
+
 	return response.Id, nil
 }
 
@@ -147,12 +153,18 @@ func (o *TwoStageL3ClosClient) updateConfiglet(ctx context.Context, id ObjectId,
 	if err != nil {
 		return convertTtaeToAceWherePossible(err)
 	}
+
 	return nil
 }
 
 func (o *TwoStageL3ClosClient) deleteConfiglet(ctx context.Context, id ObjectId) error {
-	return o.client.talkToApstra(ctx, &talkToApstraIn{
+	err := o.client.talkToApstra(ctx, &talkToApstraIn{
 		method: http.MethodDelete,
 		urlStr: fmt.Sprintf(apiUrlBlueprintConfigletsById, o.blueprintId.String(), id.String()),
 	})
+	if err != nil {
+		return convertTtaeToAceWherePossible(err)
+	}
+
+	return nil
 }

--- a/apstra/two_stage_l3_clos_configlet_integration_test.go
+++ b/apstra/two_stage_l3_clos_configlet_integration_test.go
@@ -8,119 +8,226 @@ package apstra
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"log"
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/hashicorp/go-version"
+	"github.com/stretchr/testify/require"
 )
 
 func TestImportGetUpdateGetDeleteConfiglet(t *testing.T) {
 	ctx := context.Background()
+
+	compareGenerators := func(t *testing.T, a, b ConfigletGenerator) {
+		require.Equal(t, a.ConfigStyle.String(), b.ConfigStyle.String())
+		require.Equal(t, a.Section.String(), b.Section.String())
+		require.Equal(t, a.SectionCondition, b.SectionCondition)
+		require.Equal(t, a.TemplateText, b.TemplateText)
+		require.Equal(t, a.NegationTemplateText, b.NegationTemplateText)
+		require.Equal(t, a.Filename, b.Filename)
+	}
+
+	compare := func(t *testing.T, a, b *TwoStageL3ClosConfigletData) {
+		t.Helper()
+
+		require.NotNil(t, a)
+		require.NotNil(t, b)
+		require.Equal(t, a.Label, b.Label)
+		require.Equal(t, a.Condition, b.Condition)
+		require.NotNil(t, a.Data)
+		require.NotNil(t, b.Data)
+		require.Equal(t, a.Data.DisplayName, b.Data.DisplayName)
+		require.Equal(t, len(a.Data.Generators), len(b.Data.Generators))
+		for i := range a.Data.Generators {
+			compareGenerators(t, a.Data.Generators[i], b.Data.Generators[i])
+		}
+	}
+
 	clients, err := getTestClients(ctx, t)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	configletData := ConfigletData{
-		DisplayName: randString(5, "hex"),
-		RefArchs:    []enum.RefDesign{enum.RefDesignDatacenter},
-		Generators: []ConfigletGenerator{{
-			ConfigStyle:  enum.ConfigletStyleJunos,
-			Section:      enum.ConfigletSectionSystem,
-			TemplateText: "interfaces {\n   {% if 'leaf1' in hostname %}\n    xe-0/0/3 {\n      disable;\n    }\n   {% endif %}\n   {% if 'leaf2' in hostname %}\n    xe-0/0/2 {\n      disable;\n    }\n   {% endif %}\n}",
-		}},
+	type testStep struct {
+		data TwoStageL3ClosConfigletData
+	}
+
+	type testCase struct {
+		versionConstraint version.Constraints
+		steps             []testStep
+	}
+
+	testCases := map[string]testCase{
+		"simple_test": {
+			steps: []testStep{
+				{
+					data: TwoStageL3ClosConfigletData{
+						Label:     randString(6, "hex"),
+						Condition: fmt.Sprintf(`label in ["%s"]`, randString(6, "hex")),
+						Data: &ConfigletData{
+							Generators: []ConfigletGenerator{
+								{
+									ConfigStyle:          enum.ConfigletStyleJunos,
+									Section:              enum.ConfigletSectionSystem,
+									TemplateText:         "set " + randString(6, "hex"),
+									NegationTemplateText: "del " + randString(6, "hex"),
+								},
+							},
+							DisplayName: randString(6, "hex"),
+						},
+					},
+				},
+				{
+					data: TwoStageL3ClosConfigletData{
+						Label:     randString(6, "hex"),
+						Condition: fmt.Sprintf(`label in ["%s"]`, randString(6, "hex")),
+						Data: &ConfigletData{
+							Generators: []ConfigletGenerator{
+								{
+									ConfigStyle:          enum.ConfigletStyleEos,
+									Section:              enum.ConfigletSectionInterface,
+									SectionCondition:     `role in ["spine_leaf"]`,
+									TemplateText:         "set " + randString(6, "hex"),
+									NegationTemplateText: "del " + randString(6, "hex"),
+								},
+							},
+							DisplayName: randString(6, "hex"),
+						},
+					},
+				},
+				{
+					data: TwoStageL3ClosConfigletData{
+						Label:     randString(6, "hex"),
+						Condition: fmt.Sprintf("label in [%q]", randString(6, "hex")),
+						Data: &ConfigletData{
+							Generators: []ConfigletGenerator{
+								{
+									ConfigStyle:          enum.ConfigletStyleEos,
+									Section:              enum.ConfigletSectionOspf,
+									TemplateText:         "set " + randString(6, "hex"),
+									NegationTemplateText: "del " + randString(6, "hex"),
+								},
+							},
+							DisplayName: randString(6, "hex"),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for clientName, client := range clients {
-		client := client // use of client in deferred func means we can't use the iterator variable
+		t.Run(client.name(), func(t *testing.T) {
+			t.Parallel()
 
-		// Create Configlet
-		catalogConfigletId, err := client.client.CreateConfiglet(ctx, &configletData)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer func() {
-			err := client.client.DeleteConfiglet(ctx, catalogConfigletId)
-			if err != nil {
-				t.Fatal(err)
+			bp := testBlueprintA(ctx, t, client.client)
+
+			for tName, tCase := range testCases {
+				t.Run(tName, func(t *testing.T) {
+					t.Parallel()
+
+					if tCase.versionConstraint != nil && !tCase.versionConstraint.Check(client.client.apiVersion) {
+						t.Skipf("skipping %q due to version constraints: %q. API version: %q",
+							tName, tCase.versionConstraint, client.client.apiVersion)
+					}
+
+					require.GreaterOrEqualf(t, len(tCase.steps), 1, "test %s has no test steps!", tName)
+
+					log.Printf("testing CreateConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.apiVersion)
+					id, err := bp.CreateConfiglet(ctx, &tCase.steps[0].data)
+					require.NoError(t, err)
+					require.NotEmpty(t, id)
+
+					log.Printf("testing GetConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.apiVersion)
+					configlet, err := bp.GetConfiglet(ctx, id)
+					require.NoError(t, err)
+					require.Equal(t, id, configlet.Id)
+					compare(t, &tCase.steps[0].data, configlet.Data)
+
+					log.Printf("testing GetConfigletByName() against %s %s (%s)", client.clientType, clientName, client.client.apiVersion)
+					configlet, err = bp.GetConfigletByName(ctx, tCase.steps[0].data.Label)
+					require.NoError(t, err)
+					require.Equal(t, id, configlet.Id)
+					compare(t, &tCase.steps[0].data, configlet.Data)
+
+					log.Printf("testing GetAllConfiglets() against %s %s (%s)", client.clientType, clientName, client.client.apiVersion)
+					configlets, err := bp.GetAllConfiglets(ctx)
+					require.NoError(t, err)
+					configlet = nil
+					for _, c := range configlets {
+						if c.Id == id {
+							configlet = &c
+							break
+						}
+					}
+					require.NotNil(t, configlet)
+					require.Equal(t, id, configlet.Id)
+					compare(t, &tCase.steps[0].data, configlet.Data)
+
+					for _, step := range tCase.steps {
+						log.Printf("testing UpdateConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.apiVersion)
+						err = bp.UpdateConfiglet(ctx, id, &step.data)
+						require.NoError(t, err)
+
+						log.Printf("testing GetConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.apiVersion)
+						configlet, err = bp.GetConfiglet(ctx, id)
+						require.NoError(t, err)
+						require.Equal(t, id, configlet.Id)
+						compare(t, &step.data, configlet.Data)
+
+						log.Printf("testing GetConfigletByName() against %s %s (%s)", client.clientType, clientName, client.client.apiVersion)
+						configlet, err = bp.GetConfigletByName(ctx, step.data.Label)
+						require.NoError(t, err)
+						require.Equal(t, id, configlet.Id)
+						compare(t, &step.data, configlet.Data)
+
+						log.Printf("testing GetAllConfigletIds() against %s %s (%s)", client.clientType, clientName, client.client.apiVersion)
+						ids, err := bp.GetAllConfigletIds(ctx)
+						require.NoError(t, err)
+						require.Contains(t, ids, id)
+
+						log.Printf("testing GetAllConfiglets() against %s %s (%s)", client.clientType, clientName, client.client.apiVersion)
+						configlets, err = bp.GetAllConfiglets(ctx)
+						require.NoError(t, err)
+						configlet = nil
+						for _, c := range configlets {
+							if c.Id == id {
+								configlet = &c
+								break
+							}
+						}
+						require.NotNil(t, configlet)
+						require.Equal(t, id, configlet.Id)
+						compare(t, &step.data, configlet.Data)
+					}
+
+					log.Printf("testing DeleteConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.apiVersion)
+					err = bp.DeleteConfiglet(ctx, id)
+					require.NoError(t, err)
+
+					var ace ClientErr
+
+					log.Printf("testing GetConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.apiVersion)
+					_, err = bp.GetConfiglet(ctx, id)
+					require.Error(t, err)
+					require.ErrorAs(t, err, &ace)
+					require.Equal(t, ace.Type(), ErrNotfound)
+
+					log.Printf("testing GetConfigletByName() against %s %s (%s)", client.clientType, clientName, client.client.apiVersion)
+					_, err = bp.GetConfigletByName(ctx, tCase.steps[len(tCase.steps)-1].data.Label)
+					require.Error(t, err)
+					require.ErrorAs(t, err, &ace)
+					require.Equal(t, ace.Type(), ErrNotfound)
+
+					log.Printf("testing DeleteConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.apiVersion)
+					err = bp.DeleteConfiglet(ctx, id)
+					require.Error(t, err)
+					require.ErrorAs(t, err, &ace)
+					require.Equal(t, ace.Type(), ErrNotfound)
+				})
 			}
-		}()
-
-		bpClient := testBlueprintA(ctx, t, client.client)
-
-		log.Printf("testing ImportConfigletById() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		bpConfigletId, err := bpClient.ImportConfigletById(ctx, catalogConfigletId, `role in ["spine", "leaf"]`, "")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		log.Printf("testing GetConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		_, err = bpClient.GetConfiglet(ctx, bpConfigletId)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		log.Printf("testing DeleteConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		err = bpClient.DeleteConfiglet(ctx, bpConfigletId)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		_, err = bpClient.GetConfiglet(ctx, bpConfigletId)
-		if err == nil {
-			t.Fatal("fetch configlet after delete should have produced an error")
-		} else {
-			var ace ClientErr
-			if !errors.As(err, &ace) || ace.Type() != ErrNotfound {
-				t.Fatal("fetch configlet after delete should have produced ErrNotFound")
-			}
-		}
-
-		configletData.DisplayName = randString(5, "hex")
-		c := TwoStageL3ClosConfigletData{
-			Data:      &configletData,
-			Condition: "role in [\"spine\", \"leaf\"]",
-			Label:     "",
-		}
-
-		log.Printf("testing CreateConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		bpConfigletId, err = bpClient.CreateConfiglet(ctx, &c)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		log.Printf("testing GetConfigletByName() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		icfg1, err := bpClient.GetConfigletByName(ctx, configletData.DisplayName)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		icfg1.Data.Label = "new name"
-		icfg1.Data.Condition = "role in [\"spine\"]"
-		log.Printf("testing UpdateConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		err = bpClient.UpdateConfiglet(ctx, icfg1.Id, icfg1.Data)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		log.Printf("testing GetConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		icfg2, err := bpClient.GetConfiglet(ctx, bpConfigletId)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if icfg1.Data.Label != icfg2.Data.Label {
-			t.Fatal("Name Change Failed")
-		}
-		if icfg1.Data.Condition != icfg2.Data.Condition {
-			t.Fatal("Condition Change Failed")
-		}
-
-		log.Printf("testing DeleteConfiglet() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		err = bpClient.DeleteConfiglet(ctx, bpConfigletId)
-		if err != nil {
-			t.Fatal(err)
-		}
+		})
 	}
 }


### PR DESCRIPTION
Changes in here:
- Introduction of `ConfigletGenerator.SectionCondition` string attribute
- Minor formatting changes to configlet code
- Return `ClientErr` type in all configlet methods
- Complete rewrite of configlet tests (both catalog and in-bluepritn) to table-driven style
- Checks to ensure compatibility:
  - `RefArchs` is not set when creating a configlet in a blueprint
  - `SectionCondition` is not set when creating a catalog configlet

Closes #486