### PR TITLE
Introduce test objects package

### DIFF
--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -353,6 +353,7 @@ func TestImmediateTickerSecondTick(t *testing.T) {
 	log.Printf("start %s first tick %s second tick %s", start, firstTick, secondTick)
 }
 
+// Deprecated: Use testutils.TestBlueprintA
 func testBlueprintA(ctx context.Context, t *testing.T, client *Client) *TwoStageL3ClosClient {
 	t.Helper()
 
@@ -371,6 +372,7 @@ func testBlueprintA(ctx context.Context, t *testing.T, client *Client) *TwoStage
 	return bpClient
 }
 
+// Deprecated: Use testutils.TestBlueprintB
 func testBlueprintB(ctx context.Context, t *testing.T, client *Client) *TwoStageL3ClosClient {
 	t.Helper()
 
@@ -389,6 +391,7 @@ func testBlueprintB(ctx context.Context, t *testing.T, client *Client) *TwoStage
 	return bpClient
 }
 
+// Deprecated: Use testutils.TestBlueprintC
 func testBlueprintC(ctx context.Context, t testing.TB, client *Client) *TwoStageL3ClosClient {
 	t.Helper()
 
@@ -406,6 +409,7 @@ func testBlueprintC(ctx context.Context, t testing.TB, client *Client) *TwoStage
 	return bpClient
 }
 
+// Deprecated: Use testutils.TestBlueprintD
 func testBlueprintD(ctx context.Context, t *testing.T, client *Client) *TwoStageL3ClosClient {
 	t.Helper()
 
@@ -451,6 +455,7 @@ func testBlueprintD(ctx context.Context, t *testing.T, client *Client) *TwoStage
 	return bpClient
 }
 
+// Deprecated: Use testutils.TestBlueprintE
 func testBlueprintE(ctx context.Context, t *testing.T, client *Client) *TwoStageL3ClosClient {
 	bpId, err := client.CreateBlueprintFromTemplate(ctx, &CreateBlueprintFromTemplateRequest{
 		RefDesign:  enum.RefDesignDatacenter,
@@ -526,6 +531,7 @@ func testBlueprintE(ctx context.Context, t *testing.T, client *Client) *TwoStage
 
 // testBlueprintH creates a test blueprint using client and returns a *TwoStageL3ClosClient.
 // The blueprint will use a dual-stack fabric and have ipv6 enabled.
+// Deprecated: Use testutils.TestBlueprintH
 func testBlueprintH(ctx context.Context, t *testing.T, client *Client) *TwoStageL3ClosClient {
 	t.Helper()
 
@@ -570,6 +576,7 @@ func testBlueprintH(ctx context.Context, t *testing.T, client *Client) *TwoStage
 }
 
 // testBlueprintI returns a collapsed fabric which has been committed and has no build errors
+// Deprecated: Use testutils.TestBlueprintI
 func testBlueprintI(ctx context.Context, t *testing.T, client *Client) *TwoStageL3ClosClient {
 	t.Helper()
 
@@ -708,6 +715,7 @@ func TestItemInSlice(t *testing.T) {
 	}
 }
 
+// Deprecated: Use testutils.TestRackA
 func testRackA(ctx context.Context, t *testing.T, client *Client) (ObjectId, func(context.Context) error) {
 	deleteFunc := func(context.Context) error { return nil }
 	request := RackTypeRequest{
@@ -734,6 +742,7 @@ func testRackA(ctx context.Context, t *testing.T, client *Client) (ObjectId, fun
 	return id, deleteFunc
 }
 
+// Deprecated: Use testutils.TestTemplateA
 func testTemplateA(ctx context.Context, t *testing.T, client *Client) (ObjectId, func(context.Context) error) {
 	deleteFunc := func(context.Context) error { return nil }
 	rackId, rackDeleteFunc := testRackA(ctx, t, client)
@@ -773,6 +782,7 @@ func testTemplateA(ctx context.Context, t *testing.T, client *Client) (ObjectId,
 	return id, deleteFunc
 }
 
+// Deprecated: Use testutils.TestBlueprintF
 func testBlueprintF(ctx context.Context, t *testing.T, client *Client) (*TwoStageL3ClosClient, func(context.Context) error) {
 	deleteFunc := func(context.Context) error { return nil }
 	templateId, templateDeleteFunc := testTemplateA(ctx, t, client)
@@ -800,6 +810,7 @@ func testBlueprintF(ctx context.Context, t *testing.T, client *Client) (*TwoStag
 	return bpClient, deleteFunc
 }
 
+// Deprecated: Use testutils.TestBlueprintG
 func testBlueprintG(ctx context.Context, t *testing.T, client *Client) *TwoStageL3ClosClient {
 	t.Helper()
 
@@ -911,6 +922,7 @@ func compareDashboards(d1, d2 IbaDashboardData) bool {
 	return true
 }
 
+// Deprecated: Use testutils.TestTemplateB
 func testTemplateB(ctx context.Context, t *testing.T, client *Client) ObjectId {
 	t.Helper()
 
@@ -944,6 +956,7 @@ func testTemplateB(ctx context.Context, t *testing.T, client *Client) ObjectId {
 	return id
 }
 
+// Deprecated: Use testutils.TestSecurityZoneA
 func testSecurityZone(t testing.TB, ctx context.Context, bp *TwoStageL3ClosClient) ObjectId {
 	t.Helper()
 
@@ -965,6 +978,7 @@ func testSecurityZone(t testing.TB, ctx context.Context, bp *TwoStageL3ClosClien
 	return id
 }
 
+// Deprecated: Use testutils.TestVirtualNetworkA
 func testVirtualNetwork(t testing.TB, ctx context.Context, bp *TwoStageL3ClosClient, szId ObjectId) ObjectId {
 	t.Helper()
 

--- a/internal/test_utils/datacenter_test_objects/blueprints.go
+++ b/internal/test_utils/datacenter_test_objects/blueprints.go
@@ -1,0 +1,340 @@
+// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package dctestobj
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	testutils "github.com/Juniper/apstra-go-sdk/internal/test_utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlueprintA(t testing.TB, ctx context.Context, client *apstra.Client) *apstra.TwoStageL3ClosClient {
+	t.Helper()
+
+	bpId, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
+		RefDesign:  enum.RefDesignDatacenter,
+		Label:      testutils.RandString(5, "hex"),
+		TemplateId: "L3_Collapsed_ESI",
+	})
+	require.NoError(t, err)
+
+	bpClient, err := client.NewTwoStageL3ClosClient(ctx, bpId)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { require.NoError(t, client.DeleteBlueprint(ctx, bpId)) })
+
+	return bpClient
+}
+
+func TestBlueprintB(t testing.TB, ctx context.Context, client *apstra.Client) *apstra.TwoStageL3ClosClient {
+	t.Helper()
+
+	bpId, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
+		RefDesign:  enum.RefDesignDatacenter,
+		Label:      testutils.RandString(5, "hex"),
+		TemplateId: "L2_Virtual",
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() { require.NoError(t, client.DeleteBlueprint(ctx, bpId)) })
+
+	bpClient, err := client.NewTwoStageL3ClosClient(ctx, bpId)
+	require.NoError(t, err)
+
+	return bpClient
+}
+
+func TestBlueprintC(t testing.TB, ctx context.Context, client *apstra.Client) *apstra.TwoStageL3ClosClient {
+	t.Helper()
+
+	bpId, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
+		RefDesign:  enum.RefDesignDatacenter,
+		Label:      testutils.RandString(5, "hex"),
+		TemplateId: "L2_Virtual_EVPN",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.DeleteBlueprint(ctx, bpId)) })
+
+	bpClient, err := client.NewTwoStageL3ClosClient(ctx, bpId)
+	require.NoError(t, err)
+
+	return bpClient
+}
+
+func TestBlueprintD(t testing.TB, ctx context.Context, client *apstra.Client) *apstra.TwoStageL3ClosClient {
+	t.Helper()
+
+	bpId, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
+		RefDesign:  enum.RefDesignDatacenter,
+		Label:      testutils.RandString(5, "hex"),
+		TemplateId: "L2_Virtual_ESI_2x_Links",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, client.DeleteBlueprint(ctx, bpId))
+	})
+
+	bpClient, err := client.NewTwoStageL3ClosClient(ctx, bpId)
+	require.NoError(t, err)
+
+	query := new(apstra.PathQuery).
+		SetBlueprintId(bpId).
+		SetBlueprintType(apstra.BlueprintTypeStaging).
+		SetClient(client).
+		Node([]apstra.QEEAttribute{
+			apstra.NodeTypeSystem.QEEAttribute(),
+			{"system_type", apstra.QEStringVal("switch")},
+			{"role", apstra.QEStringVal("leaf")},
+			{"name", apstra.QEStringVal("n_leaf")},
+		})
+	var response struct {
+		Items []struct {
+			Leaf struct {
+				ID string `json:"id"`
+			} `json:"n_leaf"`
+		} `json:"items"`
+	}
+	require.NoError(t, query.Do(ctx, &response))
+
+	assignments := make(apstra.SystemIdToInterfaceMapAssignment)
+	for _, item := range response.Items {
+		assignments[item.Leaf.ID] = "Juniper_vQFX__AOS-7x10-Leaf"
+	}
+
+	require.NoError(t, bpClient.SetInterfaceMapAssignments(ctx, assignments))
+
+	return bpClient
+}
+
+func TestBlueprintE(t testing.TB, ctx context.Context, client *apstra.Client) *apstra.TwoStageL3ClosClient {
+	bpId, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
+		RefDesign:  enum.RefDesignDatacenter,
+		Label:      testutils.RandString(5, "hex"),
+		TemplateId: "L2_ESI_Access",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.DeleteBlueprint(ctx, bpId)) })
+
+	bpClient, err := client.NewTwoStageL3ClosClient(ctx, bpId)
+	require.NoError(t, err)
+
+	leafQuery := new(apstra.PathQuery).
+		SetBlueprintId(bpId).
+		SetBlueprintType(apstra.BlueprintTypeStaging).
+		SetClient(client).
+		Node([]apstra.QEEAttribute{
+			apstra.NodeTypeSystem.QEEAttribute(),
+			{"system_type", apstra.QEStringVal("switch")},
+			{"role", apstra.QEStringVal("leaf")},
+			{"name", apstra.QEStringVal("n_leaf")},
+		})
+	var leafResponse struct {
+		Items []struct {
+			Leaf struct {
+				ID string `json:"id"`
+			} `json:"n_leaf"`
+		} `json:"items"`
+	}
+	err = leafQuery.Do(ctx, &leafResponse)
+	require.NoError(t, err)
+
+	leafAssignements := make(apstra.SystemIdToInterfaceMapAssignment)
+	for _, item := range leafResponse.Items {
+		leafAssignements[item.Leaf.ID] = "Juniper_vQFX__AOS-7x10-Leaf"
+	}
+	err = bpClient.SetInterfaceMapAssignments(ctx, leafAssignements)
+	require.NoError(t, err)
+
+	accessQuery := new(apstra.PathQuery).
+		SetBlueprintId(bpId).
+		SetBlueprintType(apstra.BlueprintTypeStaging).
+		SetClient(client).
+		Node([]apstra.QEEAttribute{
+			apstra.NodeTypeSystem.QEEAttribute(),
+			{"system_type", apstra.QEStringVal("switch")},
+			{"role", apstra.QEStringVal("access")},
+			{"name", apstra.QEStringVal("n_access")},
+		})
+	var accessResponse struct {
+		Items []struct {
+			Leaf struct {
+				ID string `json:"id"`
+			} `json:"n_access"`
+		} `json:"items"`
+	}
+	require.NoError(t, accessQuery.Do(ctx, &accessResponse))
+
+	accessAssignements := make(apstra.SystemIdToInterfaceMapAssignment)
+	for _, item := range accessResponse.Items {
+		accessAssignements[item.Leaf.ID] = "Juniper_vQFX__AOS-8x10-1"
+	}
+	require.NoError(t, bpClient.SetInterfaceMapAssignments(ctx, accessAssignements))
+
+	return bpClient
+}
+
+func TestBlueprintF(t testing.TB, ctx context.Context, client *apstra.Client) *apstra.TwoStageL3ClosClient {
+	templateId := TestTemplateA(t, ctx, client)
+
+	bpId, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
+		RefDesign:  enum.RefDesignDatacenter,
+		Label:      testutils.RandString(5, "hex"),
+		TemplateId: templateId,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.DeleteBlueprint(ctx, bpId)) })
+
+	bpClient, err := client.NewTwoStageL3ClosClient(ctx, bpId)
+	require.NoError(t, err)
+
+	return bpClient
+}
+
+func TestBlueprintG(t testing.TB, ctx context.Context, client *apstra.Client) *apstra.TwoStageL3ClosClient {
+	t.Helper()
+
+	templateId := TestTemplateB(t, ctx, client)
+
+	bpId, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
+		RefDesign:  enum.RefDesignDatacenter,
+		Label:      testutils.RandString(5, "hex"),
+		TemplateId: templateId,
+		FabricSettings: &apstra.FabricSettings{
+			SpineSuperspineLinks: testutils.ToPtr(apstra.AddressingSchemeIp46),
+			SpineLeafLinks:       testutils.ToPtr(apstra.AddressingSchemeIp46),
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.DeleteBlueprint(ctx, bpId)) })
+
+	bpClient, err := client.NewTwoStageL3ClosClient(ctx, bpId)
+	require.NoError(t, err)
+
+	require.NoError(t, bpClient.SetFabricSettings(ctx, &apstra.FabricSettings{Ipv6Enabled: testutils.ToPtr(true)}))
+
+	return bpClient
+}
+
+// TestBlueprintH creates a test blueprint using client and returns a *TwoStageL3ClosClient.
+// The blueprint will use a dual-stack fabric and have ipv6 enabled.
+func TestBlueprintH(t testing.TB, ctx context.Context, client *apstra.Client) *apstra.TwoStageL3ClosClient {
+	t.Helper()
+
+	bpRequest := apstra.CreateBlueprintFromTemplateRequest{
+		RefDesign:  enum.RefDesignDatacenter,
+		Label:      testutils.RandString(5, "hex"),
+		TemplateId: "L2_Virtual_EVPN",
+		FabricSettings: &apstra.FabricSettings{
+			SpineSuperspineLinks: testutils.ToPtr(apstra.AddressingSchemeIp46),
+			SpineLeafLinks:       testutils.ToPtr(apstra.AddressingSchemeIp46),
+		},
+	}
+
+	bpId, err := client.CreateBlueprintFromTemplate(ctx, &bpRequest)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.DeleteBlueprint(ctx, bpId)) })
+
+	bpClient, err := client.NewTwoStageL3ClosClient(ctx, bpId)
+	require.NoError(t, err)
+
+	// enable IPv6
+	require.NoError(t, bpClient.SetFabricSettings(ctx, &apstra.FabricSettings{Ipv6Enabled: testutils.ToPtr(true)}))
+
+	return bpClient
+}
+
+// TestBlueprintI returns a collapsed fabric which has been committed and has no build errors
+func TestBlueprintI(t testing.TB, ctx context.Context, client *apstra.Client) *apstra.TwoStageL3ClosClient {
+	t.Helper()
+
+	bpId, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
+		RefDesign:  enum.RefDesignDatacenter,
+		Label:      testutils.RandString(5, "hex"),
+		TemplateId: "L3_Collapsed_ESI",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.DeleteBlueprint(ctx, bpId)) })
+
+	bpClient, err := client.NewTwoStageL3ClosClient(ctx, bpId)
+	require.NoError(t, err)
+
+	// assign leaf interface maps
+	leafIds, err := testutils.GetSystemIdsByRole(ctx, bpClient, "leaf")
+	require.NoError(t, err)
+	mappings := make(apstra.SystemIdToInterfaceMapAssignment, len(leafIds))
+	for _, leafId := range leafIds {
+		mappings[leafId.String()] = "Juniper_vQFX__AOS-7x10-Leaf"
+	}
+	err = bpClient.SetInterfaceMapAssignments(ctx, mappings)
+	require.NoError(t, err)
+
+	// set leaf loopback pool
+	err = bpClient.SetResourceAllocation(ctx, &apstra.ResourceGroupAllocation{
+		ResourceGroup: apstra.ResourceGroup{
+			Type: apstra.ResourceTypeIp4Pool,
+			Name: apstra.ResourceGroupNameLeafIp4,
+		},
+		PoolIds: []apstra.ObjectId{"Private-10_0_0_0-8"},
+	})
+	require.NoError(t, err)
+
+	// set leaf-leaf pool
+	err = bpClient.SetResourceAllocation(ctx, &apstra.ResourceGroupAllocation{
+		ResourceGroup: apstra.ResourceGroup{
+			Type: apstra.ResourceTypeIp4Pool,
+			Name: apstra.ResourceGroupNameLeafLeafIp4,
+		},
+		PoolIds: []apstra.ObjectId{"Private-10_0_0_0-8"},
+	})
+	require.NoError(t, err)
+
+	// set leaf ASN pool
+	err = bpClient.SetResourceAllocation(ctx, &apstra.ResourceGroupAllocation{
+		ResourceGroup: apstra.ResourceGroup{
+			Type: apstra.ResourceTypeAsnPool,
+			Name: apstra.ResourceGroupNameLeafAsn,
+		},
+		PoolIds: []apstra.ObjectId{"Private-64512-65534"},
+	})
+	require.NoError(t, err)
+
+	// set VN VNI pool
+	err = bpClient.SetResourceAllocation(ctx, &apstra.ResourceGroupAllocation{
+		ResourceGroup: apstra.ResourceGroup{
+			Type: apstra.ResourceTypeVniPool,
+			Name: apstra.ResourceGroupNameEvpnL3Vni,
+		},
+		PoolIds: []apstra.ObjectId{"Default-10000-20000"},
+	})
+	require.NoError(t, err)
+
+	// set VN VNI pool
+	err = bpClient.SetResourceAllocation(ctx, &apstra.ResourceGroupAllocation{
+		ResourceGroup: apstra.ResourceGroup{
+			Type: apstra.ResourceTypeVniPool,
+			Name: apstra.ResourceGroupNameVxlanVnIds,
+		},
+		PoolIds: []apstra.ObjectId{"Default-10000-20000"},
+	})
+	require.NoError(t, err)
+
+	// commit
+	bpStatus, err := client.GetBlueprintStatus(ctx, bpClient.Id())
+	require.NoError(t, err)
+	_, err = client.DeployBlueprint(ctx, &apstra.BlueprintDeployRequest{
+		Id:          bpClient.Id(),
+		Description: "initial commit in test: " + t.Name(),
+		Version:     bpStatus.Version,
+	})
+	require.NoError(t, err)
+
+	return bpClient
+}

--- a/internal/test_utils/datacenter_test_objects/racks.go
+++ b/internal/test_utils/datacenter_test_objects/racks.go
@@ -1,0 +1,41 @@
+// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package dctestobj
+
+import (
+	"context"
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	testutils "github.com/Juniper/apstra-go-sdk/internal/test_utils"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestRackA(t testing.TB, ctx context.Context, client *apstra.Client) apstra.ObjectId {
+	t.Helper()
+
+	request := apstra.RackTypeRequest{
+		DisplayName:              testutils.RandString(5, "hex"),
+		FabricConnectivityDesign: enum.FabricConnectivityDesignL3Clos,
+		LeafSwitches: []apstra.RackElementLeafSwitchRequest{
+			{
+				Label:             testutils.RandString(5, "hex"),
+				LinkPerSpineCount: 1,
+				LinkPerSpineSpeed: "40G",
+				LogicalDeviceId:   "AOS-48x10_6x40-1",
+			},
+		},
+	}
+
+	id, err := client.CreateRackType(ctx, &request)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, client.DeleteRackType(ctx, id))
+	})
+
+	return id
+}

--- a/internal/test_utils/datacenter_test_objects/security_zones.go
+++ b/internal/test_utils/datacenter_test_objects/security_zones.go
@@ -1,0 +1,36 @@
+// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package dctestobj
+
+import (
+	"context"
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	testutils "github.com/Juniper/apstra-go-sdk/internal/test_utils"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestSecurityZoneA(t testing.TB, ctx context.Context, bp *apstra.TwoStageL3ClosClient) apstra.ObjectId {
+	t.Helper()
+
+	rs := testutils.RandString(6, "hex")
+
+	id, err := bp.CreateSecurityZone(ctx, &apstra.SecurityZoneData{
+		Label:            rs,
+		SzType:           apstra.SecurityZoneTypeEVPN,
+		VrfName:          rs,
+		RoutingPolicyId:  "",
+		RouteTarget:      nil,
+		RtPolicy:         nil,
+		VlanId:           nil,
+		VniId:            nil,
+		JunosEvpnIrbMode: nil,
+	})
+	require.NoError(t, err)
+
+	return id
+}

--- a/internal/test_utils/datacenter_test_objects/templates.go
+++ b/internal/test_utils/datacenter_test_objects/templates.go
@@ -1,0 +1,82 @@
+// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package dctestobj
+
+import (
+	"context"
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	testutils "github.com/Juniper/apstra-go-sdk/internal/test_utils"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestTemplateA(t testing.TB, ctx context.Context, client *apstra.Client) apstra.ObjectId {
+	t.Helper()
+
+	rackId := TestRackA(t, ctx, client)
+
+	request := apstra.CreateRackBasedTemplateRequest{
+		DisplayName: testutils.RandString(5, "hex"),
+		Spine: &apstra.TemplateElementSpineRequest{
+			Count:         1,
+			LogicalDevice: "AOS-16x40-1",
+		},
+		RackInfos: map[apstra.ObjectId]apstra.TemplateRackBasedRackInfo{
+			rackId: {Count: 1},
+		},
+		AntiAffinityPolicy: &apstra.AntiAffinityPolicy{
+			Algorithm:                apstra.AlgorithmHeuristic,
+			MaxLinksPerPort:          1,
+			MaxLinksPerSlot:          1,
+			MaxPerSystemLinksPerPort: 1,
+			MaxPerSystemLinksPerSlot: 1,
+			Mode:                     apstra.AntiAffinityModeDisabled,
+		},
+		AsnAllocationPolicy:  &apstra.AsnAllocationPolicy{SpineAsnScheme: apstra.AsnAllocationSchemeDistinct},
+		VirtualNetworkPolicy: &apstra.VirtualNetworkPolicy{OverlayControlProtocol: apstra.OverlayControlProtocolEvpn},
+	}
+
+	id, err := client.CreateRackBasedTemplate(ctx, &request)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, client.DeleteTemplate(ctx, id))
+	})
+
+	return id
+}
+
+func TestTemplateB(t testing.TB, ctx context.Context, client *apstra.Client) apstra.ObjectId {
+	t.Helper()
+
+	rbt, err := client.GetRackBasedTemplate(ctx, "L2_Virtual")
+	require.NoError(t, err)
+
+	rbt.Data.DisplayName = testutils.RandString(5, "hex")
+	for k, v := range rbt.Data.RackInfo {
+		v.RackTypeData = nil
+		rbt.Data.RackInfo[k] = v
+	}
+
+	id, err := client.CreateRackBasedTemplate(ctx, &apstra.CreateRackBasedTemplateRequest{
+		DisplayName: rbt.Data.DisplayName,
+		Spine: &apstra.TemplateElementSpineRequest{
+			Count:                  rbt.Data.Spine.Count,
+			LinkPerSuperspineSpeed: rbt.Data.Spine.LinkPerSuperspineSpeed,
+			LogicalDevice:          "AOS-7x10-Spine",
+			LinkPerSuperspineCount: rbt.Data.Spine.LinkPerSuperspineCount,
+		},
+		RackInfos:            rbt.Data.RackInfo,
+		DhcpServiceIntent:    &rbt.Data.DhcpServiceIntent,
+		AntiAffinityPolicy:   rbt.Data.AntiAffinityPolicy,
+		AsnAllocationPolicy:  &rbt.Data.AsnAllocationPolicy,
+		VirtualNetworkPolicy: &rbt.Data.VirtualNetworkPolicy,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.DeleteTemplate(ctx, id)) })
+
+	return id
+}

--- a/internal/test_utils/datacenter_test_objects/virtual_networks.go
+++ b/internal/test_utils/datacenter_test_objects/virtual_networks.go
@@ -1,0 +1,41 @@
+// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package dctestobj
+
+import (
+	"context"
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	testutils "github.com/Juniper/apstra-go-sdk/internal/test_utils"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestVirtualNetworkA(t testing.TB, ctx context.Context, bp *apstra.TwoStageL3ClosClient, szId apstra.ObjectId) apstra.ObjectId {
+	t.Helper()
+
+	leafIds, err := testutils.GetSystemIdsByRole(ctx, bp, "leaf")
+	require.NoError(t, err)
+
+	vnBindings := make([]apstra.VnBinding, len(leafIds))
+	for i, leafId := range leafIds {
+		vnBindings[i] = apstra.VnBinding{SystemId: leafId}
+	}
+
+	id, err := bp.CreateVirtualNetwork(ctx, &apstra.VirtualNetworkData{
+		Ipv4Enabled:               true,
+		Label:                     testutils.RandString(6, "hex"),
+		SecurityZoneId:            szId,
+		VirtualGatewayIpv4Enabled: true,
+		VnBindings:                vnBindings,
+		VnType:                    enum.VnTypeVxlan,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, bp.DeleteVirtualNetwork(ctx, id)) })
+
+	return id
+}

--- a/internal/test_utils/pointer.go
+++ b/internal/test_utils/pointer.go
@@ -1,0 +1,9 @@
+// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package testutils
+
+func ToPtr[A any](a A) *A {
+	return &a
+}

--- a/internal/test_utils/queries.go
+++ b/internal/test_utils/queries.go
@@ -1,0 +1,44 @@
+// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package testutils
+
+import (
+	"context"
+	"github.com/Juniper/apstra-go-sdk/apstra"
+)
+
+func GetSystemIdsByRole(ctx context.Context, bp *apstra.TwoStageL3ClosClient, role string) ([]apstra.ObjectId, error) {
+	leafQuery := new(apstra.PathQuery).
+		SetClient(bp.Client()).
+		SetBlueprintId(bp.Id()).
+		SetBlueprintType(apstra.BlueprintTypeStaging).
+		Node([]apstra.QEEAttribute{
+			apstra.NodeTypeSystem.QEEAttribute(),
+			{"role", apstra.QEStringVal(role)},
+			{"name", apstra.QEStringVal("n_system")},
+		})
+
+	var leafQueryResult struct {
+		Items []struct {
+			System struct {
+				Id apstra.ObjectId `json:"id"`
+			} `json:"n_system"`
+		} `json:"items"`
+	}
+
+	err := leafQuery.Do(ctx, &leafQueryResult)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]apstra.ObjectId, len(leafQueryResult.Items))
+	for i, item := range leafQueryResult.Items {
+		result[i] = item.System.Id
+	}
+
+	return result, nil
+}


### PR DESCRIPTION
This PR introduces the `internal/datacenter_test_objects` package.

It contains functions like `TestBlueprintA()`