### PR TITLE
Bugfix: Ensure task monitor starts when `talkToApstra()` encounters HTTP 401 (other than via api-ops)

### DIFF
--- a/apstra/talk_to_apstra.go
+++ b/apstra/talk_to_apstra.go
@@ -15,6 +15,7 @@ import (
 	"math"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -282,9 +283,15 @@ func (o *Client) talkToApstra(ctx context.Context, in *talkToApstraIn) error {
 						resp.StatusCode, apstraUrl, in.doNotLogin))
 			}
 
+			if _, ok := os.LookupEnv(envAosOpsEdgeId); ok {
+				return newTalkToApstraErr(req, requestBody, resp,
+					fmt.Sprintf("http %d at '%s' and %s has been set",
+						resp.StatusCode, apstraUrl, envAosOpsEdgeId))
+			}
+
 			o.logStr(1, fmt.Sprintf("got http %d '%s' at '%s' attempting login", resp.StatusCode, resp.Status, apstraUrl.String()))
 			// Try logging in
-			err := o.login(ctx)
+			err := o.Login(ctx)
 			if err != nil {
 				return fmt.Errorf("error attempting login after initial AuthFail - %w", err)
 			}


### PR DESCRIPTION
https://github.com/Juniper/apstra-go-sdk/pull/507 moved task monitor startup from login() to Login().

An unauthenticated client automatically gets logged in when talkToApstra() encounters a 401 HTTP response code.

But talkToApstra() has been doing that with login(), which now doesn't start the task montior, leading to a deadlock condition.

This PR ensures that the task monitor is started by `talkToApstra()`, but only when not using the api-ops proxy.

Closes #521