### PR TITLE
Introduce support for `experience/web/security-zones` endpoint

### DIFF
--- a/apstra/enum/enums.go
+++ b/apstra/enum/enums.go
@@ -284,3 +284,11 @@ var (
 	ConfigletSectionSystem               = ConfigletSection{Value: "system"}
 	ConfigletSectionSystemTop            = ConfigletSection{Value: "system_top"}
 )
+
+type SecurityZoneType oenum.Member[string]
+
+var (
+	SecurityZoneTypeEvpn            = SecurityZoneType{Value: "evpn"}
+	SecurityZoneTypeL3Fabric        = SecurityZoneType{Value: "l3_fabric"}
+	SecurityZoneTypeVirtualL3Fabric = SecurityZoneType{Value: "virtual_l3_fabric"}
+)

--- a/apstra/enum/generated_enums.go
+++ b/apstra/enum/generated_enums.go
@@ -726,6 +726,37 @@ func (o *RoutingZoneConstraintMode) UnmarshalJSON(bytes []byte) error {
 }
 
 var (
+	_ enum             = (*SecurityZoneType)(nil)
+	_ json.Marshaler   = (*SecurityZoneType)(nil)
+	_ json.Unmarshaler = (*SecurityZoneType)(nil)
+)
+
+func (o SecurityZoneType) String() string {
+	return o.Value
+}
+
+func (o *SecurityZoneType) FromString(s string) error {
+	if SecurityZoneTypes.Parse(s) == nil {
+		return newEnumParseError(o, s)
+	}
+	o.Value = s
+	return nil
+}
+
+func (o *SecurityZoneType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(o.String())
+}
+
+func (o *SecurityZoneType) UnmarshalJSON(bytes []byte) error {
+	var s string
+	err := json.Unmarshal(bytes, &s)
+	if err != nil {
+		return err
+	}
+	return o.FromString(s)
+}
+
+var (
 	_ enum             = (*StorageSchemaPath)(nil)
 	_ json.Marshaler   = (*StorageSchemaPath)(nil)
 	_ json.Unmarshaler = (*StorageSchemaPath)(nil)
@@ -1095,6 +1126,13 @@ var (
 		RoutingZoneConstraintModeNone,
 		RoutingZoneConstraintModeAllow,
 		RoutingZoneConstraintModeDeny,
+	)
+
+	_                 enum = new(SecurityZoneType)
+	SecurityZoneTypes      = oenum.New(
+		SecurityZoneTypeEvpn,
+		SecurityZoneTypeL3Fabric,
+		SecurityZoneTypeVirtualL3Fabric,
 	)
 
 	_                  enum = new(StorageSchemaPath)

--- a/apstra/two_stage_l3_clos_security_zone_info.go
+++ b/apstra/two_stage_l3_clos_security_zone_info.go
@@ -1,0 +1,143 @@
+// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package apstra
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/netip"
+
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+)
+
+const (
+	apiUrlWebExpSecurityZones = apiUrlBlueprintByIdPrefix + "experience/web/security-zones"
+)
+
+var _ json.Unmarshaler = (*TwoStageL3ClosSecurityZoneInfoInterface)(nil)
+
+type TwoStageL3ClosSecurityZoneInfoInterface struct {
+	Id       ObjectId
+	Ipv4Addr *netip.Prefix
+	Ipv6Addr *netip.Prefix
+}
+
+func (o *TwoStageL3ClosSecurityZoneInfoInterface) UnmarshalJSON(bytes []byte) error {
+	var raw struct {
+		Id       ObjectId `json:"id"`
+		Ipv4Addr *string  `json:"ipv4_addr"`
+		Ipv6Addr *string  `json:"ipv6_addr"`
+	}
+
+	err := json.Unmarshal(bytes, &raw)
+	if err != nil {
+		return err
+	}
+
+	o.Id = raw.Id
+
+	if raw.Ipv4Addr != nil {
+		ipv4Addr, err := netip.ParsePrefix(*raw.Ipv4Addr)
+		if err != nil {
+			return fmt.Errorf("failed parsing ipv4 address %q - %w", *raw.Ipv4Addr, err)
+		}
+		if !ipv4Addr.Addr().Is4() {
+			return fmt.Errorf("invalid ipv4 address %q", *raw.Ipv4Addr)
+		}
+		o.Ipv4Addr = &ipv4Addr
+	} else {
+		o.Ipv4Addr = nil
+	}
+
+	if raw.Ipv6Addr != nil {
+		ipv6Addr, err := netip.ParsePrefix(*raw.Ipv6Addr)
+		if err != nil {
+			return fmt.Errorf("failed parsing ipv6 address %q - %w", *raw.Ipv6Addr, err)
+		}
+		if !ipv6Addr.Addr().Is6() {
+			return fmt.Errorf("invalid ipv6 address %q", *raw.Ipv6Addr)
+		}
+		o.Ipv6Addr = &ipv6Addr
+	} else {
+		o.Ipv6Addr = nil
+	}
+
+	return nil
+}
+
+type TwoStageL3ClosSecurityZoneInfo struct {
+	Id               ObjectId               `json:"id"`
+	Label            string                 `json:"label"`
+	VrfName          string                 `json:"vrf_name"`
+	SecurityZoneType *enum.SecurityZoneType `json:"sz_type"`
+	VlanId           *Vlan                  `json:"vlan_id"`
+	RoutingPolicyId  *ObjectId              `json:"routing_policy_id"`
+	JunosEvpnIrbMode *enum.JunosEvpnIrbMode `json:"junos_evpn_irb_mode"`
+	RouteTarget      *string                `json:"route_target"`
+	VniId            *int                   `json:"vni_id"`
+	RtPolicy         *RtPolicy              `json:"rt_policy"`
+	Tags             []string               `json:"tags"`
+	MemberInterfaces []struct {
+		Loopbacks     []TwoStageL3ClosSecurityZoneInfoInterface `json:"loopbacks"`
+		Subinterfaces []TwoStageL3ClosSecurityZoneInfoInterface `json:"subinterfaces"`
+		HostingSystem struct {
+			Id       ObjectId `json:"id"`
+			Label    *string  `json:"label"`
+			Hostname *string  `json:"hostname"`
+		} `json:"hosting_system"`
+	} `json:"member_interfaces"`
+}
+
+// GetAllSecurityZoneInfos returns map[ObjectId]TwoStageL3CloSecurityZoneInfo
+// keyed by Security Zone ID.
+func (o *TwoStageL3ClosClient) GetAllSecurityZoneInfos(ctx context.Context) (map[ObjectId]TwoStageL3ClosSecurityZoneInfo, error) {
+	var apiResponse struct {
+		SecurityZones []TwoStageL3ClosSecurityZoneInfo `json:"security_zones"`
+	}
+
+	err := o.client.talkToApstra(ctx, &talkToApstraIn{
+		method:      http.MethodGet,
+		urlStr:      fmt.Sprintf(apiUrlWebExpSecurityZones, o.blueprintId),
+		apiResponse: &apiResponse,
+	})
+	if err != nil {
+		return nil, convertTtaeToAceWherePossible(err)
+	}
+
+	result := make(map[ObjectId]TwoStageL3ClosSecurityZoneInfo, len(apiResponse.SecurityZones))
+	for _, zone := range apiResponse.SecurityZones {
+		result[zone.Id] = zone
+	}
+
+	return result, nil
+}
+
+// GetSecurityZoneInfo returns TwoStageL3ClosSecurityZoneInfo describing
+// the Security Zone represented by ID.
+func (o *TwoStageL3ClosClient) GetSecurityZoneInfo(ctx context.Context, id ObjectId) (*TwoStageL3ClosSecurityZoneInfo, error) {
+	allSZs, err := o.GetAllSecurityZoneInfos(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var result *TwoStageL3ClosSecurityZoneInfo
+	for _, v := range allSZs {
+		if v.Id == id {
+			result = &v
+			break
+		}
+	}
+
+	if result == nil {
+		return nil, ClientErr{
+			errType: ErrNotfound,
+			err:     fmt.Errorf("security zone with id %v not found", id),
+		}
+	}
+
+	return result, nil
+}

--- a/apstra/two_stage_l3_clos_security_zone_info_integration_test.go
+++ b/apstra/two_stage_l3_clos_security_zone_info_integration_test.go
@@ -8,11 +8,11 @@ package apstra
 
 import (
 	"context"
-	"github.com/Juniper/apstra-go-sdk/apstra/compatibility"
 	"math/rand"
 	"net/netip"
 	"testing"
 
+	"github.com/Juniper/apstra-go-sdk/apstra/compatibility"
 	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"github.com/stretchr/testify/require"
 )

--- a/apstra/two_stage_l3_clos_security_zone_info_integration_test.go
+++ b/apstra/two_stage_l3_clos_security_zone_info_integration_test.go
@@ -1,0 +1,189 @@
+// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package apstra
+
+import (
+	"context"
+	"github.com/Juniper/apstra-go-sdk/apstra/compatibility"
+	"math/rand"
+	"net/netip"
+	"testing"
+
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTwoStageL3ClosClient_GetSecurityZoneInfo(t *testing.T) {
+	ctx := context.Background()
+	clients, err := getTestClients(ctx, t)
+	require.NoError(t, err)
+
+	securityZoneCount := rand.Intn(3) + 3
+
+	compareSzDataToSzInfo := func(t *testing.T, a *SecurityZoneData, b *TwoStageL3ClosSecurityZoneInfo) {
+		t.Helper()
+
+		require.NotNil(t, a)
+		require.NotNil(t, b)
+
+		require.Equal(t, a.Label, b.Label)
+		require.Equal(t, a.SzType.String(), b.SecurityZoneType.String())
+		require.Equal(t, a.VrfName, b.VrfName)
+		require.Equal(t, a.VlanId, b.VlanId)
+		require.NotNil(t, a.JunosEvpnIrbMode)
+		require.NotNil(t, b.JunosEvpnIrbMode)
+		require.Equal(t, *a.JunosEvpnIrbMode, *b.JunosEvpnIrbMode)
+	}
+
+	compareLoopbacksToSzInfo := func(t *testing.T, a map[ObjectId]SecurityZoneLoopback, b TwoStageL3ClosSecurityZoneInfo) {
+		t.Helper()
+
+		// reorganize member interfaces into a map keyed by interface ID
+		loopbacks := make(map[ObjectId]TwoStageL3ClosSecurityZoneInfoInterface)
+		for _, memberInterface := range b.MemberInterfaces {
+			for _, loopback := range memberInterface.Loopbacks {
+				loopbacks[loopback.Id] = loopback
+			}
+		}
+
+		for ifId, loopbackInfo := range a {
+			if loopback, ok := loopbacks[ifId]; ok {
+				require.Equal(t, loopbackInfo.IPv4Addr.String(), loopback.Ipv4Addr.String())
+				require.Equal(t, loopbackInfo.IPv6Addr.String(), loopback.Ipv6Addr.String())
+			} else {
+				t.Fatalf("loopback not found for %s", ifId)
+			}
+		}
+	}
+
+	// sub-test per client
+	for _, client := range clients {
+		t.Run(client.name(), func(t *testing.T) {
+			t.Parallel()
+
+			if !compatibility.SecurityZoneLoopbackApiSupported.Check(client.client.apiVersion) {
+				t.Skip("Security zone loopback api not supported")
+			}
+
+			bp := testBlueprintH(ctx, t, client.client)
+
+			// get all systems
+			var response struct {
+				Nodes map[ObjectId]struct {
+					Id       ObjectId `json:"id"`
+					Label    string   `json:"label"`
+					Hostname string   `json:"hostname"`
+					Role     string   `json:"role"`
+					Ipv4Addr netip.Prefix
+					Ipv6Addr netip.Prefix
+				} `json:"nodes"`
+			}
+			err = bp.Client().GetNodes(ctx, bp.Id(), NodeTypeSystem, &response)
+			require.NoError(t, err)
+
+			var vnBindings []VnBinding // we'll use this binding slice when creating VNs later
+
+			// whittle down the systems to just leaf switches and add a record to to vnBindings
+			for k, v := range response.Nodes {
+				if v.Role != "leaf" {
+					delete(response.Nodes, k)
+					continue
+				}
+				vnBindings = append(vnBindings, VnBinding{SystemId: k})
+			}
+
+			szIds := make([]ObjectId, securityZoneCount)
+			szDatas := make([]SecurityZoneData, securityZoneCount)
+			VlanIds := make([]int, securityZoneCount) // dedicated vlan slice ensures no collisions
+			randomIntsN(VlanIds, vlanMax-2)
+
+			// create security zones
+			for i := range securityZoneCount {
+				szDatas[i] = SecurityZoneData{
+					Label:            randString(6, "hex"),
+					SzType:           SecurityZoneTypeEVPN,
+					VrfName:          randString(6, "hex"),
+					VlanId:           toPtr(Vlan(VlanIds[i])),
+					JunosEvpnIrbMode: oneOf(&enum.JunosEvpnIrbModeAsymmetric, &enum.JunosEvpnIrbModeSymmetric),
+				}
+
+				// create security zone, record ID
+				szIds[i], err = bp.CreateSecurityZone(ctx, &szDatas[i])
+				require.NoError(t, err)
+
+				// create a VN to activate the SZ is on leaf switches
+				_, err := bp.CreateVirtualNetwork(ctx, &VirtualNetworkData{
+					Ipv4Enabled:    true,
+					Ipv6Enabled:    true,
+					Label:          randString(6, "hex"),
+					SecurityZoneId: szIds[i],
+					VnBindings:     vnBindings,
+					VnType:         enum.VnTypeVxlan,
+				})
+				require.NoError(t, err)
+			}
+
+			// set ipv4 and ipv6 addresses of each leaf in each security zone
+			szidToIfidToLoopbackInfo := make(map[ObjectId]map[ObjectId]SecurityZoneLoopback, securityZoneCount)
+			for _, szId := range szIds {
+				szidToIfidToLoopbackInfo[szId], err = bp.GetSecurityZoneLoopbacks(ctx, szId)
+				require.NoError(t, err)
+				for k, v := range szidToIfidToLoopbackInfo[szId] {
+					v.IPv4Addr = toPtr(netip.MustParsePrefix(randomIpv4().String() + "/32"))
+					v.IPv6Addr = toPtr(netip.MustParsePrefix(randomIpv6().String() + "/128"))
+					szidToIfidToLoopbackInfo[szId][k] = v
+				}
+
+				err := bp.SetSecurityZoneLoopbacks(ctx, szId, szidToIfidToLoopbackInfo[szId])
+				require.NoError(t, err)
+			}
+
+			infos, err := bp.GetAllSecurityZoneInfos(ctx)
+			require.NoError(t, err)
+			require.Equal(t, securityZoneCount+1, len(infos)) // one extra for default SZ
+
+			// drop the default SZ from infos since we didn't set addresses in there
+			for k := range infos {
+				if !sliceContains(szIds, k) {
+					delete(infos, k)
+				}
+			}
+			require.Equal(t, securityZoneCount, len(infos))
+
+			for i, szId := range szIds {
+				info, err := bp.GetSecurityZoneInfo(ctx, szId)
+				require.NoError(t, err)
+
+				// check security zone details
+				compareSzDataToSzInfo(t, &szDatas[i], info)
+
+				// check per-sz loopback addresses
+				compareLoopbacksToSzInfo(t, szidToIfidToLoopbackInfo[szId], infos[szId])
+			}
+		})
+	}
+}
+
+func TestTwoStageL3ClosClient_GetSecurityZoneInfoBogus(t *testing.T) {
+	ctx := context.Background()
+	clients, err := getTestClients(ctx, t)
+	require.NoError(t, err)
+
+	for _, client := range clients {
+		t.Run(client.name(), func(t *testing.T) {
+			t.Parallel()
+
+			bp := testBlueprintA(ctx, t, client.client)
+
+			_, err := bp.GetSecurityZoneInfo(ctx, "bogus")
+			require.Error(t, err)
+			var ace ClientErr
+			require.ErrorAs(t, err, &ace)
+			require.Equal(t, ace.errType, ErrNotfound)
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces enums, structs and methods related to the `/api/%s/experience/web/security-zones` API endpoint.

This endpoint is required to support the terraform `apstra_datacenter_routing_zone_loopback_addresses` resource.