### PR TITLE
Add support for integrated interconnect dci configurations

### DIFF
--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -88,7 +88,7 @@ func randomIpv6() net.IP {
 	}
 }
 
-// randomHardwareAddre returns a net.HardwareAddr. The set and unset arguments
+// randomHardwareAddr returns a net.HardwareAddr. The set and unset arguments
 // allow the caller to specify certain bits which must be set or must be unset
 // in the result.
 // For example, to get a random mac with only the LAA bit set, you'd invoke the

--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -88,6 +88,25 @@ func randomIpv6() net.IP {
 	}
 }
 
+func randomHardwareAddr(group ...bool) net.HardwareAddr {
+	result := net.HardwareAddr{
+		byte(rand.Intn(math.MaxUint8 + 1)),
+		byte(rand.Intn(math.MaxUint8 + 1)),
+		byte(rand.Intn(math.MaxUint8 + 1)),
+		byte(rand.Intn(math.MaxUint8 + 1)),
+		byte(rand.Intn(math.MaxUint8 + 1)),
+		byte(rand.Intn(math.MaxUint8 + 1)),
+	}
+
+	if len(group) > 0 {
+		result[0] = result[0] | 1 // force an odd number
+	} else {
+		result[0] = result[0] & (math.MaxUint8 - 1) // force an even number
+	}
+
+	return result
+}
+
 // randomIntsN fills the supplied slice with non-negative pseudo-random values in the half-open interval [0,n)
 func randomIntsN(s []int, n int) {
 	l := len(s)

--- a/apstra/query_node.go
+++ b/apstra/query_node.go
@@ -14,6 +14,7 @@ const (
 	NodeTypeDomain
 	NodeTypeEpEndpointPolicy
 	NodeTypeEpGroup
+	NodeTypeEvpnInterconnectGroup
 	NodeTypeFabricAddressingPolicy
 	NodeTypeFabricPolicy
 	NodeTypeInterface
@@ -45,6 +46,7 @@ const (
 	nodeTypeDomain                 = nodeType("domain")
 	nodeTypeEpEndpointPolicy       = nodeType("ep_endpoint_policy")
 	nodeTypeEpGroup                = nodeType("ep_group")
+	nodeTypeEvpnInterconnectGroup  = nodeType("evpn_interconnect_group")
 	nodeTypeFabricAddressingPolicy = nodeType("fabric_addressing_policy")
 	nodeTypeFabricPolicy           = nodeType("fabric_policy")
 	nodeTypeInterface              = nodeType("interface")
@@ -91,6 +93,8 @@ func (o NodeType) String() string {
 		return string(nodeTypeEpEndpointPolicy)
 	case NodeTypeEpGroup:
 		return string(nodeTypeEpGroup)
+	case NodeTypeEvpnInterconnectGroup:
+		return string(nodeTypeEvpnInterconnectGroup)
 	case NodeTypeFabricAddressingPolicy:
 		return string(nodeTypeFabricAddressingPolicy)
 	case NodeTypeFabricPolicy:

--- a/apstra/query_node.go
+++ b/apstra/query_node.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// Copyright (c) Juniper Networks, Inc., 2023-2025.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/apstra/two_stage_l3_clos_evpn_interconnect_group.go
+++ b/apstra/two_stage_l3_clos_evpn_interconnect_group.go
@@ -1,0 +1,180 @@
+// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package apstra
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+)
+
+const (
+	apiUrlBlueprintEvpnInterconnectGroups       = apiUrlBlueprintById + apiUrlPathDelim + "evpn_interconnect_groups"
+	apiUrlBlueprintEvpnInterconnectGroupsPrefix = apiUrlBlueprintEvpnInterconnectGroups + apiUrlPathDelim
+	apiUrlBlueprintEvpnInterconnectGroupById    = apiUrlBlueprintEvpnInterconnectGroupsPrefix + "%s"
+)
+
+var _ json.Unmarshaler = (*EvpnInterconnectGroup)(nil)
+
+type EvpnInterconnectGroup struct {
+	Id   ObjectId
+	Data *EvpnInterconnectGroupData
+}
+
+func (o *EvpnInterconnectGroup) UnmarshalJSON(bytes []byte) error {
+	var raw struct {
+		Id          ObjectId `json:"id"`
+		Label       string   `json:"label"`
+		RouteTarget string   `json:"interconnect_route_target"`
+		EsiMac      *string  `json:"interconnect_esi_mac"`
+	}
+
+	if err := json.Unmarshal(bytes, &raw); err != nil {
+		return err
+	}
+
+	o.Id = raw.Id
+	o.Data = new(EvpnInterconnectGroupData)
+	o.Data.Label = raw.Label
+	o.Data.RouteTarget = raw.RouteTarget
+	if raw.EsiMac != nil {
+		esiMac, err := net.ParseMAC(*raw.EsiMac)
+		if err != nil {
+			return fmt.Errorf("error parsing interconnect esi mac: %s", err)
+		}
+		o.Data.EsiMac = esiMac
+	}
+
+	return nil
+}
+
+var _ json.Marshaler = (*EvpnInterconnectGroupData)(nil)
+
+type EvpnInterconnectGroupData struct {
+	Label       string
+	RouteTarget string
+	EsiMac      net.HardwareAddr
+}
+
+func (o EvpnInterconnectGroupData) MarshalJSON() ([]byte, error) {
+	var raw struct {
+		Label       string  `json:"label"`
+		RouteTarget string  `json:"interconnect_route_target"`
+		EsiMac      *string `json:"interconnect_esi_mac,omitempty"`
+	}
+
+	raw.Label = o.Label
+	raw.RouteTarget = o.RouteTarget
+	if o.EsiMac != nil {
+		raw.EsiMac = toPtr(o.EsiMac.String())
+	}
+
+	return json.Marshal(raw)
+}
+
+func (o *TwoStageL3ClosClient) CreateEvpnInterconnectGroup(ctx context.Context, in *EvpnInterconnectGroupData) (ObjectId, error) {
+	var response objectIdResponse
+
+	err := o.client.talkToApstra(ctx, &talkToApstraIn{
+		method:      http.MethodPost,
+		urlStr:      fmt.Sprintf(apiUrlBlueprintEvpnInterconnectGroups, o.Id()),
+		apiInput:    in,
+		apiResponse: &response,
+	})
+	if err != nil {
+		return "", convertTtaeToAceWherePossible(err)
+	}
+
+	return response.Id, nil
+}
+
+func (o *TwoStageL3ClosClient) GetEvpnInterconnectGroup(ctx context.Context, id ObjectId) (*EvpnInterconnectGroup, error) {
+	var response EvpnInterconnectGroup
+
+	err := o.client.talkToApstra(ctx, &talkToApstraIn{
+		method:      http.MethodGet,
+		urlStr:      fmt.Sprintf(apiUrlBlueprintEvpnInterconnectGroupById, o.Id(), id),
+		apiResponse: &response,
+	})
+	if err != nil {
+		return nil, convertTtaeToAceWherePossible(err)
+	}
+
+	return &response, nil
+}
+
+func (o *TwoStageL3ClosClient) GetAllEvpnInterconnectGroups(ctx context.Context) ([]EvpnInterconnectGroup, error) {
+	var response struct {
+		Items []EvpnInterconnectGroup `json:"evpn_interconnect_groups"`
+	}
+
+	err := o.client.talkToApstra(ctx, &talkToApstraIn{
+		method:      http.MethodGet,
+		urlStr:      fmt.Sprintf(apiUrlBlueprintEvpnInterconnectGroups, o.Id()),
+		apiResponse: &response,
+	})
+	if err != nil {
+		return nil, convertTtaeToAceWherePossible(err)
+	}
+
+	return response.Items, nil
+}
+
+func (o *TwoStageL3ClosClient) GetEvpnInterconnectGroupByName(ctx context.Context, name string) (*EvpnInterconnectGroup, error) {
+	items, err := o.GetAllEvpnInterconnectGroups(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("GetAllEvpnInterconnectGroups: %w", err)
+	}
+
+	var evpnInterconnectGroup *EvpnInterconnectGroup
+	for _, item := range items {
+		if item.Data.Label == name {
+			if evpnInterconnectGroup == nil {
+				evpnInterconnectGroup = &item
+			} else {
+				return nil, ClientErr{
+					errType: ErrMultipleMatch,
+					err:     fmt.Errorf("found multiple EVPN Interconnect Groups with label %q", name),
+				}
+			}
+		}
+	}
+
+	if evpnInterconnectGroup == nil {
+		return nil, ClientErr{
+			errType: ErrNotfound,
+			err:     fmt.Errorf("EVPN Interconnect Group with label %q not found", name),
+		}
+	}
+
+	return evpnInterconnectGroup, nil
+}
+
+func (o *TwoStageL3ClosClient) UpdateEvpnInterconnectGroup(ctx context.Context, id ObjectId, cfg *EvpnInterconnectGroupData) error {
+	err := o.client.talkToApstra(ctx, &talkToApstraIn{
+		method:   http.MethodPatch,
+		urlStr:   fmt.Sprintf(apiUrlBlueprintEvpnInterconnectGroupById, o.Id(), id),
+		apiInput: cfg,
+	})
+	if err != nil {
+		return convertTtaeToAceWherePossible(err)
+	}
+
+	return nil
+}
+
+func (o *TwoStageL3ClosClient) DeleteEvpnInterconnectGroup(ctx context.Context, id ObjectId) error {
+	err := o.client.talkToApstra(ctx, &talkToApstraIn{
+		method: http.MethodDelete,
+		urlStr: fmt.Sprintf(apiUrlBlueprintEvpnInterconnectGroupById, o.Id(), id),
+	})
+	if err != nil {
+		return convertTtaeToAceWherePossible(err)
+	}
+
+	return nil
+}

--- a/apstra/two_stage_l3_clos_evpn_interconnect_group.go
+++ b/apstra/two_stage_l3_clos_evpn_interconnect_group.go
@@ -62,15 +62,15 @@ type EvpnInterconnectGroupData struct {
 
 func (o EvpnInterconnectGroupData) MarshalJSON() ([]byte, error) {
 	var raw struct {
-		Label       string  `json:"label"`
-		RouteTarget string  `json:"interconnect_route_target"`
-		EsiMac      *string `json:"interconnect_esi_mac,omitempty"`
+		Label       string `json:"label"`
+		RouteTarget string `json:"interconnect_route_target"`
+		EsiMac      string `json:"interconnect_esi_mac,omitempty"`
 	}
 
 	raw.Label = o.Label
 	raw.RouteTarget = o.RouteTarget
 	if o.EsiMac != nil {
-		raw.EsiMac = toPtr(o.EsiMac.String())
+		raw.EsiMac = o.EsiMac.String()
 	}
 
 	return json.Marshal(raw)

--- a/apstra/two_stage_l3_clos_evpn_interconnect_group.go
+++ b/apstra/two_stage_l3_clos_evpn_interconnect_group.go
@@ -44,7 +44,7 @@ func (o *EvpnInterconnectGroup) UnmarshalJSON(bytes []byte) error {
 	if raw.EsiMac != nil {
 		esiMac, err := net.ParseMAC(*raw.EsiMac)
 		if err != nil {
-			return fmt.Errorf("error parsing interconnect esi mac: %s", err)
+			return fmt.Errorf("parsing interconnect esi mac: %s", err)
 		}
 		o.Data.EsiMac = esiMac
 	}

--- a/apstra/two_stage_l3_clos_evpn_interconnect_group_integration_test.go
+++ b/apstra/two_stage_l3_clos_evpn_interconnect_group_integration_test.go
@@ -167,7 +167,6 @@ func TestEvpnInterconnectGroup(t *testing.T) {
 
 				for _, evpnInterconnectGroup := range all {
 					t.Run("delete_"+evpnInterconnectGroup.Id.String(), func(t *testing.T) {
-
 						t.Parallel()
 
 						err = bpClient.DeleteEvpnInterconnectGroup(ctx, evpnInterconnectGroup.Id)
@@ -193,6 +192,5 @@ func TestEvpnInterconnectGroup(t *testing.T) {
 				}
 			})
 		})
-
 	}
 }

--- a/apstra/two_stage_l3_clos_evpn_interconnect_group_integration_test.go
+++ b/apstra/two_stage_l3_clos_evpn_interconnect_group_integration_test.go
@@ -1,0 +1,198 @@
+// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package apstra
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvpnInterconnectGroup(t *testing.T) {
+	ctx := context.Background()
+
+	clients, err := getTestClients(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	compare := func(t *testing.T, a, b *EvpnInterconnectGroupData) {
+		t.Helper()
+
+		require.NotNil(t, a)
+		require.NotNil(t, b)
+
+		require.Equal(t, a.Label, b.Label)
+
+		require.NotNil(t, b.EsiMac)
+		if a.EsiMac != nil {
+			require.Equal(t, a.EsiMac, b.EsiMac)
+		}
+
+		require.Equal(t, a.RouteTarget, b.RouteTarget)
+	}
+
+	for clientName, client := range clients {
+		t.Run(clientName, func(t *testing.T) {
+			t.Parallel()
+
+			bpClient := testBlueprintA(ctx, t, client.client)
+
+			type testStep struct {
+				config EvpnInterconnectGroupData
+			}
+
+			type testCase struct {
+				steps []testStep
+			}
+
+			testCases := map[string]testCase{
+				"start_minimal": {
+					steps: []testStep{
+						{
+							config: EvpnInterconnectGroupData{
+								Label:       "a" + randString(6, "hex"),
+								RouteTarget: fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1),
+							},
+						},
+						{
+							config: EvpnInterconnectGroupData{
+								Label:       "a" + randString(6, "hex"),
+								RouteTarget: fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1),
+								EsiMac:      randomHardwareAddr(), // unicast mac
+							},
+						},
+						{
+							config: EvpnInterconnectGroupData{
+								Label:       "a" + randString(6, "hex"),
+								RouteTarget: fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1),
+							},
+						},
+					},
+				},
+				"start_maximal": {
+					steps: []testStep{
+						{
+							config: EvpnInterconnectGroupData{
+								Label:       "a" + randString(6, "hex"),
+								RouteTarget: fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1),
+								EsiMac:      randomHardwareAddr(),
+							},
+						},
+						{
+							config: EvpnInterconnectGroupData{
+								Label:       "a" + randString(6, "hex"),
+								RouteTarget: fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1),
+							},
+						},
+						{
+							config: EvpnInterconnectGroupData{
+								Label:       "a" + randString(6, "hex"),
+								RouteTarget: fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1),
+								EsiMac:      randomHardwareAddr(),
+							},
+						},
+					},
+				},
+			}
+
+			var createdIds []ObjectId
+			idMutex := new(sync.Mutex)
+
+			wg := sync.WaitGroup{}
+			wg.Add(len(testCases))
+
+			for tName, tCase := range testCases {
+				t.Run(tName, func(t *testing.T) {
+					t.Cleanup(func() { wg.Done() })
+					t.Parallel()
+
+					require.Greater(t, len(tCase.steps), 0)
+					id, err := bpClient.CreateEvpnInterconnectGroup(ctx, &tCase.steps[0].config)
+					require.NoError(t, err)
+					idMutex.Lock()
+					createdIds = append(createdIds, id)
+					idMutex.Unlock()
+
+					get, err := bpClient.GetEvpnInterconnectGroup(ctx, id)
+					require.NoError(t, err)
+					require.Equal(t, id, get.Id)
+					require.NotNil(t, get.Data)
+					compare(t, &tCase.steps[0].config, get.Data)
+
+					for i, step := range tCase.steps {
+						t.Logf("%s update step %d", tName, i)
+						err := bpClient.UpdateEvpnInterconnectGroup(ctx, id, &step.config)
+						require.NoError(t, err)
+
+						get, err := bpClient.GetEvpnInterconnectGroup(ctx, id)
+						require.NoError(t, err)
+						require.Equal(t, id, get.Id)
+						require.NotNil(t, get.Data)
+						compare(t, &step.config, get.Data)
+
+						get, err = bpClient.GetEvpnInterconnectGroupByName(ctx, step.config.Label)
+						require.NoError(t, err)
+						require.Equal(t, id, get.Id)
+						require.NotNil(t, get.Data)
+						compare(t, &step.config, get.Data)
+					}
+				})
+			}
+
+			t.Run("get_all", func(t *testing.T) {
+				t.Parallel()
+
+				wg.Wait()
+
+				all, err := bpClient.GetAllEvpnInterconnectGroups(ctx)
+				require.NoError(t, err)
+				require.Equal(t, len(testCases), len(all))
+
+				retrievedIds := make([]ObjectId, len(all))
+				for i, o := range all {
+					retrievedIds[i] = o.Id
+				}
+
+				compareSlicesAsSets(t, createdIds, retrievedIds, "created and retrieved IDs do not match")
+
+				for _, evpnInterconnectGroup := range all {
+					t.Run("delete_"+evpnInterconnectGroup.Id.String(), func(t *testing.T) {
+
+						t.Parallel()
+
+						err = bpClient.DeleteEvpnInterconnectGroup(ctx, evpnInterconnectGroup.Id)
+						require.NoError(t, err)
+
+						var ace ClientErr
+
+						err = bpClient.DeleteEvpnInterconnectGroup(ctx, evpnInterconnectGroup.Id)
+						require.Error(t, err)
+						require.ErrorAs(t, err, &ace)
+						require.Equal(t, ErrNotfound, ace.errType)
+
+						_, err = bpClient.GetEvpnInterconnectGroup(ctx, evpnInterconnectGroup.Id)
+						require.Error(t, err)
+						require.ErrorAs(t, err, &ace)
+						require.Equal(t, ErrNotfound, ace.errType)
+
+						_, err = bpClient.GetEvpnInterconnectGroupByName(ctx, evpnInterconnectGroup.Data.Label)
+						require.Error(t, err)
+						require.ErrorAs(t, err, &ace)
+						require.Equal(t, ErrNotfound, ace.errType)
+					})
+				}
+			})
+		})
+
+	}
+}


### PR DESCRIPTION
Introduce support for `/api/blueprints/%s/evpn_interconnect_groups`

The usual methods: Create / Get / GetAll / GetByName / Update / Delete

Tested with the following versions:

- 4.2.0-236
- 4.2.1-207
- 4.2.1.1-10
- 4.2.2-2
- 5.0.0-63
- 5.0.1-1
- 5.1.0-117
- 6.0.0-189


Closes #524