### PR TITLE
Add support for DCI group L3 policy

### DIFF
--- a/apstra/two_stage_l3_clos_evpn_interconnect_group.go
+++ b/apstra/two_stage_l3_clos_evpn_interconnect_group.go
@@ -27,10 +27,11 @@ type EvpnInterconnectGroup struct {
 
 func (o *EvpnInterconnectGroup) UnmarshalJSON(bytes []byte) error {
 	var raw struct {
-		Id          ObjectId `json:"id"`
-		Label       string   `json:"label"`
-		RouteTarget string   `json:"interconnect_route_target"`
-		EsiMac      *string  `json:"interconnect_esi_mac"`
+		Id                        ObjectId                                  `json:"id"`
+		Label                     string                                    `json:"label"`
+		RouteTarget               string                                    `json:"interconnect_route_target"`
+		EsiMac                    *string                                   `json:"interconnect_esi_mac"`
+		InterconnectSecurityZones map[ObjectId]InterconnectSecurityZoneData `json:"interconnect_security_zones"`
 	}
 
 	if err := json.Unmarshal(bytes, &raw); err != nil {
@@ -48,23 +49,32 @@ func (o *EvpnInterconnectGroup) UnmarshalJSON(bytes []byte) error {
 		}
 		o.Data.EsiMac = esiMac
 	}
+	o.Data.InterconnectSecurityZones = raw.InterconnectSecurityZones
 
 	return nil
+}
+
+type InterconnectSecurityZoneData struct {
+	RoutingPolicyId *ObjectId `json:"routing_policy_id"`
+	RouteTarget     *string   `json:"interconnect_route_target"`
+	L3Enabled       bool      `json:"enabled_for_l3"`
 }
 
 var _ json.Marshaler = (*EvpnInterconnectGroupData)(nil)
 
 type EvpnInterconnectGroupData struct {
-	Label       string
-	RouteTarget string
-	EsiMac      net.HardwareAddr
+	Label                     string
+	RouteTarget               string
+	EsiMac                    net.HardwareAddr
+	InterconnectSecurityZones map[ObjectId]InterconnectSecurityZoneData
 }
 
 func (o EvpnInterconnectGroupData) MarshalJSON() ([]byte, error) {
 	var raw struct {
-		Label       string `json:"label"`
-		RouteTarget string `json:"interconnect_route_target"`
-		EsiMac      string `json:"interconnect_esi_mac,omitempty"`
+		Label                     string                                    `json:"label"`
+		RouteTarget               string                                    `json:"interconnect_route_target"`
+		EsiMac                    string                                    `json:"interconnect_esi_mac,omitempty"`
+		InterconnectSecurityZones map[ObjectId]InterconnectSecurityZoneData `json:"interconnect_security_zones"`
 	}
 
 	raw.Label = o.Label
@@ -72,6 +82,7 @@ func (o EvpnInterconnectGroupData) MarshalJSON() ([]byte, error) {
 	if o.EsiMac != nil {
 		raw.EsiMac = o.EsiMac.String()
 	}
+	raw.InterconnectSecurityZones = o.InterconnectSecurityZones
 
 	return json.Marshal(raw)
 }

--- a/apstra/two_stage_l3_clos_evpn_interconnect_group_integration_test.go
+++ b/apstra/two_stage_l3_clos_evpn_interconnect_group_integration_test.go
@@ -18,11 +18,35 @@ import (
 )
 
 func TestEvpnInterconnectGroup(t *testing.T) {
+	securityZoneCount := 3
+	routingPolicyCount := 3
+
 	ctx := context.Background()
 
 	clients, err := getTestClients(ctx, t)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	// in order to "wipe out" the association between a security zone and a
+	// routing policy the map entry for that security zone must be present.
+	populateMissingSZIDs := func(data *EvpnInterconnectGroupData, ids []ObjectId) {
+		if data.InterconnectSecurityZones == nil {
+			data.InterconnectSecurityZones = make(map[ObjectId]InterconnectSecurityZoneData)
+		}
+		for _, id := range ids {
+			if _, ok := data.InterconnectSecurityZones[id]; ok {
+				continue
+			}
+
+			data.InterconnectSecurityZones[id] = InterconnectSecurityZoneData{}
+		}
+	}
+
+	compareSecurityZoneData := func(t *testing.T, a, b InterconnectSecurityZoneData) {
+		require.Equal(t, a.RoutingPolicyId, b.RoutingPolicyId)
+		require.Equal(t, a.RouteTarget, b.RouteTarget)
+		require.Equal(t, a.L3Enabled, b.L3Enabled)
 	}
 
 	compare := func(t *testing.T, a, b *EvpnInterconnectGroupData) {
@@ -39,6 +63,15 @@ func TestEvpnInterconnectGroup(t *testing.T) {
 		}
 
 		require.Equal(t, a.RouteTarget, b.RouteTarget)
+
+		require.Equal(t, len(a.InterconnectSecurityZones), len(b.InterconnectSecurityZones))
+		for k, va := range a.InterconnectSecurityZones {
+			vb, ok := b.InterconnectSecurityZones[k]
+			if !ok {
+				t.Fatalf("a has InterconnectSecurityZone %q, but b does not", k)
+			}
+			compareSecurityZoneData(t, va, vb)
+		}
 	}
 
 	for clientName, client := range clients {
@@ -54,6 +87,36 @@ func TestEvpnInterconnectGroup(t *testing.T) {
 			t.Logf("Setting blueprint ESI MAC MSB to %d", *fs.EsiMacMsb)
 			err = bpClient.SetFabricSettings(ctx, fs)
 			require.NoError(t, err)
+
+			securityZoneIDs := make([]ObjectId, securityZoneCount)
+			for i := range securityZoneIDs {
+				vrfName := randString(6, "hex")
+				id, err := bpClient.CreateSecurityZone(ctx, &SecurityZoneData{
+					Label:   vrfName,
+					SzType:  SecurityZoneTypeEVPN,
+					VrfName: vrfName,
+				})
+				require.NoError(t, err)
+				securityZoneIDs[i] = id
+			}
+
+			routingPolicyIDs := make([]ObjectId, routingPolicyCount)
+			importPolicies := []DcRoutingPolicyImportPolicy{
+				DcRoutingPolicyImportPolicyAll,
+				DcRoutingPolicyImportPolicyDefaultOnly,
+				DcRoutingPolicyImportPolicyExtraOnly,
+			}
+			for i := range routingPolicyIDs {
+				importPolicy := importPolicies[i%len(importPolicies)]
+				id, err := bpClient.CreateRoutingPolicy(ctx, &DcRoutingPolicyData{
+					Label:        randString(6, "hex"),
+					PolicyType:   DcRoutingPolicyTypeUser,
+					ImportPolicy: importPolicy,
+					ExportPolicy: DcRoutingExportPolicy{},
+				})
+				require.NoError(t, err)
+				routingPolicyIDs[i] = id
+			}
 
 			type testStep struct {
 				config EvpnInterconnectGroupData
@@ -77,6 +140,37 @@ func TestEvpnInterconnectGroup(t *testing.T) {
 								Label:       "a" + randString(6, "hex"),
 								RouteTarget: fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1),
 								EsiMac:      randomHardwareAddr([]byte{*fs.EsiMacMsb}, []byte{^*fs.EsiMacMsb}), // match policy MAC MSB
+								InterconnectSecurityZones: map[ObjectId]InterconnectSecurityZoneData{
+									securityZoneIDs[0]: {
+										RoutingPolicyId: &routingPolicyIDs[0],
+										RouteTarget:     toPtr(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
+										L3Enabled:       true,
+									},
+									securityZoneIDs[1]: {
+										RoutingPolicyId: &routingPolicyIDs[1],
+										RouteTarget:     toPtr(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
+										L3Enabled:       false,
+									},
+								},
+							},
+						},
+						{
+							config: EvpnInterconnectGroupData{
+								Label:       "a" + randString(6, "hex"),
+								RouteTarget: fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1),
+								EsiMac:      randomHardwareAddr([]byte{*fs.EsiMacMsb}, []byte{^*fs.EsiMacMsb}), // match policy MAC MSB
+								InterconnectSecurityZones: map[ObjectId]InterconnectSecurityZoneData{
+									securityZoneIDs[2]: {
+										RoutingPolicyId: &routingPolicyIDs[2],
+										RouteTarget:     toPtr(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
+										L3Enabled:       false,
+									},
+									securityZoneIDs[1]: {
+										RoutingPolicyId: &routingPolicyIDs[1],
+										RouteTarget:     toPtr(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
+										L3Enabled:       true,
+									},
+								},
 							},
 						},
 						{
@@ -94,6 +188,18 @@ func TestEvpnInterconnectGroup(t *testing.T) {
 								Label:       "a" + randString(6, "hex"),
 								RouteTarget: fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1),
 								EsiMac:      randomHardwareAddr([]byte{*fs.EsiMacMsb}, []byte{^*fs.EsiMacMsb}), // match policy MAC MSB
+								InterconnectSecurityZones: map[ObjectId]InterconnectSecurityZoneData{
+									securityZoneIDs[0]: {
+										RoutingPolicyId: &routingPolicyIDs[0],
+										RouteTarget:     toPtr(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
+										L3Enabled:       true,
+									},
+									securityZoneIDs[1]: {
+										RoutingPolicyId: &routingPolicyIDs[1],
+										RouteTarget:     toPtr(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
+										L3Enabled:       false,
+									},
+								},
 							},
 						},
 						{
@@ -107,6 +213,18 @@ func TestEvpnInterconnectGroup(t *testing.T) {
 								Label:       "a" + randString(6, "hex"),
 								RouteTarget: fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1),
 								EsiMac:      randomHardwareAddr([]byte{*fs.EsiMacMsb}, []byte{^*fs.EsiMacMsb}), // match policy MAC MSB
+								InterconnectSecurityZones: map[ObjectId]InterconnectSecurityZoneData{
+									securityZoneIDs[0]: {
+										RoutingPolicyId: &routingPolicyIDs[0],
+										RouteTarget:     toPtr(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
+										L3Enabled:       true,
+									},
+									securityZoneIDs[1]: {
+										RoutingPolicyId: &routingPolicyIDs[1],
+										RouteTarget:     toPtr(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
+										L3Enabled:       false,
+									},
+								},
 							},
 						},
 					},
@@ -124,13 +242,18 @@ func TestEvpnInterconnectGroup(t *testing.T) {
 					t.Cleanup(func() { wg.Done() })
 					t.Parallel()
 
+					// use the first config/step for initial creation
+					config := tCase.steps[0].config
+					populateMissingSZIDs(&config, securityZoneIDs)
+
 					require.Greater(t, len(tCase.steps), 0)
-					if tCase.steps[0].config.EsiMac == nil {
+					if config.EsiMac == nil {
 						t.Log("creating EVPN Interconnect Group with unspecified ESI MAC")
 					} else {
-						t.Logf("creating EVPN Interconnect Group with ESI MAC %s", tCase.steps[0].config.EsiMac)
+						t.Logf("creating EVPN Interconnect Group with ESI MAC %s", config.EsiMac)
 					}
-					id, err := bpClient.CreateEvpnInterconnectGroup(ctx, &tCase.steps[0].config)
+
+					id, err := bpClient.CreateEvpnInterconnectGroup(ctx, &config)
 					require.NoError(t, err)
 					idMutex.Lock()
 					createdIds = append(createdIds, id)
@@ -140,9 +263,10 @@ func TestEvpnInterconnectGroup(t *testing.T) {
 					require.NoError(t, err)
 					require.Equal(t, id, get.Id)
 					require.NotNil(t, get.Data)
-					compare(t, &tCase.steps[0].config, get.Data)
+					compare(t, &config, get.Data)
 
 					for i, step := range tCase.steps {
+						populateMissingSZIDs(&step.config, securityZoneIDs)
 						t.Logf("%s update step %d", tName, i)
 						if step.config.EsiMac == nil {
 							t.Log("updating EVPN Interconnect Group with unspecified ESI MAC")


### PR DESCRIPTION
This PR adds support for binding routing policies to VRFs within an Interconnect Domain.

It introduces a new `InterconnectSecurityZoneData` struct and adds a map of those to the existing `EvpnInterconnectGroup` struct. Also includes test code to exercise it.

Tested with:
- 4.2.0-236
- 4.2.1-207
- 4.2.1.1-10
- 4.2.2-2
- 5.0.0-63
- 5.0.1-1
- 5.1.0-117
- 6.0.0-189
