### PR TITLE
Introduce blueprint tag CRUD methods

### DIFF
--- a/apstra/two_stage_l3_clos_tagging.go
+++ b/apstra/two_stage_l3_clos_tagging.go
@@ -1,0 +1,108 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package apstra
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const (
+	apiUrlBlueprintTagging = apiUrlBlueprintById + apiUrlPathDelim + "tagging"
+)
+
+func (o *TwoStageL3ClosClient) GetNodeTags(ctx context.Context, nodeId ObjectId) ([]string, error) {
+	query := new(PathQuery).
+		SetBlueprintType(BlueprintTypeStaging).
+		SetBlueprintId(o.blueprintId).
+		SetClient(o.client).
+		Node([]QEEAttribute{{"id", QEStringVal(nodeId.String())}}).
+		In([]QEEAttribute{RelationshipTypeTag.QEEAttribute()}).
+		Node([]QEEAttribute{
+			NodeTypeTag.QEEAttribute(),
+			{"name", QEStringVal("n_tag")},
+		})
+
+	var response struct {
+		Items []struct {
+			Tag struct {
+				Label string `json:"label"`
+			} `json:"n_tag"`
+		} `json:"items"`
+	}
+
+	err := query.Do(ctx, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(response.Items) == 0 {
+		// no tags found in the graph query. does the node even exist?
+		var trash struct{}
+		return nil, o.Client().GetNode(ctx, o.blueprintId, nodeId, &trash)
+	}
+
+	result := make([]string, len(response.Items))
+	for i, item := range response.Items {
+		result[i] = item.Tag.Label
+	}
+
+	return result, nil
+}
+
+func (o *TwoStageL3ClosClient) SetNodeTags(ctx context.Context, nodeId ObjectId, tags []string) error {
+	desiredTags := make(map[string]bool, len(tags))
+	for _, tag := range tags {
+		desiredTags[tag] = true
+	}
+
+	tags, err := o.GetNodeTags(ctx, nodeId)
+	if err != nil {
+		return err
+	}
+	currentTags := make(map[string]bool, len(tags))
+	for _, tag := range tags {
+		currentTags[tag] = true
+	}
+
+	var addTags, removeTags []string
+	for k := range desiredTags {
+		if currentTags[k] {
+			delete(currentTags, k)
+			delete(desiredTags, k)
+		}
+	}
+
+	if len(currentTags) == 0 && len(desiredTags) == 0 {
+		// nothing to add, nothing to remove - our job is done
+		return nil
+	}
+
+	for k := range desiredTags {
+		addTags = append(addTags, k)
+	}
+
+	for k := range currentTags {
+		removeTags = append(removeTags, k)
+	}
+
+	apiInput := struct {
+		Nodes  []string `json:"nodes"`
+		Add    []string `json:"add"`
+		Remove []string `json:"remove"`
+	}{
+		Nodes:  []string{nodeId.String()},
+		Add:    addTags,
+		Remove: removeTags,
+	}
+
+	err = o.client.talkToApstra(ctx, &talkToApstraIn{
+		method:   http.MethodPost,
+		urlStr:   fmt.Sprintf(apiUrlBlueprintTagging, o.blueprintId),
+		apiInput: &apiInput,
+	})
+	return convertTtaeToAceWherePossible(err)
+}

--- a/apstra/two_stage_l3_clos_tagging.go
+++ b/apstra/two_stage_l3_clos_tagging.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// Copyright (c) Juniper Networks, Inc., 2023-2025.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/apstra/two_stage_l3_clos_tagging_integration_test.go
+++ b/apstra/two_stage_l3_clos_tagging_integration_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package apstra
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNodeTagging(t *testing.T) {
+	ctx := context.Background()
+	clients, err := getTestClients(ctx, t)
+	require.NoError(t, err)
+
+	for clientName, client := range clients {
+		clientName, client := clientName, client
+		t.Run(fmt.Sprintf("%s_%s", client.client.apiVersion, clientName), func(t *testing.T) {
+			t.Parallel()
+
+			bpClient := testBlueprintD(ctx, t, client.client)
+
+			query := new(PathQuery).
+				SetBlueprintId(bpClient.blueprintId).
+				SetBlueprintType(BlueprintTypeStaging).
+				SetClient(bpClient.client).
+				Node([]QEEAttribute{
+					NodeTypeSystem.QEEAttribute(),
+					{"label", QEStringVal("spine1")},
+					{"name", QEStringVal("n_system")},
+				})
+
+			var queryResponse struct {
+				Items []struct {
+					System struct {
+						Id ObjectId `json:"id"`
+					} `json:"n_system"`
+				} `json:"items"`
+			}
+
+			require.NoError(t, query.Do(ctx, &queryResponse))
+			require.Equal(t, 1, len(queryResponse.Items))
+
+			spine1 := queryResponse.Items[0].System.Id
+
+			type testCase struct {
+				tags []string
+			}
+
+			testCases := []testCase{
+				{tags: []string{}},
+				{tags: []string{"a"}},
+				{tags: []string{"a", "b"}},
+				{tags: []string{"a"}},
+				{tags: []string{}},
+				{tags: []string{"c", "d"}},
+				{tags: []string{"c", "d"}},
+				{tags: []string{"a"}},
+			}
+
+			for i, tc := range testCases {
+				log.Printf("testing SetNodeTags() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+				require.NoError(t, bpClient.SetNodeTags(ctx, spine1, tc.tags))
+
+				log.Printf("testing GetNodeTags() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+				tags, err := bpClient.GetNodeTags(ctx, spine1)
+				require.NoError(t, err)
+
+				sort.Strings(tc.tags)
+				sort.Strings(tags)
+				compareSlices(t, tc.tags, tags, fmt.Sprintf("test case %d spine 1 tags expected vs. reality", i))
+			}
+		})
+	}
+}

--- a/apstra/two_stage_l3_clos_tagging_integration_test.go
+++ b/apstra/two_stage_l3_clos_tagging_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// Copyright (c) Juniper Networks, Inc., 2023-2025.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/apstra/two_stage_l3_clos_tags.go
+++ b/apstra/two_stage_l3_clos_tags.go
@@ -79,6 +79,24 @@ func (o TwoStageL3ClosClient) GetTag(ctx context.Context, id ObjectId) (TwoStage
 	return apiResponse, nil
 }
 
+func (o TwoStageL3ClosClient) GetTagByLabel(ctx context.Context, label string) (TwoStageL3ClosTag, error) {
+	tags, err := o.GetAllTags(ctx)
+	if err != nil {
+		return TwoStageL3ClosTag{}, fmt.Errorf("getting all tags: %w", err)
+	}
+
+	for _, tag := range tags {
+		if tag.Data.Label == label {
+			return tag, nil
+		}
+	}
+
+	return TwoStageL3ClosTag{}, ClientErr{
+		errType: ErrNotfound,
+		err:     fmt.Errorf("tag with label %q not found", label),
+	}
+}
+
 func (o TwoStageL3ClosClient) GetAllTags(ctx context.Context) (map[ObjectId]TwoStageL3ClosTag, error) {
 	var apiResponse struct {
 		Items []TwoStageL3ClosTag `json:"items"`

--- a/apstra/two_stage_l3_clos_tags.go
+++ b/apstra/two_stage_l3_clos_tags.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// Copyright (c) Juniper Networks, Inc., 2023-2025.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/apstra/two_stage_l3_clos_tags_integration_test.go
+++ b/apstra/two_stage_l3_clos_tags_integration_test.go
@@ -95,7 +95,7 @@ func TestCRUDTwoStageL3ClosTags(t *testing.T) {
 
 			for tName, tCase := range testCases {
 				t.Run(tName, func(t *testing.T) {
-					//t.Parallel(x) // do not parallelize - we count the total number of tags in here
+					// t.Parallel(x) // do not parallelize - we count the total number of tags in here
 
 					require.Greater(t, len(tCase.steps), 0) // we will blindly refer to steps[0] - it better exist
 

--- a/apstra/two_stage_l3_clos_tags_integration_test.go
+++ b/apstra/two_stage_l3_clos_tags_integration_test.go
@@ -9,74 +9,145 @@ package apstra
 import (
 	"context"
 	"fmt"
-	"log"
-	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestNodeTagging(t *testing.T) {
+func TestCRUDTwoStageL3ClosTags(t *testing.T) {
 	ctx := context.Background()
 	clients, err := getTestClients(ctx, t)
 	require.NoError(t, err)
 
+	extraTagCount := 3
+
+	compare := func(t *testing.T, a, b *TwoStageL3ClosTagData) {
+		t.Helper()
+
+		require.NotNil(t, a)
+		require.NotNil(t, b)
+		require.Equal(t, a.Label, b.Label)
+		require.Equal(t, a.Description, b.Description)
+	}
+
+	type testStep struct {
+		tagData TwoStageL3ClosTagData
+	}
+
+	type testCase struct {
+		steps []testStep
+	}
+
+	testCases := map[string]testCase{
+		"start_minimal": {
+			steps: []testStep{
+				{
+					tagData: TwoStageL3ClosTagData{
+						Label: "start_minimal",
+					},
+				},
+				{
+					tagData: TwoStageL3ClosTagData{
+						Label:       "start_minimal",
+						Description: randString(6, "hex"),
+					},
+				},
+				{
+					tagData: TwoStageL3ClosTagData{
+						Label: "start_minimal",
+					},
+				},
+			},
+		},
+		"start_maximal": {
+			steps: []testStep{
+				{
+					tagData: TwoStageL3ClosTagData{
+						Label:       "start_maximal",
+						Description: randString(6, "hex"),
+					},
+				},
+				{
+					tagData: TwoStageL3ClosTagData{
+						Label: "start_maximal",
+					},
+				},
+				{
+					tagData: TwoStageL3ClosTagData{
+						Label:       "start_maximal",
+						Description: randString(6, "hex"),
+					},
+				},
+			},
+		},
+	}
+
 	for clientName, client := range clients {
-		clientName, client := clientName, client
 		t.Run(fmt.Sprintf("%s_%s", client.client.apiVersion, clientName), func(t *testing.T) {
 			t.Parallel()
 
-			bpClient := testBlueprintD(ctx, t, client.client)
+			bp := testBlueprintA(ctx, t, client.client)
 
-			query := new(PathQuery).
-				SetBlueprintId(bpClient.blueprintId).
-				SetBlueprintType(BlueprintTypeStaging).
-				SetClient(bpClient.client).
-				Node([]QEEAttribute{
-					NodeTypeSystem.QEEAttribute(),
-					{"label", QEStringVal("spine1")},
-					{"name", QEStringVal("n_system")},
-				})
-
-			var queryResponse struct {
-				Items []struct {
-					System struct {
-						Id ObjectId `json:"id"`
-					} `json:"n_system"`
-				} `json:"items"`
-			}
-
-			require.NoError(t, query.Do(ctx, &queryResponse))
-			require.Equal(t, 1, len(queryResponse.Items))
-
-			spine1 := queryResponse.Items[0].System.Id
-
-			type testCase struct {
-				tags []string
-			}
-
-			testCases := []testCase{
-				{tags: []string{}},
-				{tags: []string{"a"}},
-				{tags: []string{"a", "b"}},
-				{tags: []string{"a"}},
-				{tags: []string{}},
-				{tags: []string{"c", "d"}},
-				{tags: []string{"c", "d"}},
-				{tags: []string{"a"}},
-			}
-
-			for i, tc := range testCases {
-				log.Printf("testing SetNodeTags() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-				require.NoError(t, bpClient.SetNodeTags(ctx, spine1, tc.tags))
-
-				log.Printf("testing GetNodeTags() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-				tags, err := bpClient.GetNodeTags(ctx, spine1)
+			for range extraTagCount {
+				_, err = bp.CreateTag(ctx, TwoStageL3ClosTagData{Label: randString(6, "hex")})
 				require.NoError(t, err)
+			}
 
-				sort.Strings(tc.tags)
-				sort.Strings(tags)
-				compareSlices(t, tc.tags, tags, fmt.Sprintf("test case %d spine 1 tags expected vs. reality", i))
+			for tName, tCase := range testCases {
+				t.Run(tName, func(t *testing.T) {
+					//t.Parallel(x) // do not parallelize - we count the total number of tags in here
+
+					require.Greater(t, len(tCase.steps), 0) // we will blindly refer to steps[0] - it better exist
+
+					id, err := bp.CreateTag(ctx, tCase.steps[0].tagData)
+					require.NoError(t, err)
+
+					tag, err := bp.GetTag(ctx, id)
+					require.NoError(t, err)
+					require.Equal(t, id, tag.Id)
+					compare(t, &tCase.steps[0].tagData, tag.Data)
+
+					tags, err := bp.GetAllTags(ctx)
+					require.NoError(t, err)
+					require.Equal(t, extraTagCount+1, len(tags))
+					require.Contains(t, tags, id)
+					compare(t, tags[id].Data, &tCase.steps[0].tagData)
+
+					for _, step := range tCase.steps {
+						err = bp.UpdateTag(ctx, id, step.tagData)
+						require.NoError(t, err)
+
+						tag, err := bp.GetTag(ctx, id)
+						require.NoError(t, err)
+						require.Equal(t, id, tag.Id)
+						compare(t, &step.tagData, tag.Data)
+
+						tags, err := bp.GetAllTags(ctx)
+						require.NoError(t, err)
+						require.Equal(t, extraTagCount+1, len(tags))
+						require.Contains(t, tags, id)
+						compare(t, tags[id].Data, &step.tagData)
+					}
+
+					err = bp.DeleteTag(ctx, id)
+					require.NoError(t, err)
+
+					tags, err = bp.GetAllTags(ctx)
+					require.NoError(t, err)
+					require.NotContains(t, tags, id)
+
+					var ace ClientErr
+
+					_, err = bp.GetTag(ctx, id)
+					require.Error(t, err)
+					require.ErrorAs(t, err, &ace)
+					require.Equal(t, ErrNotfound, ace.Type())
+
+					err = bp.DeleteTag(ctx, id)
+					require.Error(t, err)
+					require.ErrorAs(t, err, &ace)
+					require.Equal(t, ErrNotfound, ace.Type())
+				})
 			}
 		})
 	}

--- a/apstra/two_stage_l3_clos_tags_integration_test.go
+++ b/apstra/two_stage_l3_clos_tags_integration_test.go
@@ -108,6 +108,11 @@ func TestCRUDTwoStageL3ClosTags(t *testing.T) {
 					require.Equal(t, id, tag.Id)
 					compare(t, &tCase.steps[0].tagData, tag.Data)
 
+					tag, err = bp.GetTagByLabel(ctx, tCase.steps[0].tagData.Label)
+					require.NoError(t, err)
+					require.Equal(t, id, tag.Id)
+					compare(t, &tCase.steps[0].tagData, tag.Data)
+
 					tags, err := bp.GetAllTags(ctx)
 					require.NoError(t, err)
 					require.Equal(t, extraTagCount+1, len(tags))
@@ -120,6 +125,11 @@ func TestCRUDTwoStageL3ClosTags(t *testing.T) {
 						require.NoError(t, err)
 
 						tag, err := bp.GetTag(ctx, id)
+						require.NoError(t, err)
+						require.Equal(t, id, tag.Id)
+						compare(t, &step.tagData, tag.Data)
+
+						tag, err = bp.GetTagByLabel(ctx, step.tagData.Label)
 						require.NoError(t, err)
 						require.Equal(t, id, tag.Id)
 						compare(t, &step.tagData, tag.Data)
@@ -143,6 +153,12 @@ func TestCRUDTwoStageL3ClosTags(t *testing.T) {
 
 					// ensure 404
 					_, err = bp.GetTag(ctx, id)
+					require.Error(t, err)
+					require.ErrorAs(t, err, &ace)
+					require.Equal(t, ErrNotfound, ace.Type())
+
+					// ensure 404
+					_, err = bp.GetTagByLabel(ctx, tCase.steps[0].tagData.Label)
 					require.Error(t, err)
 					require.ErrorAs(t, err, &ace)
 					require.Equal(t, ErrNotfound, ace.Type())

--- a/apstra/two_stage_l3_clos_tags_integration_test.go
+++ b/apstra/two_stage_l3_clos_tags_integration_test.go
@@ -88,6 +88,7 @@ func TestCRUDTwoStageL3ClosTags(t *testing.T) {
 
 			bp := testBlueprintA(ctx, t, client.client)
 
+			// create extra tags so we can count them when doing GetAllTags()
 			for range extraTagCount {
 				_, err = bp.CreateTag(ctx, TwoStageL3ClosTagData{Label: randString(6, "hex")})
 				require.NoError(t, err)
@@ -113,6 +114,7 @@ func TestCRUDTwoStageL3ClosTags(t *testing.T) {
 					require.Contains(t, tags, id)
 					compare(t, tags[id].Data, &tCase.steps[0].tagData)
 
+					// update the tag with each step and re-check as above
 					for _, step := range tCase.steps {
 						err = bp.UpdateTag(ctx, id, step.tagData)
 						require.NoError(t, err)
@@ -132,17 +134,20 @@ func TestCRUDTwoStageL3ClosTags(t *testing.T) {
 					err = bp.DeleteTag(ctx, id)
 					require.NoError(t, err)
 
+					// make sure the tag is gone
 					tags, err = bp.GetAllTags(ctx)
 					require.NoError(t, err)
 					require.NotContains(t, tags, id)
 
 					var ace ClientErr
 
+					// ensure 404
 					_, err = bp.GetTag(ctx, id)
 					require.Error(t, err)
 					require.ErrorAs(t, err, &ace)
 					require.Equal(t, ErrNotfound, ace.Type())
 
+					// ensure 404
 					err = bp.DeleteTag(ctx, id)
 					require.Error(t, err)
 					require.ErrorAs(t, err, &ace)

--- a/apstra/two_stage_l3_clos_tags_integration_test.go
+++ b/apstra/two_stage_l3_clos_tags_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// Copyright (c) Juniper Networks, Inc., 2023-2025.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
This PR introduces structs and CRUD methods for tags within a blueprint (blueprint -> staged -> catalog -> tags)

Files `apstra/two_stage_l3_clos_tags.go` and `apstra/two_stage_l3_clos_tags_integration_test.go` already existed, but they contained node tagging code, rather than code for managing tags directly.

So those files have been renamed, but otherwise unchanged. The diff is ugly. It's probably reasonable to ignore the `*tagging*` files.

Renamed files:
- `apstra/two_stage_l3_clos_tags.go` -> `apstra/two_stage_l3_clos_tagging.go`
- `apstra/two_stage_l3_clos_tags_integration_test.go` -> `apstra/two_stage_l3_clos_tagging_integration_test.go`

Otherwise, this is a pretty straightforward PR.

Closes #534
