### PR TITLE
Introduce `QEHaving{}` and path query `Having()` method

### DIFF
--- a/apstra/query_engine.go
+++ b/apstra/query_engine.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// Copyright (c) Juniper Networks, Inc., 2022-2025.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/apstra/query_engine_test.go
+++ b/apstra/query_engine_test.go
@@ -480,6 +480,25 @@ func TestQueryString(t *testing.T) {
 					AtMost:  1,
 				}),
 		},
+		"having_1_5_loopbacks": {
+			e: "node(type='system',name='system-1-5-loopbacks').having(node(name='system-1-5-loopbacks').out(type='hosted_interfaces').node(type='interface',if_type='loopback'),at_least=1,at_most=5)",
+			q: new(PathQuery).
+				Node([]QEEAttribute{
+					NodeTypeSystem.QEEAttribute(),
+					{Key: "name", Value: QEStringVal("system-1-5-loopbacks")},
+				}).
+				Having(QEHaving{
+					Query: new(PathQuery).
+						Node([]QEEAttribute{{Key: "name", Value: QEStringVal("system-1-5-loopbacks")}}).
+						Out([]QEEAttribute{RelationshipTypeHostedInterfaces.QEEAttribute()}).
+						Node([]QEEAttribute{
+							NodeTypeInterface.QEEAttribute(),
+							{Key: "if_type", Value: QEStringVal("loopback")},
+						}),
+					AtLeast: 1,
+					AtMost:  5,
+				}),
+		},
 	}
 
 	for tName, tCase := range testCases {

--- a/apstra/query_engine_test.go
+++ b/apstra/query_engine_test.go
@@ -450,6 +450,36 @@ func TestQueryString(t *testing.T) {
 				Node(nil)).
 				Optional(new(RawQuery).SetQuery("node()")),
 		},
+		"minimal_having": {
+			e: "node().having(node())",
+			q: new(PathQuery).
+				Node(nil).
+				Having(QEHaving{
+					Query:   new(PathQuery).Node(nil),
+					AtLeast: -1,
+					AtMost:  -1,
+				}),
+		},
+		"having": {
+			e: "node().having(node(),at_least=0).having(node(),at_most=0).having(node(),at_least=1,at_most=1)",
+			q: new(PathQuery).
+				Node(nil).
+				Having(QEHaving{
+					Query:   new(PathQuery).Node(nil),
+					AtLeast: 0,
+					AtMost:  -1,
+				}).
+				Having(QEHaving{
+					Query:   new(PathQuery).Node(nil),
+					AtLeast: -1,
+					AtMost:  0,
+				}).
+				Having(QEHaving{
+					Query:   new(PathQuery).Node(nil),
+					AtLeast: 1,
+					AtMost:  1,
+				}),
+		},
 	}
 
 	for tName, tCase := range testCases {

--- a/apstra/query_engine_test.go
+++ b/apstra/query_engine_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// Copyright (c) Juniper Networks, Inc., 2022-2025.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
This PR introduces the `Having()` method for the `PathQuery` struct, which allows us to write queries which specify a count of partial path traversals.

For example, to find systems with at least one, but no more than five loopback interfaces, we might do use this graph query:

```
node(type='system', name='system-1-5-loopbacks')
  .having(
    node(name='system-1-5-loopbacks')
      .out(type='hosted_interfaces')
      .node(type='interface', if_type='loopback'),
    at_least=1,
    at_most=5
  )
```

Which can be written in Go like this:

```Go
new(PathQuery).
    Node([]QEEAttribute{
        NodeTypeSystem.QEEAttribute(),
        {Key: "name", Value: QEStringVal("system-1-5-loopbacks")},
    }).
     Having(QEHaving{
         Query: new(PathQuery).
               Node([]QEEAttribute{{Key: "name", Value: QEStringVal("system-1-5-loopbacks")}}).
               Out([]QEEAttribute{RelationshipTypeHostedInterfaces.QEEAttribute()}).
               Node([]QEEAttribute{
                    NodeTypeInterface.QEEAttribute(),
                    {Key: "if_type", Value: QEStringVal("loopback")},
               }),
         AtLeast: 1,
         AtMost:  5,
    }),
```