### PR TITLE
Ensure that test uses *datacenter* blueprints only

### DIFF
--- a/apstra/two_stage_l3_clos_system_node_info_integration_test.go
+++ b/apstra/two_stage_l3_clos_system_node_info_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// Copyright (c) Juniper Networks, Inc., 2023-2025.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
This PR fixes a bug in a test function.

The bug assumed that any pre-existing blueprint is a *datacenter* blueprint when running tests relevant to *datacenter* reference design.

This PR ensures that only *datacenter* blueprints are considered by the test.