### PR TITLE
Parse errors and return detailed error struct for `obj-policy-batch-apply` API

### DIFF
--- a/apstra/client.go
+++ b/apstra/client.go
@@ -48,6 +48,7 @@ const (
 	ErrIbaCurrentMountConflictsWithExistingMount
 	ErrInvalidId
 	ErrUnsafePatchProhibited
+	ErrCtAssignmentFailed
 
 	clientPollingIntervalMs = 1000
 
@@ -68,6 +69,11 @@ type ErrCtAssignedToLinkDetail struct {
 
 type ErrLagHasAssignedStructuresDetail struct {
 	GroupLabels []string
+}
+
+type ErrCtAssignmentFailedDetail struct {
+	InvalidApplicationPointIndexes []int
+	InvalidConnectivityTemplateIds []ObjectId
 }
 
 type ClientErr struct {

--- a/apstra/talk_to_apstra_error.go
+++ b/apstra/talk_to_apstra_error.go
@@ -1,0 +1,149 @@
+package apstra
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// TalkToApstraErr implements error{} and carries around http.Request and
+// http.Response object pointers. Error() method produces a string like
+// "<error> - http response <status> at url <url>".
+type TalkToApstraErr struct {
+	Request  *http.Request
+	Response *http.Response
+	Msg      string
+}
+
+func (o TalkToApstraErr) Error() string {
+	apstraUrl := "nil"
+	if o.Request != nil {
+		apstraUrl = o.Request.URL.String()
+	}
+
+	status := "nil"
+	if o.Response != nil {
+		status = o.Response.Status
+	}
+
+	return fmt.Sprintf("%s - http response '%s' at '%s'", o.Msg, status, apstraUrl)
+}
+
+func (o TalkToApstraErr) parseApiUrlBlueprintObjPolicyBatchApplyError() error {
+	body, err := io.ReadAll(o.Response.Body)
+	if err != nil {
+		return fmt.Errorf("reading error response body: %w", err)
+	}
+
+	var raw struct {
+		ApplicationPoints map[string]struct {
+			Policies map[string]json.RawMessage `json:"policies"` // these might be strings or a structs
+		} `json:"application_points"`
+	}
+
+	if json.Unmarshal(body, &raw) != nil {
+		return fmt.Errorf("parsing obj-policy-batch-apply error: %w", o)
+	}
+
+	var detail ErrCtAssignmentFailedDetail // we return this
+
+	var rawPolicyMsg struct { // we unpack each policy element here
+		Policy string `json:"policy"`
+	}
+
+	policyIdRegexp := regexp.MustCompile("^Endpoint policy with node id (.*) does not exist$")
+
+	invalidApplicationPointIndexes := make(map[int]struct{})
+
+	for apKey, ap := range raw.ApplicationPoints {
+		apIdx, err := strconv.Atoi(apKey)
+		if err != nil {
+			return fmt.Errorf("parsing obj-policy-batch-apply application point map index %q: %w': parsing obj-policy-batch-apply error: %w", apKey, err, o)
+		}
+
+		for pKey, p := range ap.Policies {
+			err = json.Unmarshal(p, &rawPolicyMsg)
+			if err != nil {
+				err = json.Unmarshal(p, &rawPolicyMsg.Policy)
+				if err != nil {
+					return fmt.Errorf("cannot parse error at application point %q, policy %q: %w", apKey, pKey, o) // don't wrap either err here
+				}
+			}
+
+			policyIdSubMatches := policyIdRegexp.FindStringSubmatch(rawPolicyMsg.Policy)
+
+			switch {
+			case len(policyIdSubMatches) == 2:
+				detail.InvalidConnectivityTemplateIds = append(detail.InvalidConnectivityTemplateIds, ObjectId(policyIdSubMatches[1]))
+			case rawPolicyMsg.Policy == "Not a valid application point":
+				invalidApplicationPointIndexes[apIdx] = struct{}{}
+			default:
+				return fmt.Errorf("cannot parse error at application point %q, policy %q: %w", apKey, pKey, o)
+			}
+		}
+
+		for invalidApplicationPointIdx := range invalidApplicationPointIndexes {
+			detail.InvalidApplicationPointIndexes = append(detail.InvalidApplicationPointIndexes, invalidApplicationPointIdx)
+		}
+	}
+
+	return ClientErr{
+		errType:   ErrCtAssignmentFailed,
+		err:       fmt.Errorf("assigning connectivity templates: %s", o),
+		detail:    &detail,
+		retryable: false,
+	}
+}
+
+// newTalkToApstraErr returns a TalkToApstraErr. It's intended to be called after the
+// http.Request has been executed with Do(), so the request body has already
+// been "spent" by Read(). We'll fill it back in. The response body is likely to
+// be closed by a 'defer body.Close()' somewhere, so we'll replace that as well,
+// up to some reasonable limit (don't try to buffer gigabytes of data from the
+// webserver).
+func newTalkToApstraErr(req *http.Request, reqBody []byte, resp *http.Response, errMsg string) TalkToApstraErr {
+	// don't include secret in error
+	req.Header.Del(apstraAuthHeader)
+
+	// redact request body for sensitive URLs
+	switch req.URL.Path {
+	case apiUrlUserLogin:
+		req.Body = io.NopCloser(strings.NewReader(fmt.Sprintf("request body for '%s' redacted", req.URL.Path)))
+	default:
+		rehydratedRequest := bytes.NewBuffer(reqBody)
+		req.Body = io.NopCloser(rehydratedRequest)
+	}
+
+	// redact response body for sensitive URLs
+	switch req.URL.Path {
+	case apiUrlUserLogin:
+		_ = resp.Body.Close() // close the real network socket
+		resp.Body = io.NopCloser(strings.NewReader(fmt.Sprintf("resposne body for '%s' redacted", req.URL.Path)))
+	default:
+		// prepare a stunt double response body for the one that's likely attached to a network
+		// socket, and likely to be closed by a `defer` somewhere
+		rehydratedResponse := &bytes.Buffer{}
+		_, _ = io.CopyN(rehydratedResponse, resp.Body, errResponseBodyLimit) // size limit
+		resp.Body = io.NopCloser(rehydratedResponse)                         // replace the original body
+	}
+
+	// use first part of response body if errMsg empty
+	if errMsg == "" {
+		peekAbleBodyReader := bufio.NewReader(resp.Body)
+		resp.Body = io.NopCloser(peekAbleBodyReader)
+		peek, _ := peekAbleBodyReader.Peek(errResponseStringLimit)
+		errMsg = string(peek)
+	}
+
+	return TalkToApstraErr{
+		Request:  req,
+		Response: resp,
+		Msg:      errMsg,
+	}
+}

--- a/apstra/talk_to_apstra_error.go
+++ b/apstra/talk_to_apstra_error.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra
 
 import (

--- a/apstra/two_stage_l3_clos_connectivity_template_assignment.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_assignment.go
@@ -10,19 +10,24 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
+	"strings"
 
 	oenum "github.com/orsinium-labs/enum"
 )
 
 const (
-	apiUrlBlueprintObjPolicyBatchApply        = apiUrlBlueprintById + apiUrlPathDelim + "obj-policy-batch-apply"
+	apiUrlBlueprintObjPolicyBatchApply = apiUrlBlueprintById + apiUrlPathDelim + "obj-policy-batch-apply"
+
 	apiUrlBlueprintObjPolicyApplicationPoints = apiUrlBlueprintById + apiUrlPathDelim + "obj-policy-application-points"
 
 	objPolicyApplicationPageSizeValue = 1000
 	objPolicyApplicationPageSizeParam = "max_count"
 	objPolicyApplicationPageSkipParam = "offset_max_count"
 )
+
+var apiUrlBlueprintObjPolicyBatchApplyRegex = regexp.MustCompile("^" + strings.Replace(apiUrlBlueprintObjPolicyBatchApply, "%s", "[^/]+", -1) + "$")
 
 // GetAllInterfacesConnectivityTemplates returns a map of ConnectivityTemplate
 // IDs keyed by Interface (switch port) ID.

--- a/apstra/two_stage_l3_clos_connectivity_template_assignment.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_assignment.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// Copyright (c) Juniper Networks, Inc., 2023-2025.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/apstra/two_stage_l3_clos_connectivity_template_assignment_integration_test.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_assignment_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// Copyright (c) Juniper Networks, Inc., 2023-2025.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -523,5 +523,4 @@ func TestSetDelApplicationPointConnectivityTemplates_Errors(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/apstra/two_stage_l3_clos_connectivity_template_assignment_integration_test.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_assignment_integration_test.go
@@ -8,10 +8,12 @@ package apstra
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	"github.com/stretchr/testify/require"
 )
 
 func compareConnectivityTemplateAssignments(a, b map[ObjectId]bool, applicationPointId ObjectId, t *testing.T) {
@@ -284,4 +286,242 @@ func TestAssignClearCtToInterface(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSetDelApplicationPointConnectivityTemplates_Errors(t *testing.T) {
+	ctx := context.Background()
+
+	ctCount := 5
+
+	type testCase struct {
+		apIdx  int   // index of application point ID in our slice of AP IDs. Negative value indicates "use a bogus AP ID"
+		ctIdxs []int // index of connectivity template ID in our slice of CT IDs. Negative value indicates "use a bogus CT ID"
+	}
+
+	testCases := map[string]testCase{
+		"not_bogus_one_CT": {
+			apIdx:  0,
+			ctIdxs: []int{0},
+		},
+		"not_bogus_two_CTs": {
+			apIdx:  0,
+			ctIdxs: []int{0, 1},
+		},
+		"bogus_AP_one_CT": {
+			apIdx:  -1,
+			ctIdxs: []int{0},
+		},
+		"bogus_AP_two_CTs": {
+			apIdx:  -1,
+			ctIdxs: []int{0, 2},
+		},
+		"good_AP_one_bogus_CT": {
+			apIdx:  0,
+			ctIdxs: []int{-1},
+		},
+		"good_AP_two_bogus_CTs": {
+			apIdx:  0,
+			ctIdxs: []int{-1, -1},
+		},
+		"good_AP_blended_CTs_a": {
+			apIdx:  0,
+			ctIdxs: []int{0, -1, 1},
+		},
+		"good_AP_blended_CTs_b": {
+			apIdx:  0,
+			ctIdxs: []int{-1, 0, -1},
+		},
+		"good_AP_blended_CTs_c": {
+			apIdx:  0,
+			ctIdxs: []int{0, -1, -1, 1},
+		},
+		"good_AP_blended_CTs_d": {
+			apIdx:  0,
+			ctIdxs: []int{-1, 0, 1, -1},
+		},
+		"good_AP_blended_CTs_e": {
+			apIdx:  0,
+			ctIdxs: []int{0, -1, 1, -1},
+		},
+		"good_AP_blended_CTs_f": {
+			apIdx:  0,
+			ctIdxs: []int{-1, 0, -1, 1},
+		},
+	}
+
+	clients, err := getTestClients(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for clientName, client := range clients {
+		t.Run(client.name(), func(t *testing.T) {
+			t.Parallel()
+
+			bpClient := testBlueprintC(ctx, t, client.client)
+
+			leafIds, err := getSystemIdsByRole(ctx, bpClient, "leaf")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// create assignments for the leaf switch nodes
+			assignments := make(SystemIdToInterfaceMapAssignment, len(leafIds))
+			bindings := make([]VnBinding, len(leafIds))
+			for i, leafId := range leafIds {
+				assignments[leafId.String()] = "Juniper_vQFX__AOS-7x10-Leaf"
+				bindings[i] = VnBinding{SystemId: leafId}
+			}
+
+			log.Printf("testing SetInterfaceMapAssignments() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+			err = bpClient.SetInterfaceMapAssignments(ctx, assignments)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			zones, err := bpClient.GetAllSecurityZones(ctx)
+			require.NoError(t, err)
+			require.Equal(t, 1, len(zones))
+
+			cts := make([]*ConnectivityTemplate, ctCount)
+			ctIds := make([]ObjectId, ctCount)
+			ctLabel := randString(5, "hex")
+			for i := range ctCount {
+				cts[i] = &ConnectivityTemplate{
+					Label: ctLabel + fmt.Sprintf("-%d", i),
+					Subpolicies: []*ConnectivityTemplatePrimitive{
+						{
+							Attributes: &ConnectivityTemplatePrimitiveAttributesAttachLogicalLink{
+								SecurityZone:       &zones[0].Id,
+								Tagged:             true,
+								Vlan:               toPtr(Vlan(i + 101)),
+								IPv4AddressingType: CtPrimitiveIPv4AddressingTypeNumbered,
+							},
+						},
+					},
+				}
+
+				require.NoError(t, cts[i].SetIds())
+				require.NoError(t, cts[i].SetUserData())
+				require.NoError(t, bpClient.CreateConnectivityTemplate(ctx, cts[i]))
+				ctIds[i] = *cts[i].Id
+			}
+
+			// Graph query which picks out generic-facing interfaces on leaf switches
+			query := new(PathQuery).
+				SetBlueprintType(BlueprintTypeStaging).
+				SetBlueprintId(bpClient.blueprintId).
+				SetClient(bpClient.client).
+				// Node([]QEEAttribute{{"id", QEStringVal(leaf1Id.String())}}).
+				Node([]QEEAttribute{
+					NodeTypeSystem.QEEAttribute(),
+					{"role", QEStringVal("leaf")},
+				}).
+				Out([]QEEAttribute{RelationshipTypeHostedInterfaces.QEEAttribute()}).
+				Node([]QEEAttribute{
+					NodeTypeInterface.QEEAttribute(),
+					{"name", QEStringVal("switch_port")},
+				}).
+				Out([]QEEAttribute{RelationshipTypeLink.QEEAttribute()}).
+				Node([]QEEAttribute{NodeTypeLink.QEEAttribute()}).
+				In([]QEEAttribute{RelationshipTypeLink.QEEAttribute()}).
+				Node([]QEEAttribute{NodeTypeInterface.QEEAttribute()}).
+				In([]QEEAttribute{RelationshipTypeHostedInterfaces.QEEAttribute()}).
+				Node([]QEEAttribute{
+					NodeTypeSystem.QEEAttribute(),
+					{"role", QEStringVal("generic")},
+				})
+
+			var queryResponse struct {
+				Items []struct {
+					Interface struct {
+						Id ObjectId `json:"id"`
+					} `json:"switch_port"`
+				} `json:"items"`
+			}
+
+			err = query.Do(ctx, &queryResponse)
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, len(queryResponse.Items), 2)
+
+			// collect the server-facing interfaces of leaf switches
+			leafInterfaceIds := make([]ObjectId, len(queryResponse.Items))
+			for i, item := range queryResponse.Items {
+				leafInterfaceIds[i] = item.Interface.Id
+			}
+
+			for tName, tCase := range testCases {
+				t.Run(tName, func(t *testing.T) {
+					// t.Parallel() -- do not use -- all tests use the same interfaces
+
+					var testApId ObjectId
+					var errorExpected bool
+					if tCase.apIdx >= 0 {
+						testApId = leafInterfaceIds[tCase.apIdx]
+					} else {
+						testApId = ObjectId(randString(6, "hex"))
+						errorExpected = true
+					}
+
+					testCtIds := make([]ObjectId, len(tCase.ctIdxs))
+					for i, idx := range tCase.ctIdxs {
+						if idx >= 0 {
+							testCtIds[i] = ctIds[idx]
+						} else {
+							testCtIds[i] = ObjectId(randString(6, "hex"))
+							errorExpected = true
+						}
+					}
+
+					log.Printf("testing SetApplicationPointConnectivityTemplates() error handling against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+					setErr := bpClient.SetApplicationPointConnectivityTemplates(ctx, testApId, testCtIds)
+					if !errorExpected {
+						require.NoError(t, setErr)
+					}
+
+					log.Printf("testing DelApplicationPointConnectivityTemplates() error handling against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+					delErr := bpClient.DelApplicationPointConnectivityTemplates(ctx, testApId, testCtIds)
+					if !errorExpected {
+						require.NoError(t, delErr)
+						return
+					}
+
+					// if we got here, there should be errors to inspect
+					for _, err := range []error{setErr, delErr} {
+						require.Error(t, err)
+
+						var ace ClientErr
+						require.ErrorAs(t, setErr, &ace)
+						require.Equal(t, ErrCtAssignmentFailed, ace.Type())
+						detail := ace.detail.(*ErrCtAssignmentFailedDetail)
+
+						// collect the bad data we used
+						var bogusApIdxs []int
+						var bogusCtIds []ObjectId
+						if tCase.apIdx < 0 {
+							bogusApIdxs = []int{0} // there's only one AP ID in this test
+						}
+						for i, idx := range tCase.ctIdxs {
+							if idx < 0 {
+								bogusCtIds = append(bogusCtIds, testCtIds[i])
+							}
+						}
+
+						require.Equal(t, len(bogusCtIds), len(detail.InvalidConnectivityTemplateIds))
+						for _, bogusCtId := range bogusCtIds {
+							require.Contains(t, detail.InvalidConnectivityTemplateIds, bogusCtId)
+						}
+
+						if len(bogusApIdxs) > 0 && len(bogusCtIds) == 0 { // bogus CT IDs take precedence over bogus AP IDs
+							require.Equal(t, len(bogusApIdxs), len(detail.InvalidApplicationPointIndexes))
+							for _, bogusApId := range bogusApIdxs {
+								require.Contains(t, detail.InvalidApplicationPointIndexes, bogusApId)
+							}
+						}
+					}
+				})
+			}
+		})
+	}
+
 }


### PR DESCRIPTION
This PR introduces error handling for the `/api/blueprints/%s/obj-policy-batch-apply` API endpoint.

A new error type `ErrCtAssignmentFailed` and struct `ErrCtAssignmentFailedDetail` are introduced, along with error parsing downstream of the `convertTtaeToAceWherePossible()` function.

Includes tests.

Tested with Apstra 5.1.0 (so far)