### PR TITLE
Add support for `Tags` (`[]string`) to `VirtualNetworkData` struct

### DIFF
--- a/apstra/client.go
+++ b/apstra/client.go
@@ -37,6 +37,7 @@ const (
 	ErrInUse
 	ErrMultipleMatch
 	ErrNotfound
+	ErrNotSupported
 	ErrUncommitted
 	ErrWrongType
 	ErrReadOnly

--- a/apstra/compatibility/constraints.go
+++ b/apstra/compatibility/constraints.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// Copyright (c) Juniper Networks, Inc., 2024-2025.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -48,5 +48,8 @@ var (
 	}
 	TemplateRequestRequiresAntiAffinityPolicy = Constraint{
 		constraints: version.MustConstraints(version.NewConstraint("<=" + apstra420)),
+	}
+	VirtualNetworkTags = Constraint{
+		constraints: version.MustConstraints(version.NewConstraint(">=" + apstra500)),
 	}
 )

--- a/apstra/talk_to_apstra.go
+++ b/apstra/talk_to_apstra.go
@@ -15,6 +15,7 @@ import (
 	"math"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -282,9 +283,15 @@ func (o *Client) talkToApstra(ctx context.Context, in *talkToApstraIn) error {
 						resp.StatusCode, apstraUrl, in.doNotLogin))
 			}
 
+			if _, ok := os.LookupEnv(envAosOpsEdgeId); ok {
+				return newTalkToApstraErr(req, requestBody, resp,
+					fmt.Sprintf("http %d at '%s' and %s has been set",
+						resp.StatusCode, apstraUrl, envAosOpsEdgeId))
+			}
+
 			o.logStr(1, fmt.Sprintf("got http %d '%s' at '%s' attempting login", resp.StatusCode, resp.Status, apstraUrl.String()))
 			// Try logging in
-			err := o.login(ctx)
+			err := o.Login(ctx)
 			if err != nil {
 				return fmt.Errorf("error attempting login after initial AuthFail - %w", err)
 			}

--- a/apstra/two_stage_l3_clos_client.go
+++ b/apstra/two_stage_l3_clos_client.go
@@ -344,6 +344,13 @@ func (o *TwoStageL3ClosClient) DeletePolicyRuleById(ctx context.Context, policyI
 
 // CreateVirtualNetwork creates a new virtual network according to the supplied VirtualNetworkData
 func (o *TwoStageL3ClosClient) CreateVirtualNetwork(ctx context.Context, in *VirtualNetworkData) (ObjectId, error) {
+	if in.Tags != nil {
+		return "", ClientErr{
+			errType: ErrNotSupported,
+			err:     errors.New("tags must be nil when creating virtual network"),
+		}
+	}
+
 	return o.createVirtualNetwork(ctx, in)
 }
 
@@ -373,6 +380,13 @@ func (o *TwoStageL3ClosClient) GetAllVirtualNetworks(ctx context.Context) (map[O
 // UpdateVirtualNetwork updates the virtual network specified by ID using the
 // VirtualNetworkData and HTTP method PUT.
 func (o *TwoStageL3ClosClient) UpdateVirtualNetwork(ctx context.Context, id ObjectId, in *VirtualNetworkData) error {
+	if in.Tags != nil {
+		return ClientErr{
+			errType: ErrNotSupported,
+			err:     errors.New("tags must be nil when updating virtual network"),
+		}
+	}
+
 	return o.updateVirtualNetwork(ctx, id, in)
 }
 

--- a/apstra/two_stage_l3_clos_virtual_networks.go
+++ b/apstra/two_stage_l3_clos_virtual_networks.go
@@ -255,6 +255,7 @@ func (o *VirtualNetwork) UnmarshalJSON(bytes []byte) error {
 		RtPolicy                  *RtPolicy   `json:"rt_policy"`
 		SecurityZoneId            ObjectId    `json:"security_zone_id"`
 		SviIps                    []SviIp     `json:"svi_ips"`
+		Tags                      []string    `json:"tags"`
 		VirtualGatewayIpv4        string      `json:"virtual_gateway_ipv4"`
 		VirtualGatewayIpv6        string      `json:"virtual_gateway_ipv6"`
 		VirtualGatewayIpv4Enabled bool        `json:"virtual_gateway_ipv4_enabled"`
@@ -299,6 +300,7 @@ func (o *VirtualNetwork) UnmarshalJSON(bytes []byte) error {
 	o.Data.RtPolicy = raw.RtPolicy
 	o.Data.SecurityZoneId = raw.SecurityZoneId
 	o.Data.SviIps = raw.SviIps
+	o.Data.Tags = raw.Tags
 
 	o.Data.VirtualGatewayIpv4, err = ipFromString(raw.VirtualGatewayIpv4)
 	if err != nil {
@@ -357,6 +359,7 @@ type VirtualNetworkData struct {
 	RtPolicy                  *RtPolicy          `json:"rt_policy"`
 	SecurityZoneId            ObjectId           `json:"security_zone_id,omitempty"`
 	SviIps                    []SviIp            `json:"svi_ips"`
+	Tags                      []string           `json:"tags"`
 	VirtualGatewayIpv4        net.IP             `json:"virtual_gateway_ipv4,omitempty"`
 	VirtualGatewayIpv6        net.IP             `json:"virtual_gateway_ipv6,omitempty"`
 	VirtualGatewayIpv4Enabled bool               `json:"virtual_gateway_ipv4_enabled"`


### PR DESCRIPTION
This PR introduces the `Tags` element to the `VirtualNetworkData` struct.

As of Apstra 5.1.0, virtual network tags can only be retrieved from the API with GET. Presence of `Tags` is ignored by POST/PUT/PATCH.