### PR TITLE
Apstra 6.0.0 compatibility

### DIFF
--- a/apstra/compatibility/compatibility.go
+++ b/apstra/compatibility/compatibility.go
@@ -16,6 +16,7 @@ const (
 	apstra500  = "5.0.0"
 	apstra501  = "5.0.1"
 	apstra510  = "5.1.0"
+	apstra600  = "6.0.0"
 )
 
 var (
@@ -35,5 +36,6 @@ func SupportedApiVersions() []string {
 		apstra500,
 		apstra501,
 		apstra510,
+		apstra600,
 	}
 }

--- a/apstra/talk_to_apstra.go
+++ b/apstra/talk_to_apstra.go
@@ -100,6 +100,8 @@ func convertTtaeToAceWherePossible(err error) error {
 				return ClientErr{errType: ErrNotfound, err: errors.New(ttae.Msg)}
 			case strings.Contains(ttae.Msg, "No virtual_network with id: "):
 				return ClientErr{errType: ErrNotfound, err: errors.New(ttae.Msg)}
+			case strings.Contains(ttae.Msg, "Virtual Network name ") && strings.Contains(ttae.Msg, "not unique"):
+				return ClientErr{errType: ErrExists, err: errors.New(ttae.Msg)}
 			case strings.Contains(ttae.Msg, "Virtual Network name not unique"):
 				return ClientErr{errType: ErrExists, err: errors.New(ttae.Msg)}
 			case strings.Contains(ttae.Msg, "Transformation cannot be changed"):


### PR DESCRIPTION
The only compatibility issue was in the text of an error. Apstra 6.0.0 returns the name of the VN when you attempt creation of a VN with a duplicate name.