### PR TITLE
Bump to Go 1.25.0

### DIFF
--- a/.github/workflows/go_tools.yml
+++ b/.github/workflows/go_tools.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: '1.24.3'
+          go-version: '1.25.0'
 
       - name: go generate
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Juniper/apstra-go-sdk
 
-go 1.24.3
+go 1.25.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.17.8


### PR DESCRIPTION
Go 1.25.0 includes the `synctest` package will be useful for manipulating the passage of time during tests.

I want to use it for testing some of our `sync.Mutex` functions without actually having to invoke `time.Sleep()`.