### PR TITLE
Use new test packages in `apstra/two_stage_l3_clos_fabric_settings_integration_test.go`

### DIFF
--- a/apstra/api_blueprints_integration_test.go
+++ b/apstra/api_blueprints_integration_test.go
@@ -4,39 +4,38 @@
 
 //go:build integration
 
-package apstra
+package apstra_test
 
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/apstra/compatibility"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	testutils "github.com/Juniper/apstra-go-sdk/internal/test_utils"
+	"github.com/Juniper/apstra-go-sdk/internal/test_utils/compare"
+	dctestobj "github.com/Juniper/apstra-go-sdk/internal/test_utils/datacenter_test_objects"
+	testclient "github.com/Juniper/apstra-go-sdk/internal/test_utils/test_client"
+	"github.com/hashicorp/go-version"
 	"log"
 	"math/rand"
 	"os"
 	"testing"
 
-	"github.com/Juniper/apstra-go-sdk/apstra/compatibility"
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	"github.com/stretchr/testify/require"
 )
 
 func TestListAllBlueprintIds(t *testing.T) {
-	ctx := context.Background()
+	ctx := testutils.WrapCtxWithTestId(t, context.Background())
 
-	clients, err := getTestClients(ctx, t)
-	require.NoError(t, err)
+	clients := testclient.GetTestClients(t, ctx)
 
-	ctx = wrapCtxWithTestId(t, ctx)
-	for clientName, client := range clients {
-		clientName, client := clientName, client
-
-		t.Run(client.name(), func(t *testing.T) {
+	for _, client := range clients {
+		t.Run(client.Name(), func(t *testing.T) {
 			t.Parallel()
-			ctx := wrapCtxWithTestId(t, ctx)
-			// ctx := context.WithValue(ctx, CtxKeyTestId, fmt.Sprintf("%s/%s", testId.String(), t.Name()))
+			ctx := testutils.WrapCtxWithTestId(t, ctx)
 
-			log.Printf("testing listAllBlueprintIds() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-			blueprints, err := client.client.listAllBlueprintIds(ctx)
+			blueprints, err := client.Client.ListAllBlueprintIds(ctx)
 			require.NoError(t, err)
 
 			result, err := json.Marshal(blueprints)
@@ -48,111 +47,89 @@ func TestListAllBlueprintIds(t *testing.T) {
 }
 
 func TestGetAllBlueprintStatus(t *testing.T) {
-	clients, err := getTestClients(context.Background(), t)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ctx := testutils.WrapCtxWithTestId(t, context.Background())
 
-	for clientName, client := range clients {
-		log.Printf("testing getAllBlueprintStatus() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		bps, err := client.client.getAllBlueprintStatus(context.TODO())
-		if err != nil {
-			t.Fatal(err)
-		}
+	clients := testclient.GetTestClients(t, ctx)
 
-		log.Println(len(bps))
+	for _, client := range clients {
+		t.Run(client.Name(), func(t *testing.T) {
+			t.Parallel()
+			ctx := testutils.WrapCtxWithTestId(t, ctx)
+
+			bps, err := client.Client.GetAllBlueprintStatus(ctx)
+			require.NoError(t, err)
+
+			log.Println(len(bps))
+		})
 	}
 }
 
 func TestCreateDeleteBlueprint(t *testing.T) {
-	ctx := context.Background()
+	ctx := testutils.WrapCtxWithTestId(t, context.Background())
 
-	clients, err := getTestClients(ctx, t)
-	if err != nil {
-		t.Fatal(err)
-	}
+	clients := testclient.GetTestClients(t, ctx)
 
-	for clientName, client := range clients {
-		t.Run(client.name(), func(t *testing.T) {
+	for _, client := range clients {
+		t.Run(client.Name(), func(t *testing.T) {
 			t.Parallel()
+			ctx := testutils.WrapCtxWithTestId(t, ctx)
 
-			req := CreateBlueprintFromTemplateRequest{
+			req := apstra.CreateBlueprintFromTemplateRequest{
 				RefDesign:  enum.RefDesignDatacenter,
-				Label:      randString(10, "hex"),
+				Label:      testutils.RandString(10, "hex"),
 				TemplateId: "L2_Virtual_EVPN",
-				FabricSettings: &FabricSettings{
-					FabricL3Mtu:          toPtr(uint16(rand.Intn(50)*2 + 9100)),
-					SpineLeafLinks:       toPtr(AddressingSchemeIp46),
-					SpineSuperspineLinks: toPtr(AddressingSchemeIp46),
+				FabricSettings: &apstra.FabricSettings{
+					FabricL3Mtu:          testutils.ToPtr(uint16(rand.Intn(50)*2 + 9100)),
+					SpineLeafLinks:       testutils.ToPtr(apstra.AddressingSchemeIp46),
+					SpineSuperspineLinks: testutils.ToPtr(apstra.AddressingSchemeIp46),
 				},
 			}
 
-			log.Printf("testing createBlueprintFromTemplate() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-			id, err := client.client.CreateBlueprintFromTemplate(ctx, &req)
-			if err != nil {
-				t.Fatal(err)
-			}
+			id, err := client.Client.CreateBlueprintFromTemplate(ctx, &req)
+			require.NoError(t, err)
 
-			bp, err := client.client.GetBlueprint(ctx, id)
-			if err != nil {
-				t.Fatal(err)
-			}
+			bp, err := client.Client.GetBlueprint(ctx, id)
+			require.NoError(t, err)
+			require.Equal(t, id, bp.Id)
+			require.Equal(t, req.Label, bp.Label)
 
-			if id != bp.Id {
-				t.Fatalf("expected id %q, got %q", id, bp.Id)
-			}
-
-			if req.Label != bp.Label {
-				t.Fatalf("expected label %q, got %q", req.Label, bp.Label)
-			}
-
-			bpClient, err := client.client.NewTwoStageL3ClosClient(ctx, id)
-			if err != nil {
-				t.Fatal(err)
-			}
+			bpClient, err := client.Client.NewTwoStageL3ClosClient(ctx, id)
+			require.NoError(t, err)
 
 			if req.FabricSettings != nil && req.FabricSettings.FabricL3Mtu != nil {
 				fap, err := bpClient.GetFabricSettings(ctx)
-				if err != nil {
-					t.Fatal(err)
-				}
-				if *req.FabricSettings.FabricL3Mtu != *fap.FabricL3Mtu {
-					t.Fatalf("expected fabric MTU %d, got %d", *req.FabricSettings.FabricL3Mtu, *fap.FabricL3Mtu)
-				}
+				require.NoError(t, err)
+				require.Equal(t, *req.FabricSettings.FabricL3Mtu, *fap.FabricL3Mtu)
 			}
 
 			log.Printf("got id '%s', deleting blueprint...\n", id)
-			log.Printf("testing deleteBlueprint() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-			err = client.client.deleteBlueprint(ctx, id)
-			if err != nil {
-				t.Fatal(err)
-			}
+			err = client.Client.DeleteBlueprint(ctx, id)
+			require.NoError(t, err)
 		})
 	}
 }
 
 func TestGetPatchGetPatchNode(t *testing.T) {
-	ctx := context.Background()
-	clients, err := getTestClients(ctx, t)
-	require.NoError(t, err)
+	ctx := testutils.WrapCtxWithTestId(t, context.Background())
+	clients := testclient.GetTestClients(t, ctx)
 
-	for clientName, client := range clients {
-		clientName, client := clientName, client
-		t.Run(fmt.Sprintf("%s_%s", client.client.apiVersion, clientName), func(t *testing.T) {
+	for _, client := range clients {
+		t.Run(client.Name(), func(t *testing.T) {
 			t.Parallel()
+			ctx := testutils.WrapCtxWithTestId(t, ctx)
 
-			bpClient := testBlueprintA(ctx, t, client.client)
+			bpClient := dctestobj.TestBlueprintA(t, ctx, client.Client)
 
 			type metadataNode struct {
-				Tags         interface{} `json:"tags,omitempty"`
-				PropertySet  interface{} `json:"property_set,omitempty"`
-				Label        string      `json:"label,omitempty"`
-				UserIp       interface{} `json:"user_ip,omitempty"`
-				TemplateJson interface{} `json:"template_json,omitempty"`
-				Design       string      `json:"design,omitempty"`
-				User         interface{} `json:"user,omitempty"`
-				Type         string      `json:"type,omitempty"`
-				Id           ObjectId    `json:"id,omitempty"`
+				Tags         interface{}     `json:"tags,omitempty"`
+				PropertySet  interface{}     `json:"property_set,omitempty"`
+				Label        string          `json:"label,omitempty"`
+				UserIp       interface{}     `json:"user_ip,omitempty"`
+				TemplateJson interface{}     `json:"template_json,omitempty"`
+				Design       string          `json:"design,omitempty"`
+				User         interface{}     `json:"user,omitempty"`
+				Type         string          `json:"type,omitempty"`
+				Id           apstra.ObjectId `json:"id,omitempty"`
 			}
 
 			type nodes struct {
@@ -161,33 +138,31 @@ func TestGetPatchGetPatchNode(t *testing.T) {
 			var nodesA, nodesB nodes
 
 			// fetch all metadata nodes into nodesA
-			log.Printf("testing getNodes() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-			require.NoError(t, bpClient.GetNodes(ctx, NodeTypeMetadata, &nodesA))
+			require.NoError(t, bpClient.GetNodes(ctx, apstra.NodeTypeMetadata, &nodesA))
 
 			// sanity check
 			require.Equal(t, 1, len(nodesA.Nodes))
 
-			newName := randString(10, "hex")
+			newName := testutils.RandString(10, "hex")
 			// loop should run just once (len check above)
 			for idA, nodeA := range nodesA.Nodes {
 				log.Printf("node id: %s ; label: %s\n", idA, nodeA.Label)
 
 				// change name to newName
 				req := metadataNode{Label: newName}
-				resp := &metadataNode{}
-				log.Printf("testing patchNode(%s) against %s %s (%s)", bpClient.Id(), client.clientType, clientName, client.client.ApiVersion())
-				if compatibility.PatchNodeSupportsUnsafeArg.Check(client.client.apiVersion) {
-					var ace ClientErr
-					err = bpClient.PatchNode(ctx, nodeA.Id, req, resp)
+				var resp metadataNode
+				if compatibility.PatchNodeSupportsUnsafeArg.Check(version.Must(version.NewVersion(client.Client.ApiVersion()))) {
+					var ace apstra.ClientErr
+					err := bpClient.PatchNode(ctx, nodeA.Id, req, &resp)
 					require.Error(t, err)
 					require.ErrorAs(t, err, &ace)
-					require.Equal(t, ace.Type(), ErrUnsafePatchProhibited)
+					require.Equal(t, ace.Type(), apstra.ErrUnsafePatchProhibited)
 
-					log.Printf("Apstra %s complained that this patch attempt is unsafe. Good!", client.client.apiVersion)
+					log.Printf("Apstra %s complained that this patch attempt is unsafe. Good!", client.Client.ApiVersion())
 
-					require.NoError(t, bpClient.PatchNodeUnsafe(ctx, nodeA.Id, req, resp))
+					require.NoError(t, bpClient.PatchNodeUnsafe(ctx, nodeA.Id, req, &resp))
 				} else {
-					require.NoError(t, bpClient.PatchNode(ctx, nodeA.Id, req, resp))
+					require.NoError(t, bpClient.PatchNode(ctx, nodeA.Id, req, &resp))
 				}
 				if resp.Label != newName {
 					t.Fatalf("expected new blueprint name %q, got %q", newName, resp.Label)
@@ -195,8 +170,7 @@ func TestGetPatchGetPatchNode(t *testing.T) {
 				log.Printf("response indicates name changed '%s' -> '%s'", nodeA.Label, resp.Label)
 
 				// fetch changed node(s) (still expecting one) into nodesB
-				log.Printf("testing getNodes(%s) against %s %s (%s)", bpClient.Id(), client.clientType, clientName, client.client.ApiVersion())
-				require.NoError(t, bpClient.GetNodes(ctx, NodeTypeMetadata, &nodesB))
+				require.NoError(t, bpClient.GetNodes(ctx, apstra.NodeTypeMetadata, &nodesB))
 				for idB, nodeB := range nodesB.Nodes {
 					log.Printf("node id: %s ; label: %s\n", idB, nodeB.Label)
 					require.Equalf(t, nodeB.Label, newName, "expected new blueprint name %q, got %q", newName, nodeB.Label)
@@ -207,303 +181,270 @@ func TestGetPatchGetPatchNode(t *testing.T) {
 }
 
 func TestGetDcNodes(t *testing.T) {
-	ctx := context.Background()
-	clients, err := getTestClients(ctx, t)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ctx := testutils.WrapCtxWithTestId(t, context.Background())
 
-	for clientName, client := range clients {
-		t.Run(client.name(), func(t *testing.T) {
+	clients := testclient.GetTestClients(t, ctx)
+
+	for _, client := range clients {
+		t.Run(client.Name(), func(t *testing.T) {
 			t.Parallel()
+			ctx := testutils.WrapCtxWithTestId(t, ctx)
 
-			bpClient := testBlueprintB(ctx, t, client.client)
+			bpClient := dctestobj.TestBlueprintB(t, ctx, client.Client)
 
 			type node struct {
-				Id         ObjectId `json:"id"`
-				Label      string   `json:"label"`
-				SystemType string   `json:"system_type"`
-			}
-			equal := func(a, b node) bool {
-				return a.Id == b.Id &&
-					a.Label == b.Label &&
-					a.SystemType == b.SystemType
+				Id         apstra.ObjectId `json:"id"`
+				Label      string          `json:"label"`
+				SystemType string          `json:"system_type"`
 			}
 
 			var response struct {
-				Nodes map[ObjectId]node `json:"nodes"`
+				Nodes map[apstra.ObjectId]node `json:"nodes"`
 			}
-			log.Printf("testing GetNodes() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-			err = bpClient.Client().GetNodes(ctx, bpClient.Id(), NodeTypeSystem, &response)
-			if err != nil {
-				t.Fatal(err)
-			}
+			err := bpClient.Client().GetNodes(ctx, bpClient.Id(), apstra.NodeTypeSystem, &response)
+			require.NoError(t, err)
 
 			log.Printf("got %d nodes. Fetch each one...", len(response.Nodes))
 			var nodeB node
 			for id, nodeA := range response.Nodes {
-				log.Printf("testing GetNode() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 				err = bpClient.Client().GetNode(ctx, bpClient.Id(), id, &nodeB)
-				if err != nil {
-					t.Fatal()
-				}
-				if !equal(nodeA, nodeB) {
-					t.Fatalf("nodes don't match:\n%v\n%v", nodeA, nodeB)
-				}
+				require.NoError(t, err)
+				require.Equal(t, nodeB, nodeA)
 			}
 		})
 	}
 }
 
 func TestPatchNodes(t *testing.T) {
-	ctx := context.Background()
-	clients, err := getTestClients(ctx, t)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ctx := testutils.WrapCtxWithTestId(t, context.Background())
 
-	for clientName, client := range clients {
-		t.Run(client.name(), func(t *testing.T) {
+	clients := testclient.GetTestClients(t, ctx)
+
+	for _, client := range clients {
+		t.Run(client.Name(), func(t *testing.T) {
 			t.Parallel()
+			ctx := testutils.WrapCtxWithTestId(t, ctx)
 
-			bpClient := testBlueprintB(ctx, t, client.client)
+			bpClient := dctestobj.TestBlueprintB(t, ctx, client.Client)
 
 			type node struct {
-				Id         ObjectId `json:"id"`
-				Label      string   `json:"label"`
-				SystemType string   `json:"system_type,omitempty"`
+				Id         apstra.ObjectId `json:"id"`
+				Label      string          `json:"label"`
+				SystemType string          `json:"system_type,omitempty"`
 			}
 
 			var getResponse struct {
-				Nodes map[ObjectId]node `json:"nodes"`
+				Nodes map[apstra.ObjectId]node `json:"nodes"`
 			}
-			log.Printf("testing GetNodes() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-			err = bpClient.Client().GetNodes(ctx, bpClient.Id(), NodeTypeSystem, &getResponse)
-			if err != nil {
-				t.Fatal(err)
-			}
+			err := bpClient.Client().GetNodes(ctx, bpClient.Id(), apstra.NodeTypeSystem, &getResponse)
+			require.NoError(t, err)
 
 			var patch []interface{}
 			for k, v := range getResponse.Nodes {
 				if v.SystemType == "server" {
 					patch = append(patch, node{
 						Id:    k,
-						Label: randString(5, "hex"),
+						Label: testutils.RandString(5, "hex"),
 					})
 				}
 			}
 
-			err = client.client.PatchNodes(ctx, bpClient.Id(), patch)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, client.Client.PatchNodes(ctx, bpClient.Id(), patch))
 
 			for _, n := range patch {
 				var result node
-				err = client.client.GetNode(ctx, bpClient.Id(), n.(node).Id, &result)
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				if n.(node).Label != result.Label {
-					t.Fatalf("patch expected label %s, got label %s", n.(node).Label, result.Label)
-				}
+				require.NoError(t, client.Client.GetNode(ctx, bpClient.Id(), n.(node).Id, &result))
+				require.Equal(t, n.(node).Label, result.Label)
 			}
 		})
 	}
 }
 
 func TestCreateDeleteEvpnBlueprint(t *testing.T) {
-	ctx := context.Background()
+	ctx := testutils.WrapCtxWithTestId(t, context.Background())
 
-	clients, err := getTestClients(ctx, t)
-	require.NoError(t, err)
+	clients := testclient.GetTestClients(t, ctx)
 
 	type testCase struct {
-		req        CreateBlueprintFromTemplateRequest
+		req        apstra.CreateBlueprintFromTemplateRequest
 		constraint *compatibility.Constraint
 	}
 
 	testCases := map[string]testCase{
 		"simple": {
-			req: CreateBlueprintFromTemplateRequest{
+			req: apstra.CreateBlueprintFromTemplateRequest{
 				RefDesign:  enum.RefDesignDatacenter,
-				Label:      randString(5, "hex"),
+				Label:      testutils.RandString(5, "hex"),
 				TemplateId: "L2_Virtual_EVPN",
 			},
 		},
 		"4.1.1_and_later": {
-			req: CreateBlueprintFromTemplateRequest{
+			req: apstra.CreateBlueprintFromTemplateRequest{
 				RefDesign:  enum.RefDesignDatacenter,
-				Label:      randString(5, "hex"),
+				Label:      testutils.RandString(5, "hex"),
 				TemplateId: "L2_Virtual_EVPN",
-				FabricSettings: &FabricSettings{
-					SpineLeafLinks:       toPtr(AddressingSchemeIp46),
-					SpineSuperspineLinks: toPtr(AddressingSchemeIp46),
+				FabricSettings: &apstra.FabricSettings{
+					SpineLeafLinks:       testutils.ToPtr(apstra.AddressingSchemeIp46),
+					SpineSuperspineLinks: testutils.ToPtr(apstra.AddressingSchemeIp46),
 				},
 			},
 		},
 		"4.2.0_specific_test": {
-			req: CreateBlueprintFromTemplateRequest{
+			req: apstra.CreateBlueprintFromTemplateRequest{
 				RefDesign:  enum.RefDesignDatacenter,
-				Label:      randString(5, "hex"),
+				Label:      testutils.RandString(5, "hex"),
 				TemplateId: "L2_Virtual_EVPN",
-				FabricSettings: &FabricSettings{
-					SpineLeafLinks:       toPtr(AddressingSchemeIp46),
-					SpineSuperspineLinks: toPtr(AddressingSchemeIp46),
-					FabricL3Mtu:          toPtr(uint16(9178)),
+				FabricSettings: &apstra.FabricSettings{
+					SpineLeafLinks:       testutils.ToPtr(apstra.AddressingSchemeIp46),
+					SpineSuperspineLinks: testutils.ToPtr(apstra.AddressingSchemeIp46),
+					FabricL3Mtu:          testutils.ToPtr(uint16(9178)),
 				},
 			},
 		},
 		"lots_of_values": {
-			req: CreateBlueprintFromTemplateRequest{
+			req: apstra.CreateBlueprintFromTemplateRequest{
 				RefDesign:  enum.RefDesignDatacenter,
-				Label:      randString(5, "hex"),
+				Label:      testutils.RandString(5, "hex"),
 				TemplateId: "L2_Virtual_EVPN",
-				FabricSettings: &FabricSettings{
-					JunosEvpnDuplicateMacRecoveryTime:     toPtr(uint16(16)),
-					MaxExternalRoutes:                     toPtr(uint32(239832)),
-					EsiMacMsb:                             toPtr(uint8(32)),
+				FabricSettings: &apstra.FabricSettings{
+					JunosEvpnDuplicateMacRecoveryTime:     testutils.ToPtr(uint16(16)),
+					MaxExternalRoutes:                     testutils.ToPtr(uint32(239832)),
+					EsiMacMsb:                             testutils.ToPtr(uint8(32)),
 					JunosGracefulRestart:                  &enum.FeatureSwitchDisabled,
 					OptimiseSzFootprint:                   &enum.FeatureSwitchDisabled,
 					JunosEvpnRoutingInstanceVlanAware:     &enum.FeatureSwitchDisabled,
 					EvpnGenerateType5HostRoutes:           &enum.FeatureSwitchDisabled,
-					MaxFabricRoutes:                       toPtr(uint32(84231)),
-					MaxMlagRoutes:                         toPtr(uint32(76112)),
+					MaxFabricRoutes:                       testutils.ToPtr(uint32(84231)),
+					MaxMlagRoutes:                         testutils.ToPtr(uint32(76112)),
 					JunosExOverlayEcmp:                    &enum.FeatureSwitchDisabled,
-					DefaultSviL3Mtu:                       toPtr(uint16(9100)),
+					DefaultSviL3Mtu:                       testutils.ToPtr(uint16(9100)),
 					JunosEvpnMaxNexthopAndInterfaceNumber: &enum.FeatureSwitchDisabled,
-					FabricL3Mtu:                           toPtr(uint16(9178)),
-					Ipv6Enabled:                           toPtr(false), // do not enable because it's a one-way trip
-					ExternalRouterMtu:                     toPtr(uint16(9100)),
-					MaxEvpnRoutes:                         toPtr(uint32(92342)),
-					AntiAffinityPolicy: &AntiAffinityPolicy{
-						Algorithm:                AlgorithmHeuristic,
+					FabricL3Mtu:                           testutils.ToPtr(uint16(9178)),
+					Ipv6Enabled:                           testutils.ToPtr(false), // do not enable because it's a one-way trip
+					ExternalRouterMtu:                     testutils.ToPtr(uint16(9100)),
+					MaxEvpnRoutes:                         testutils.ToPtr(uint32(92342)),
+					AntiAffinityPolicy: &apstra.AntiAffinityPolicy{
+						Algorithm:                apstra.AlgorithmHeuristic,
 						MaxLinksPerPort:          2,
 						MaxLinksPerSlot:          2,
 						MaxPerSystemLinksPerPort: 2,
 						MaxPerSystemLinksPerSlot: 2,
-						Mode:                     AntiAffinityModeEnabledLoose,
+						Mode:                     apstra.AntiAffinityModeEnabledLoose,
 					},
-					SpineLeafLinks:       toPtr(AddressingSchemeIp4),
-					SpineSuperspineLinks: toPtr(AddressingSchemeIp4),
+					SpineLeafLinks:       testutils.ToPtr(apstra.AddressingSchemeIp4),
+					SpineSuperspineLinks: testutils.ToPtr(apstra.AddressingSchemeIp4),
 				},
 			},
 		},
 		"different_values": {
-			req: CreateBlueprintFromTemplateRequest{
+			req: apstra.CreateBlueprintFromTemplateRequest{
 				RefDesign:  enum.RefDesignDatacenter,
-				Label:      randString(5, "hex"),
+				Label:      testutils.RandString(5, "hex"),
 				TemplateId: "L2_Virtual_EVPN",
-				FabricSettings: &FabricSettings{
-					JunosEvpnDuplicateMacRecoveryTime:     toPtr(uint16(14)),
-					MaxExternalRoutes:                     toPtr(uint32(233832)),
-					EsiMacMsb:                             toPtr(uint8(50)),
+				FabricSettings: &apstra.FabricSettings{
+					JunosEvpnDuplicateMacRecoveryTime:     testutils.ToPtr(uint16(14)),
+					MaxExternalRoutes:                     testutils.ToPtr(uint32(233832)),
+					EsiMacMsb:                             testutils.ToPtr(uint8(50)),
 					JunosGracefulRestart:                  &enum.FeatureSwitchEnabled,
 					OptimiseSzFootprint:                   &enum.FeatureSwitchEnabled,
 					JunosEvpnRoutingInstanceVlanAware:     &enum.FeatureSwitchEnabled,
 					EvpnGenerateType5HostRoutes:           &enum.FeatureSwitchEnabled,
-					MaxFabricRoutes:                       toPtr(uint32(82231)),
-					MaxMlagRoutes:                         toPtr(uint32(74112)),
+					MaxFabricRoutes:                       testutils.ToPtr(uint32(82231)),
+					MaxMlagRoutes:                         testutils.ToPtr(uint32(74112)),
 					JunosExOverlayEcmp:                    &enum.FeatureSwitchEnabled,
-					DefaultSviL3Mtu:                       toPtr(uint16(9070)),
+					DefaultSviL3Mtu:                       testutils.ToPtr(uint16(9070)),
 					JunosEvpnMaxNexthopAndInterfaceNumber: &enum.FeatureSwitchEnabled,
-					FabricL3Mtu:                           toPtr(uint16(9172)),
-					Ipv6Enabled:                           toPtr(false), // do not enable because it's a one-way trip
-					ExternalRouterMtu:                     toPtr(uint16(9080)),
-					MaxEvpnRoutes:                         toPtr(uint32(91342)),
-					AntiAffinityPolicy: &AntiAffinityPolicy{
-						Algorithm:                AlgorithmHeuristic,
+					FabricL3Mtu:                           testutils.ToPtr(uint16(9172)),
+					Ipv6Enabled:                           testutils.ToPtr(false), // do not enable because it's a one-way trip
+					ExternalRouterMtu:                     testutils.ToPtr(uint16(9080)),
+					MaxEvpnRoutes:                         testutils.ToPtr(uint32(91342)),
+					AntiAffinityPolicy: &apstra.AntiAffinityPolicy{
+						Algorithm:                apstra.AlgorithmHeuristic,
 						MaxLinksPerPort:          4,
 						MaxLinksPerSlot:          4,
 						MaxPerSystemLinksPerPort: 4,
 						MaxPerSystemLinksPerSlot: 4,
-						Mode:                     AntiAffinityModeEnabledLoose,
+						Mode:                     apstra.AntiAffinityModeEnabledLoose,
 					},
-					SpineLeafLinks:       toPtr(AddressingSchemeIp46),
-					SpineSuperspineLinks: toPtr(AddressingSchemeIp46),
+					SpineLeafLinks:       testutils.ToPtr(apstra.AddressingSchemeIp46),
+					SpineSuperspineLinks: testutils.ToPtr(apstra.AddressingSchemeIp46),
 				},
 			},
 		},
 	}
 
-	fetchFabricAddressingScheme := func(t testing.TB, client *TwoStageL3ClosClient) (AddressingScheme, AddressingScheme) {
+	fetchFabricAddressingScheme := func(t testing.TB, client *apstra.TwoStageL3ClosClient) (apstra.AddressingScheme, apstra.AddressingScheme) {
 		t.Helper()
 
-		query := new(PathQuery).
-			SetClient(client.client).
-			SetBlueprintId(client.blueprintId)
-		if compatibility.BpHasFabricAddressingPolicyNode.Check(client.client.apiVersion) {
-			query.Node([]QEEAttribute{
-				NodeTypeFabricAddressingPolicy.QEEAttribute(),
-				{Key: "name", Value: QEStringVal("node")},
+		query := new(apstra.PathQuery).
+			SetClient(client.Client()).
+			SetBlueprintId(client.Id())
+		if compatibility.BpHasFabricAddressingPolicyNode.Check(version.Must(version.NewVersion(client.Client().ApiVersion()))) {
+			query.Node([]apstra.QEEAttribute{
+				apstra.NodeTypeFabricAddressingPolicy.QEEAttribute(),
+				{Key: "name", Value: apstra.QEStringVal("node")},
 			})
 		} else {
-			query.Node([]QEEAttribute{
-				NodeTypeFabricPolicy.QEEAttribute(),
-				{Key: "name", Value: QEStringVal("node")},
+			query.Node([]apstra.QEEAttribute{
+				apstra.NodeTypeFabricPolicy.QEEAttribute(),
+				{Key: "name", Value: apstra.QEStringVal("node")},
 			})
 		}
 
 		var queryResponse struct {
 			Items []struct {
 				Node struct {
-					SpineLeafLinks       addressingScheme `json:"spine_leaf_links"`
-					SpineSuperspineLinks addressingScheme `json:"spine_superspine_links"`
+					SpineLeafLinks       string `json:"spine_leaf_links"`
+					SpineSuperspineLinks string `json:"spine_superspine_links"`
 				} `json:"node"`
 			} `json:"items"`
 		}
 
 		err := query.Do(ctx, &queryResponse)
 		require.NoError(t, err)
+		require.Equal(t, 1, len(queryResponse.Items))
 
-		if len(queryResponse.Items) != 1 {
-			t.Fatalf("got %d responses when querying for fabric addressing", len(queryResponse.Items))
-		}
+		var spineLeaf, spineSuperspine apstra.AddressingScheme
+		require.NoError(t, spineLeaf.FromString(queryResponse.Items[0].Node.SpineLeafLinks))
+		require.NoError(t, spineSuperspine.FromString(queryResponse.Items[0].Node.SpineLeafLinks))
 
-		spineLeaf, err := queryResponse.Items[0].Node.SpineLeafLinks.parse()
-		require.NoError(t, err)
-		spineSuperspine, err := queryResponse.Items[0].Node.SpineLeafLinks.parse()
-		require.NoError(t, err)
-
-		return AddressingScheme(spineLeaf), AddressingScheme(spineSuperspine)
+		return spineLeaf, spineSuperspine
 	}
 
 	for tName, tCase := range testCases {
-		tName, tCase := tName, tCase
-
 		t.Run(tName, func(t *testing.T) {
 			t.Parallel()
+			ctx := testutils.WrapCtxWithTestId(t, ctx)
 
-			for clientName, client := range clients {
-				clientName, client := clientName, client
-				t.Run(clientName, func(t *testing.T) {
-					if tCase.constraint != nil && !tCase.constraint.Check(client.client.apiVersion) {
-						t.Skipf("skipping test case %q with Apstra %s due to version constraint %q", tName, client.client.apiVersion, tCase.constraint)
+			for _, client := range clients {
+				t.Run(client.Name(), func(t *testing.T) {
+					if tCase.constraint != nil && !tCase.constraint.Check(version.Must(version.NewVersion(client.Client.ApiVersion()))) {
+						t.Skipf("skipping test case %q with Apstra %s due to version constraint %q", tName, client.Client.ApiVersion(), tCase.constraint)
 					}
 
-					t.Logf("testing CreateBlueprintFromTemplate() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-					id, err := client.client.CreateBlueprintFromTemplate(ctx, &tCase.req)
+					id, err := client.Client.CreateBlueprintFromTemplate(ctx, &tCase.req)
 					require.NoError(t, err)
 
-					if compatibility.EqApstra420.Check(client.client.apiVersion) && tCase.req.FabricSettings != nil { // 4.2.0 cannot set fabric settings when creating blueprint
-						bp, err := client.client.NewTwoStageL3ClosClient(ctx, id)
+					if !compatibility.FabricSettingsApiOk.Check(version.Must(version.NewVersion(client.Client.ApiVersion()))) && tCase.req.FabricSettings != nil {
+						// 4.2.0 cannot set fabric settings when creating blueprint, so we have to do it afterward
+						bp, err := client.Client.NewTwoStageL3ClosClient(ctx, id)
 						require.NoError(t, err)
 
-						require.NoError(t, bp.setFabricSettings420(ctx, tCase.req.FabricSettings.raw()))
+						// spine/leaf and spine/superspine addressing cannot be set, so we clear these
+						fs := tCase.req.FabricSettings
+						fs.SpineLeafLinks = nil
+						fs.SpineSuperspineLinks = nil
+						require.NoError(t, bp.SetFabricSettings(ctx, fs))
 					}
 
-					t.Logf("testing NewTwoStageL3ClosClient() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-					bpClient, err := client.client.NewTwoStageL3ClosClient(ctx, id)
+					bpClient, err := client.Client.NewTwoStageL3ClosClient(ctx, id)
 					require.NoError(t, err)
 
 					if tCase.req.FabricSettings != nil {
-						t.Logf("testing GetFabricSettings() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 						fabricSettings, err := bpClient.GetFabricSettings(ctx)
 						require.NoError(t, err)
 
-						t.Logf("comparing create-time vs. fetched blueprint fabric settings against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-						compareFabricSettings(t, *tCase.req.FabricSettings, *fabricSettings)
+						compare.FabricSettings(t, *tCase.req.FabricSettings, *fabricSettings)
 
 						if tCase.req.FabricSettings.SpineLeafLinks != nil || tCase.req.FabricSettings.SpineSuperspineLinks != nil {
 							spineLeaf, spineSuperspine := fetchFabricAddressingScheme(t, bpClient)
@@ -518,9 +459,7 @@ func TestCreateDeleteEvpnBlueprint(t *testing.T) {
 						}
 					}
 
-					t.Logf("testing DeleteBlueprint() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-					err = client.client.DeleteBlueprint(ctx, id)
-					require.NoError(t, err)
+					require.NoError(t, client.Client.DeleteBlueprint(ctx, id))
 				})
 			}
 		})
@@ -528,196 +467,190 @@ func TestCreateDeleteEvpnBlueprint(t *testing.T) {
 }
 
 func TestCreateDeleteIpFabricBlueprint(t *testing.T) {
-	ctx := context.Background()
-
-	clients, err := getTestClients(ctx, t)
-	require.NoError(t, err)
+	ctx := testutils.WrapCtxWithTestId(t, context.Background())
+	clients := testclient.GetTestClients(t, ctx)
 
 	type testCase struct {
-		req           CreateBlueprintFromTemplateRequest
+		req           apstra.CreateBlueprintFromTemplateRequest
 		compatibility *compatibility.Constraint
 	}
 
 	testCases := map[string]testCase{
 		"simple": {
-			req: CreateBlueprintFromTemplateRequest{
+			req: apstra.CreateBlueprintFromTemplateRequest{
 				RefDesign:  enum.RefDesignDatacenter,
-				Label:      randString(5, "hex"),
+				Label:      testutils.RandString(5, "hex"),
 				TemplateId: "L2_Virtual",
 			},
 		},
 		"4.1.1_and_later": {
-			req: CreateBlueprintFromTemplateRequest{
+			req: apstra.CreateBlueprintFromTemplateRequest{
 				RefDesign:  enum.RefDesignDatacenter,
-				Label:      randString(5, "hex"),
+				Label:      testutils.RandString(5, "hex"),
 				TemplateId: "L2_Virtual",
-				FabricSettings: &FabricSettings{
-					SpineLeafLinks:       toPtr(AddressingSchemeIp46),
-					SpineSuperspineLinks: toPtr(AddressingSchemeIp46),
+				FabricSettings: &apstra.FabricSettings{
+					SpineLeafLinks:       testutils.ToPtr(apstra.AddressingSchemeIp46),
+					SpineSuperspineLinks: testutils.ToPtr(apstra.AddressingSchemeIp46),
 				},
 			},
 		},
 		"4.2.0_specific_test": {
-			req: CreateBlueprintFromTemplateRequest{
+			req: apstra.CreateBlueprintFromTemplateRequest{
 				RefDesign:  enum.RefDesignDatacenter,
-				Label:      randString(5, "hex"),
+				Label:      testutils.RandString(5, "hex"),
 				TemplateId: "L2_Virtual",
-				FabricSettings: &FabricSettings{
-					SpineLeafLinks:       toPtr(AddressingSchemeIp46),
-					SpineSuperspineLinks: toPtr(AddressingSchemeIp46),
-					FabricL3Mtu:          toPtr(uint16(9178)),
+				FabricSettings: &apstra.FabricSettings{
+					SpineLeafLinks:       testutils.ToPtr(apstra.AddressingSchemeIp46),
+					SpineSuperspineLinks: testutils.ToPtr(apstra.AddressingSchemeIp46),
+					FabricL3Mtu:          testutils.ToPtr(uint16(9178)),
 				},
 			},
 		},
 		"lots_of_values": {
-			req: CreateBlueprintFromTemplateRequest{
+			req: apstra.CreateBlueprintFromTemplateRequest{
 				RefDesign:  enum.RefDesignDatacenter,
-				Label:      randString(5, "hex"),
+				Label:      testutils.RandString(5, "hex"),
 				TemplateId: "L2_Virtual",
-				FabricSettings: &FabricSettings{
-					JunosEvpnDuplicateMacRecoveryTime:     toPtr(uint16(16)),
-					MaxExternalRoutes:                     toPtr(uint32(239832)),
-					EsiMacMsb:                             toPtr(uint8(32)),
+				FabricSettings: &apstra.FabricSettings{
+					JunosEvpnDuplicateMacRecoveryTime:     testutils.ToPtr(uint16(16)),
+					MaxExternalRoutes:                     testutils.ToPtr(uint32(239832)),
+					EsiMacMsb:                             testutils.ToPtr(uint8(32)),
 					JunosGracefulRestart:                  &enum.FeatureSwitchDisabled,
 					OptimiseSzFootprint:                   &enum.FeatureSwitchDisabled,
 					JunosEvpnRoutingInstanceVlanAware:     &enum.FeatureSwitchDisabled,
 					EvpnGenerateType5HostRoutes:           &enum.FeatureSwitchDisabled,
-					MaxFabricRoutes:                       toPtr(uint32(84231)),
-					MaxMlagRoutes:                         toPtr(uint32(76112)),
+					MaxFabricRoutes:                       testutils.ToPtr(uint32(84231)),
+					MaxMlagRoutes:                         testutils.ToPtr(uint32(76112)),
 					JunosExOverlayEcmp:                    &enum.FeatureSwitchDisabled,
-					DefaultSviL3Mtu:                       toPtr(uint16(9100)),
+					DefaultSviL3Mtu:                       testutils.ToPtr(uint16(9100)),
 					JunosEvpnMaxNexthopAndInterfaceNumber: &enum.FeatureSwitchDisabled,
-					FabricL3Mtu:                           toPtr(uint16(9178)),
-					Ipv6Enabled:                           toPtr(false), // do not enable because it's a one-way trip
-					ExternalRouterMtu:                     toPtr(uint16(9100)),
-					MaxEvpnRoutes:                         toPtr(uint32(92342)),
-					AntiAffinityPolicy: &AntiAffinityPolicy{
-						Algorithm:                AlgorithmHeuristic,
+					FabricL3Mtu:                           testutils.ToPtr(uint16(9178)),
+					Ipv6Enabled:                           testutils.ToPtr(false), // do not enable because it's a one-way trip
+					ExternalRouterMtu:                     testutils.ToPtr(uint16(9100)),
+					MaxEvpnRoutes:                         testutils.ToPtr(uint32(92342)),
+					AntiAffinityPolicy: &apstra.AntiAffinityPolicy{
+						Algorithm:                apstra.AlgorithmHeuristic,
 						MaxLinksPerPort:          2,
 						MaxLinksPerSlot:          2,
 						MaxPerSystemLinksPerPort: 2,
 						MaxPerSystemLinksPerSlot: 2,
-						Mode:                     AntiAffinityModeEnabledLoose,
+						Mode:                     apstra.AntiAffinityModeEnabledLoose,
 					},
-					SpineLeafLinks:       toPtr(AddressingSchemeIp4),
-					SpineSuperspineLinks: toPtr(AddressingSchemeIp4),
+					SpineLeafLinks:       testutils.ToPtr(apstra.AddressingSchemeIp4),
+					SpineSuperspineLinks: testutils.ToPtr(apstra.AddressingSchemeIp4),
 				},
 			},
 		},
 		"different_values": {
-			req: CreateBlueprintFromTemplateRequest{
+			req: apstra.CreateBlueprintFromTemplateRequest{
 				RefDesign:  enum.RefDesignDatacenter,
-				Label:      randString(5, "hex"),
+				Label:      testutils.RandString(5, "hex"),
 				TemplateId: "L2_Virtual",
-				FabricSettings: &FabricSettings{
-					JunosEvpnDuplicateMacRecoveryTime:     toPtr(uint16(14)),
-					MaxExternalRoutes:                     toPtr(uint32(233832)),
-					EsiMacMsb:                             toPtr(uint8(50)),
+				FabricSettings: &apstra.FabricSettings{
+					JunosEvpnDuplicateMacRecoveryTime:     testutils.ToPtr(uint16(14)),
+					MaxExternalRoutes:                     testutils.ToPtr(uint32(233832)),
+					EsiMacMsb:                             testutils.ToPtr(uint8(50)),
 					JunosGracefulRestart:                  &enum.FeatureSwitchEnabled,
 					OptimiseSzFootprint:                   &enum.FeatureSwitchEnabled,
 					JunosEvpnRoutingInstanceVlanAware:     &enum.FeatureSwitchEnabled,
 					EvpnGenerateType5HostRoutes:           &enum.FeatureSwitchEnabled,
-					MaxFabricRoutes:                       toPtr(uint32(82231)),
-					MaxMlagRoutes:                         toPtr(uint32(74112)),
+					MaxFabricRoutes:                       testutils.ToPtr(uint32(82231)),
+					MaxMlagRoutes:                         testutils.ToPtr(uint32(74112)),
 					JunosExOverlayEcmp:                    &enum.FeatureSwitchEnabled,
-					DefaultSviL3Mtu:                       toPtr(uint16(9070)),
+					DefaultSviL3Mtu:                       testutils.ToPtr(uint16(9070)),
 					JunosEvpnMaxNexthopAndInterfaceNumber: &enum.FeatureSwitchEnabled,
-					FabricL3Mtu:                           toPtr(uint16(9172)),
-					Ipv6Enabled:                           toPtr(false), // do not enable because it's a one-way trip
-					ExternalRouterMtu:                     toPtr(uint16(9080)),
-					MaxEvpnRoutes:                         toPtr(uint32(91342)),
-					AntiAffinityPolicy: &AntiAffinityPolicy{
-						Algorithm:                AlgorithmHeuristic,
+					FabricL3Mtu:                           testutils.ToPtr(uint16(9172)),
+					Ipv6Enabled:                           testutils.ToPtr(false), // do not enable because it's a one-way trip
+					ExternalRouterMtu:                     testutils.ToPtr(uint16(9080)),
+					MaxEvpnRoutes:                         testutils.ToPtr(uint32(91342)),
+					AntiAffinityPolicy: &apstra.AntiAffinityPolicy{
+						Algorithm:                apstra.AlgorithmHeuristic,
 						MaxLinksPerPort:          4,
 						MaxLinksPerSlot:          4,
 						MaxPerSystemLinksPerPort: 4,
 						MaxPerSystemLinksPerSlot: 4,
-						Mode:                     AntiAffinityModeEnabledLoose,
+						Mode:                     apstra.AntiAffinityModeEnabledLoose,
 					},
-					SpineLeafLinks:       toPtr(AddressingSchemeIp46),
-					SpineSuperspineLinks: toPtr(AddressingSchemeIp46),
+					SpineLeafLinks:       testutils.ToPtr(apstra.AddressingSchemeIp46),
+					SpineSuperspineLinks: testutils.ToPtr(apstra.AddressingSchemeIp46),
 				},
 			},
 		},
 	}
 
-	fetchFabricAddressingScheme := func(t testing.TB, client *TwoStageL3ClosClient) (AddressingScheme, AddressingScheme) {
+	fetchFabricAddressingScheme := func(t testing.TB, client *apstra.TwoStageL3ClosClient) (apstra.AddressingScheme, apstra.AddressingScheme) {
 		t.Helper()
 
-		query := new(PathQuery).
-			SetClient(client.client).
-			SetBlueprintId(client.blueprintId)
-		if compatibility.BpHasFabricAddressingPolicyNode.Check(client.client.apiVersion) {
-			query.Node([]QEEAttribute{
-				NodeTypeFabricAddressingPolicy.QEEAttribute(),
-				{Key: "name", Value: QEStringVal("node")},
+		query := new(apstra.PathQuery).
+			SetClient(client.Client()).
+			SetBlueprintId(client.Id())
+		if compatibility.BpHasFabricAddressingPolicyNode.Check(version.Must(version.NewVersion(client.Client().ApiVersion()))) {
+			query.Node([]apstra.QEEAttribute{
+				apstra.NodeTypeFabricAddressingPolicy.QEEAttribute(),
+				{Key: "name", Value: apstra.QEStringVal("node")},
 			})
 		} else {
-			query.Node([]QEEAttribute{
-				NodeTypeFabricPolicy.QEEAttribute(),
-				{Key: "name", Value: QEStringVal("node")},
+			query.Node([]apstra.QEEAttribute{
+				apstra.NodeTypeFabricPolicy.QEEAttribute(),
+				{Key: "name", Value: apstra.QEStringVal("node")},
 			})
 		}
 
 		var queryResponse struct {
 			Items []struct {
 				Node struct {
-					SpineLeafLinks       addressingScheme `json:"spine_leaf_links"`
-					SpineSuperspineLinks addressingScheme `json:"spine_superspine_links"`
+					SpineLeafLinks       string `json:"spine_leaf_links"`
+					SpineSuperspineLinks string `json:"spine_superspine_links"`
 				} `json:"node"`
 			} `json:"items"`
 		}
 
 		err := query.Do(ctx, &queryResponse)
 		require.NoError(t, err)
+		require.Equal(t, 1, len(queryResponse.Items))
 
-		if len(queryResponse.Items) != 1 {
-			t.Fatalf("got %d responses when querying for fabric addressing", len(queryResponse.Items))
-		}
+		var spineLeaf, spineSuperspine apstra.AddressingScheme
+		require.NoError(t, spineLeaf.FromString(queryResponse.Items[0].Node.SpineLeafLinks))
+		require.NoError(t, spineSuperspine.FromString(queryResponse.Items[0].Node.SpineSuperspineLinks))
 
-		spineLeaf, err := queryResponse.Items[0].Node.SpineLeafLinks.parse()
-		require.NoError(t, err)
-		spineSuperspine, err := queryResponse.Items[0].Node.SpineLeafLinks.parse()
-		require.NoError(t, err)
-
-		return AddressingScheme(spineLeaf), AddressingScheme(spineSuperspine)
+		return spineLeaf, spineSuperspine
 	}
 
 	for tName, tCase := range testCases {
-		tName, tCase := tName, tCase
 
 		t.Run(tName, func(t *testing.T) {
 			t.Parallel()
+			ctx := testutils.WrapCtxWithTestId(t, ctx)
 
-			for clientName, client := range clients {
-				clientName, client := clientName, client
-				t.Run(clientName, func(t *testing.T) {
-					if tCase.compatibility != nil && !tCase.compatibility.Check(client.client.apiVersion) {
-						t.Skipf("skipping test case %q with Apstra %s due to version constraint %q", tName, client.client.apiVersion, tCase.compatibility)
+			for _, client := range clients {
+				t.Run(client.Name(), func(t *testing.T) {
+					if tCase.compatibility != nil && !tCase.compatibility.Check(version.Must(version.NewVersion(client.Client.ApiVersion()))) {
+						t.Skipf("skipping test case %q with Apstra %s due to version constraint %q", tName, client.Client.ApiVersion(), tCase.compatibility)
 					}
 
-					t.Logf("testing CreateBlueprintFromTemplate() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-					id, err := client.client.CreateBlueprintFromTemplate(ctx, &tCase.req)
+					id, err := client.Client.CreateBlueprintFromTemplate(ctx, &tCase.req)
 					require.NoError(t, err)
 
-					if compatibility.EqApstra420.Check(client.client.apiVersion) && tCase.req.FabricSettings != nil { // 4.2.0 cannot set fabric settings when creating blueprint
-						bp, err := client.client.NewTwoStageL3ClosClient(ctx, id)
+					if !compatibility.FabricSettingsApiOk.Check(version.Must(version.NewVersion(client.Client.ApiVersion()))) && tCase.req.FabricSettings != nil {
+						// 4.2.0 cannot set fabric settings when creating blueprint, so we have to do it afterward
+						bp, err := client.Client.NewTwoStageL3ClosClient(ctx, id)
 						require.NoError(t, err)
 
-						require.NoError(t, bp.setFabricSettings420(ctx, tCase.req.FabricSettings.raw()))
+						// spine/leaf and spine/superspine addressing cannot be set, so we clear these
+						fs := tCase.req.FabricSettings
+						fs.SpineLeafLinks = nil
+						fs.SpineSuperspineLinks = nil
+						require.NoError(t, bp.SetFabricSettings(ctx, fs))
 					}
 
-					t.Logf("testing NewTwoStageL3ClosClient() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-					bpClient, err := client.client.NewTwoStageL3ClosClient(ctx, id)
+					bpClient, err := client.Client.NewTwoStageL3ClosClient(ctx, id)
 					require.NoError(t, err)
 
 					if tCase.req.FabricSettings != nil {
-						t.Logf("testing GetFabricSettings() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 						fabricSettings, err := bpClient.GetFabricSettings(ctx)
 						require.NoError(t, err)
 
-						t.Logf("comparing create-time vs. fetched blueprint fabric settings against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-						compareFabricSettings(t, *tCase.req.FabricSettings, *fabricSettings)
+						compare.FabricSettings(t, *tCase.req.FabricSettings, *fabricSettings)
 
 						if tCase.req.FabricSettings.SpineLeafLinks != nil || tCase.req.FabricSettings.SpineSuperspineLinks != nil {
 							spineLeaf, spineSuperspine := fetchFabricAddressingScheme(t, bpClient)
@@ -732,9 +665,7 @@ func TestCreateDeleteIpFabricBlueprint(t *testing.T) {
 						}
 					}
 
-					t.Logf("testing DeleteBlueprint() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-					err = client.client.DeleteBlueprint(ctx, id)
-					require.NoError(t, err)
+					require.NoError(t, client.Client.DeleteBlueprint(ctx, id))
 				})
 			}
 		})
@@ -742,81 +673,78 @@ func TestCreateDeleteIpFabricBlueprint(t *testing.T) {
 }
 
 func TestCreateDeleteBlueprintWithRoutingLimits(t *testing.T) {
-	ctx := context.Background()
+	ctx := testutils.WrapCtxWithTestId(t, context.Background())
 
-	clients, err := getTestClients(ctx, t)
-	require.NoError(t, err)
+	clients := testclient.GetTestClients(t, ctx)
 
-	blueprintRequest := func() CreateBlueprintFromTemplateRequest {
-		return CreateBlueprintFromTemplateRequest{
+	blueprintRequest := func() apstra.CreateBlueprintFromTemplateRequest {
+		return apstra.CreateBlueprintFromTemplateRequest{
 			RefDesign:  enum.RefDesignDatacenter,
-			Label:      randString(5, "hex"),
+			Label:      testutils.RandString(5, "hex"),
 			TemplateId: "L2_Virtual",
 		}
 	}
 
 	type testCase struct {
-		name string
-		// compatibility   version.Constraints
-		fabricSettings FabricSettings
+		name           string
+		fabricSettings apstra.FabricSettings
 	}
 
 	testCases := []testCase{
 		{
 			name:           "create_with_defaults",
-			fabricSettings: FabricSettings{},
+			fabricSettings: apstra.FabricSettings{},
 		},
 		{
 			name: "create_with_zeros",
-			fabricSettings: FabricSettings{
-				MaxEvpnRoutes:     toPtr(uint32(0)),
-				MaxExternalRoutes: toPtr(uint32(0)),
-				MaxFabricRoutes:   toPtr(uint32(0)),
-				MaxMlagRoutes:     toPtr(uint32(0)),
+			fabricSettings: apstra.FabricSettings{
+				MaxEvpnRoutes:     testutils.ToPtr(uint32(0)),
+				MaxExternalRoutes: testutils.ToPtr(uint32(0)),
+				MaxFabricRoutes:   testutils.ToPtr(uint32(0)),
+				MaxMlagRoutes:     testutils.ToPtr(uint32(0)),
 			},
 		},
 		{
 			name: "create_with_values",
-			fabricSettings: FabricSettings{
-				MaxEvpnRoutes:     toPtr(uint32(20001)),
-				MaxExternalRoutes: toPtr(uint32(20002)),
-				MaxFabricRoutes:   toPtr(uint32(20003)),
-				MaxMlagRoutes:     toPtr(uint32(20004)),
+			fabricSettings: apstra.FabricSettings{
+				MaxEvpnRoutes:     testutils.ToPtr(uint32(20001)),
+				MaxExternalRoutes: testutils.ToPtr(uint32(20002)),
+				MaxFabricRoutes:   testutils.ToPtr(uint32(20003)),
+				MaxMlagRoutes:     testutils.ToPtr(uint32(20004)),
 			},
 		},
 	}
 
-	for clientName, client := range clients {
-		t.Run(client.client.apiVersion.String(), func(t *testing.T) {
-			if !compatibility.GeApstra421.Check(client.client.apiVersion) {
-				t.Skipf("skipping Apstra %s client due to version constraint", client.client.apiVersion)
+	for _, client := range clients {
+		t.Run(client.Name(), func(t *testing.T) {
+			t.Parallel()
+			ctx := testutils.WrapCtxWithTestId(t, ctx)
+
+			if !compatibility.GeApstra421.Check(version.Must(version.NewVersion(client.Client.ApiVersion()))) {
+				t.Skipf("skipping Apstra %s client due to version constraint", client.Client.ApiVersion())
 			}
 
 			for _, tCase := range testCases {
-				clientName, client := clientName, client
+				client := client
 				tCase := tCase
 
 				t.Run(tCase.name, func(t *testing.T) {
+					ctx := testutils.WrapCtxWithTestId(t, ctx)
+
 					bpr := blueprintRequest()
 					bpr.FabricSettings = &tCase.fabricSettings
-					t.Logf("testing CreateBlueprintFromTemplate() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-					id, err := client.client.CreateBlueprintFromTemplate(ctx, &bpr)
+					id, err := client.Client.CreateBlueprintFromTemplate(ctx, &bpr)
 					require.NoError(t, err)
 
-					t.Logf("testing NewTwoStageL3ClosClient() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-					bpClient, err := client.client.NewTwoStageL3ClosClient(ctx, id)
+					bpClient, err := client.Client.NewTwoStageL3ClosClient(ctx, id)
 					require.NoError(t, err)
 
-					t.Logf("testing GetFabricSettings() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
 					fabricSettings, err := bpClient.GetFabricSettings(ctx)
 					require.NoError(t, err)
 
-					t.Logf("comparing create-time vs. fetched blueprint fabric settings against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-					compareFabricSettings(t, tCase.fabricSettings, *fabricSettings)
+					compare.FabricSettings(t, tCase.fabricSettings, *fabricSettings)
 
-					t.Logf("testing DeleteBlueprint() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-					err = client.client.DeleteBlueprint(ctx, id)
-					require.NoError(t, err)
+					require.NoError(t, client.Client.DeleteBlueprint(ctx, id))
 				})
 			}
 		})
@@ -833,24 +761,23 @@ func TestDeleteAllBlueprints(t *testing.T) {
 	if _, ok := os.LookupEnv("DELETE_ALL_BLUEPRINTS_WITH_A_TEST"); !ok {
 		t.Skip("refusing to run without DELETE_ALL_BLUEPRINTS_WITH_A_TEST in environment")
 	}
-	ctx := context.Background()
 
-	err := os.Setenv(envApstraExperimental, "1")
-	require.NoError(t, err)
+	ctx := testutils.WrapCtxWithTestId(t, context.Background())
 
-	clients, err := getTestClients(ctx, t)
-	require.NoError(t, err)
+	require.NoError(t, os.Setenv(testclient.EnvApstraExperimental, "1"))
 
-	for clientName, client := range clients {
-		clientName, client := clientName, client
-		t.Run(clientName, func(t *testing.T) {
+	clients := testclient.GetTestClients(t, ctx)
+
+	for _, client := range clients {
+		t.Run(client.Name(), func(t *testing.T) {
 			t.Parallel()
+			ctx := testutils.WrapCtxWithTestId(t, ctx)
 
-			ids, err := client.client.ListAllBlueprintIds(ctx)
+			ids, err := client.Client.ListAllBlueprintIds(ctx)
 			require.NoError(t, err)
 
 			for _, id := range ids {
-				require.NoError(t, client.client.DeleteBlueprint(ctx, id))
+				require.NoError(t, client.Client.DeleteBlueprint(ctx, id))
 			}
 		})
 	}

--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -353,6 +353,7 @@ func TestImmediateTickerSecondTick(t *testing.T) {
 	log.Printf("start %s first tick %s second tick %s", start, firstTick, secondTick)
 }
 
+// Deprecated: Use testutils.TestBlueprintA
 func testBlueprintA(ctx context.Context, t *testing.T, client *Client) *TwoStageL3ClosClient {
 	t.Helper()
 
@@ -371,6 +372,7 @@ func testBlueprintA(ctx context.Context, t *testing.T, client *Client) *TwoStage
 	return bpClient
 }
 
+// Deprecated: Use testutils.TestBlueprintB
 func testBlueprintB(ctx context.Context, t *testing.T, client *Client) *TwoStageL3ClosClient {
 	t.Helper()
 
@@ -389,6 +391,7 @@ func testBlueprintB(ctx context.Context, t *testing.T, client *Client) *TwoStage
 	return bpClient
 }
 
+// Deprecated: Use testutils.TestBlueprintC
 func testBlueprintC(ctx context.Context, t testing.TB, client *Client) *TwoStageL3ClosClient {
 	t.Helper()
 
@@ -406,6 +409,7 @@ func testBlueprintC(ctx context.Context, t testing.TB, client *Client) *TwoStage
 	return bpClient
 }
 
+// Deprecated: Use testutils.TestBlueprintD
 func testBlueprintD(ctx context.Context, t *testing.T, client *Client) *TwoStageL3ClosClient {
 	t.Helper()
 
@@ -451,6 +455,7 @@ func testBlueprintD(ctx context.Context, t *testing.T, client *Client) *TwoStage
 	return bpClient
 }
 
+// Deprecated: Use testutils.TestBlueprintE
 func testBlueprintE(ctx context.Context, t *testing.T, client *Client) *TwoStageL3ClosClient {
 	bpId, err := client.CreateBlueprintFromTemplate(ctx, &CreateBlueprintFromTemplateRequest{
 		RefDesign:  enum.RefDesignDatacenter,
@@ -526,6 +531,7 @@ func testBlueprintE(ctx context.Context, t *testing.T, client *Client) *TwoStage
 
 // testBlueprintH creates a test blueprint using client and returns a *TwoStageL3ClosClient.
 // The blueprint will use a dual-stack fabric and have ipv6 enabled.
+// Deprecated: Use testutils.TestBlueprintH
 func testBlueprintH(ctx context.Context, t *testing.T, client *Client) *TwoStageL3ClosClient {
 	t.Helper()
 
@@ -570,6 +576,7 @@ func testBlueprintH(ctx context.Context, t *testing.T, client *Client) *TwoStage
 }
 
 // testBlueprintI returns a collapsed fabric which has been committed and has no build errors
+// Deprecated: Use testutils.TestBlueprintI
 func testBlueprintI(ctx context.Context, t *testing.T, client *Client) *TwoStageL3ClosClient {
 	t.Helper()
 
@@ -708,6 +715,7 @@ func TestItemInSlice(t *testing.T) {
 	}
 }
 
+// Deprecated: Use testutils.TestRackA
 func testRackA(ctx context.Context, t *testing.T, client *Client) (ObjectId, func(context.Context) error) {
 	deleteFunc := func(context.Context) error { return nil }
 	request := RackTypeRequest{
@@ -734,6 +742,7 @@ func testRackA(ctx context.Context, t *testing.T, client *Client) (ObjectId, fun
 	return id, deleteFunc
 }
 
+// Deprecated: Use testutils.TestTemplateA
 func testTemplateA(ctx context.Context, t *testing.T, client *Client) (ObjectId, func(context.Context) error) {
 	deleteFunc := func(context.Context) error { return nil }
 	rackId, rackDeleteFunc := testRackA(ctx, t, client)
@@ -773,6 +782,7 @@ func testTemplateA(ctx context.Context, t *testing.T, client *Client) (ObjectId,
 	return id, deleteFunc
 }
 
+// Deprecated: Use testutils.TestBlueprintF
 func testBlueprintF(ctx context.Context, t *testing.T, client *Client) (*TwoStageL3ClosClient, func(context.Context) error) {
 	deleteFunc := func(context.Context) error { return nil }
 	templateId, templateDeleteFunc := testTemplateA(ctx, t, client)
@@ -800,6 +810,7 @@ func testBlueprintF(ctx context.Context, t *testing.T, client *Client) (*TwoStag
 	return bpClient, deleteFunc
 }
 
+// Deprecated: Use testutils.TestBlueprintG
 func testBlueprintG(ctx context.Context, t *testing.T, client *Client) *TwoStageL3ClosClient {
 	t.Helper()
 
@@ -911,6 +922,7 @@ func compareDashboards(d1, d2 IbaDashboardData) bool {
 	return true
 }
 
+// Deprecated: Use testutils.TestTemplateB
 func testTemplateB(ctx context.Context, t *testing.T, client *Client) ObjectId {
 	t.Helper()
 
@@ -944,6 +956,7 @@ func testTemplateB(ctx context.Context, t *testing.T, client *Client) ObjectId {
 	return id
 }
 
+// Deprecated: Use testutils.TestSecurityZoneA
 func testSecurityZone(t testing.TB, ctx context.Context, bp *TwoStageL3ClosClient) ObjectId {
 	t.Helper()
 
@@ -965,6 +978,7 @@ func testSecurityZone(t testing.TB, ctx context.Context, bp *TwoStageL3ClosClien
 	return id
 }
 
+// Deprecated: Use testutils.TestVirtualNetworkA
 func testVirtualNetwork(t testing.TB, ctx context.Context, bp *TwoStageL3ClosClient, szId ObjectId) ObjectId {
 	t.Helper()
 

--- a/apstra/two_stage_l3_clos_fabric_settings_integration_test.go
+++ b/apstra/two_stage_l3_clos_fabric_settings_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2024-2024.
+// Copyright (c) Juniper Networks, Inc., 2024-2025.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Deprecated: Use compare.AntiAffinityPolicy
 func compareAntiAffinityPolicy(t testing.TB, set, get AntiAffinityPolicy) {
 	t.Helper()
 
@@ -44,6 +45,7 @@ func compareAntiAffinityPolicy(t testing.TB, set, get AntiAffinityPolicy) {
 	}
 }
 
+// Deprecated: Use compare.FabricSettings
 func compareFabricSettings(t testing.TB, set, get FabricSettings) {
 	t.Helper()
 

--- a/internal/test_utils/compare/dc_fabric_settings.go
+++ b/internal/test_utils/compare/dc_fabric_settings.go
@@ -1,0 +1,135 @@
+// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package compare
+
+import (
+	"testing"
+
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/stretchr/testify/require"
+)
+
+func AntiAffinityPolicy(t testing.TB, set, get apstra.AntiAffinityPolicy) {
+	t.Helper()
+
+	if set.Algorithm != get.Algorithm {
+		t.Errorf("set AntiAffinityPolicy Algorithm %s got %s", set.Algorithm, get.Algorithm)
+	}
+
+	if set.MaxLinksPerPort != get.MaxLinksPerPort {
+		t.Errorf("set AntiAffinityPolicy MaxLinksPerPort %d got %d", set.MaxLinksPerPort, get.MaxLinksPerPort)
+	}
+
+	if set.MaxLinksPerSlot != get.MaxLinksPerSlot {
+		t.Errorf("set AntiAffinityPolicy MaxLinksPerSlot %d got %d", set.MaxLinksPerSlot, get.MaxLinksPerSlot)
+	}
+
+	if set.MaxPerSystemLinksPerPort != get.MaxPerSystemLinksPerPort {
+		t.Errorf("set AntiAffinityPolicy MaxPerSystemLinksPerPort %d got %d", set.MaxPerSystemLinksPerPort, get.MaxPerSystemLinksPerPort)
+	}
+
+	if set.MaxPerSystemLinksPerSlot != get.MaxPerSystemLinksPerSlot {
+		t.Errorf("set AntiAffinityPolicy MaxPerSystemLinksPerSlot %d got %d", set.MaxPerSystemLinksPerSlot, get.MaxPerSystemLinksPerSlot)
+	}
+
+	if set.Mode != get.Mode {
+		t.Errorf("set AntiAffinityPolicy Mode %s got %s", set.Mode, get.Mode)
+	}
+}
+
+func FabricSettings(t testing.TB, set, get apstra.FabricSettings) {
+	t.Helper()
+
+	if set.AntiAffinityPolicy != nil {
+		require.NotNil(t, get.AntiAffinityPolicy)
+		AntiAffinityPolicy(t, *get.AntiAffinityPolicy, *set.AntiAffinityPolicy)
+	}
+
+	if set.DefaultSviL3Mtu != nil {
+		require.NotNil(t, get.DefaultSviL3Mtu)
+		require.Equalf(t, *set.DefaultSviL3Mtu, *get.DefaultSviL3Mtu, "DefaultSviL3Mtu: set %d get %d", *set.DefaultSviL3Mtu, *get.DefaultSviL3Mtu)
+	}
+
+	if set.EsiMacMsb != nil {
+		require.NotNil(t, get.EsiMacMsb)
+		require.Equalf(t, *set.EsiMacMsb, *get.EsiMacMsb, "EsiMacMsb: set %d get %d", *set.EsiMacMsb, *get.EsiMacMsb)
+	}
+
+	if set.EvpnGenerateType5HostRoutes != nil && *set.EvpnGenerateType5HostRoutes != *get.EvpnGenerateType5HostRoutes {
+		require.NotNil(t, get.EvpnGenerateType5HostRoutes)
+		require.Equalf(t, *set.EvpnGenerateType5HostRoutes, *get.EvpnGenerateType5HostRoutes, "EvpnGenerateType5HostRoutes: set %d get %d", *set.EvpnGenerateType5HostRoutes, *get.EvpnGenerateType5HostRoutes)
+	}
+
+	if set.ExternalRouterMtu != nil {
+		require.NotNil(t, get.ExternalRouterMtu)
+		require.Equalf(t, *set.ExternalRouterMtu, *get.ExternalRouterMtu, "ExternalRouterMtu: set %d get %d", *set.ExternalRouterMtu, *get.ExternalRouterMtu)
+	}
+
+	if set.FabricL3Mtu != nil && *set.FabricL3Mtu != *get.FabricL3Mtu {
+		require.NotNil(t, get.FabricL3Mtu)
+		require.Equalf(t, *set.FabricL3Mtu, *get.FabricL3Mtu, "FabricL3Mtu: set %d get %d", *set.FabricL3Mtu, *get.FabricL3Mtu)
+	}
+
+	if set.Ipv6Enabled != nil {
+		require.NotNil(t, get.Ipv6Enabled)
+		require.Equalf(t, *set.Ipv6Enabled, *get.Ipv6Enabled, "Ipv6Enabled: set %d get %d", *set.Ipv6Enabled, *get.Ipv6Enabled)
+	}
+
+	if set.JunosEvpnDuplicateMacRecoveryTime != nil {
+		require.NotNil(t, get.JunosEvpnDuplicateMacRecoveryTime)
+		require.Equalf(t, *set.JunosEvpnDuplicateMacRecoveryTime, *get.JunosEvpnDuplicateMacRecoveryTime, "JunosEvpnDuplicateMacRecoveryTime: set %d get %d", *set.JunosEvpnDuplicateMacRecoveryTime, *get.JunosEvpnDuplicateMacRecoveryTime)
+	}
+
+	if set.JunosEvpnRoutingInstanceVlanAware != nil {
+		require.NotNil(t, get.JunosEvpnRoutingInstanceVlanAware)
+		require.Equalf(t, *set.JunosEvpnRoutingInstanceVlanAware, *get.JunosEvpnRoutingInstanceVlanAware, "JunosEvpnRoutingInstanceVlanAware: set %d get %d", *set.JunosEvpnRoutingInstanceVlanAware, *get.JunosEvpnRoutingInstanceVlanAware)
+	}
+
+	if set.JunosEvpnMaxNexthopAndInterfaceNumber != nil {
+		require.NotNil(t, get.JunosEvpnMaxNexthopAndInterfaceNumber)
+		require.Equalf(t, *set.JunosEvpnMaxNexthopAndInterfaceNumber, *get.JunosEvpnMaxNexthopAndInterfaceNumber, "JunosEvpnMaxNexthopAndInterfaceNumber: set %d get %d", *set.JunosEvpnMaxNexthopAndInterfaceNumber, *get.JunosEvpnMaxNexthopAndInterfaceNumber)
+	}
+
+	if set.JunosExOverlayEcmp != nil {
+		require.NotNil(t, get.JunosExOverlayEcmp)
+		require.Equalf(t, *set.JunosExOverlayEcmp, *get.JunosExOverlayEcmp, "JunosExOverlayEcmp: set %d get %d", *set.JunosExOverlayEcmp, *get.JunosExOverlayEcmp)
+	}
+
+	if set.JunosGracefulRestart != nil {
+		require.NotNil(t, get.JunosGracefulRestart)
+		require.Equalf(t, *set.JunosGracefulRestart, *get.JunosGracefulRestart, "JunosGracefulRestart: set %d get %d", *set.JunosGracefulRestart, *get.JunosGracefulRestart)
+	}
+
+	if set.MaxEvpnRoutes != nil {
+		require.NotNil(t, get.MaxEvpnRoutes)
+		require.Equalf(t, *set.MaxEvpnRoutes, *get.MaxEvpnRoutes, "MaxEvpnRoutes: set %d get %d", *set.MaxEvpnRoutes, *get.MaxEvpnRoutes)
+	}
+
+	if set.MaxExternalRoutes != nil {
+		require.NotNil(t, get.MaxExternalRoutes)
+		require.Equalf(t, *set.MaxExternalRoutes, *get.MaxExternalRoutes, "MaxExternalRoutes: set %d get %d", *set.MaxExternalRoutes, *get.MaxExternalRoutes)
+	}
+
+	if set.MaxFabricRoutes != nil {
+		require.NotNil(t, get.MaxFabricRoutes)
+		require.Equalf(t, *set.MaxFabricRoutes, *get.MaxFabricRoutes, "MaxFabricRoutes: set %d get %d", *set.MaxFabricRoutes, *get.MaxFabricRoutes)
+	}
+
+	if set.MaxMlagRoutes != nil {
+		require.NotNil(t, get.MaxMlagRoutes)
+		require.Equalf(t, *set.MaxMlagRoutes, *get.MaxMlagRoutes, "MaxMlagRoutes: set %d get %d", *set.MaxMlagRoutes, *get.MaxMlagRoutes)
+	}
+
+	if set.OptimiseSzFootprint != nil && *set.OptimiseSzFootprint != *get.OptimiseSzFootprint {
+		t.Errorf("set OptimiseSzFootprint %s got %s", *set.OptimiseSzFootprint, *get.OptimiseSzFootprint)
+	}
+
+	// don't check overlay control protocol - it's an immutable value. attempts to set it have no effect.
+	//if set.OverlayControlProtocol != get.OverlayControlProtocol {
+	//	t.Errorf("set OverlayControlProtocol %s got %s", set.OverlayControlProtocol, get.OverlayControlProtocol)
+	//}
+}

--- a/internal/test_utils/context.go
+++ b/internal/test_utils/context.go
@@ -1,0 +1,48 @@
+// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package testutils
+
+import (
+	"context"
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/stretchr/testify/require"
+	"log"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// WrapCtxWithTestId produces contexts with the following values:
+// - Test-UUID: a uuid.UUID representing this test and all sub-tests.
+// - Test-ID: a string of the form uuid/test/subtest/subsubtest...
+// the Test-UUID is generated only if not found.
+// HTTP transactions related to these tests can be picked out from wireshark
+// using filters like:
+// - http.request.line contains "843a754c-cc35-4383-807f-833ad991e554"
+// - http.request.line contains "843a754c-cc35-4383-807f-833ad991e554/test/subtest"
+func WrapCtxWithTestId(t testing.TB, ctx context.Context) context.Context {
+	var UUID *uuid.UUID
+
+	switch v := ctx.Value(apstra.CtxKeyTestUUID).(type) {
+	case uuid.UUID:
+		UUID = &v
+	default:
+		UUID = ToPtr(newUUID(t))
+		ctx = context.WithValue(ctx, apstra.CtxKeyTestUUID, *UUID)
+		log.Println("Test UUID: ", UUID.String())
+	}
+
+	return context.WithValue(ctx, apstra.CtxKeyTestID, UUID.String()+"/"+t.Name())
+}
+
+func newUUID(t testing.TB) uuid.UUID {
+	t.Helper()
+
+	result, err := uuid.NewRandom()
+	require.NoError(t, err)
+	return result
+}

--- a/internal/test_utils/context.go
+++ b/internal/test_utils/context.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/stretchr/testify/require"
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 )
 
 // WrapCtxWithTestId produces contexts with the following values:

--- a/internal/test_utils/context.go
+++ b/internal/test_utils/context.go
@@ -8,11 +8,11 @@ package testutils
 
 import (
 	"context"
-	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/stretchr/testify/require"
 	"log"
 	"testing"
 
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/stretchr/testify/require"
 	"github.com/google/uuid"
 )
 

--- a/internal/test_utils/datacenter_test_objects/blueprints.go
+++ b/internal/test_utils/datacenter_test_objects/blueprints.go
@@ -1,0 +1,340 @@
+// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package dctestobj
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	testutils "github.com/Juniper/apstra-go-sdk/internal/test_utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlueprintA(t testing.TB, ctx context.Context, client *apstra.Client) *apstra.TwoStageL3ClosClient {
+	t.Helper()
+
+	bpId, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
+		RefDesign:  enum.RefDesignDatacenter,
+		Label:      testutils.RandString(5, "hex"),
+		TemplateId: "L3_Collapsed_ESI",
+	})
+	require.NoError(t, err)
+
+	bpClient, err := client.NewTwoStageL3ClosClient(ctx, bpId)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { require.NoError(t, client.DeleteBlueprint(ctx, bpId)) })
+
+	return bpClient
+}
+
+func TestBlueprintB(t testing.TB, ctx context.Context, client *apstra.Client) *apstra.TwoStageL3ClosClient {
+	t.Helper()
+
+	bpId, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
+		RefDesign:  enum.RefDesignDatacenter,
+		Label:      testutils.RandString(5, "hex"),
+		TemplateId: "L2_Virtual",
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() { require.NoError(t, client.DeleteBlueprint(ctx, bpId)) })
+
+	bpClient, err := client.NewTwoStageL3ClosClient(ctx, bpId)
+	require.NoError(t, err)
+
+	return bpClient
+}
+
+func TestBlueprintC(t testing.TB, ctx context.Context, client *apstra.Client) *apstra.TwoStageL3ClosClient {
+	t.Helper()
+
+	bpId, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
+		RefDesign:  enum.RefDesignDatacenter,
+		Label:      testutils.RandString(5, "hex"),
+		TemplateId: "L2_Virtual_EVPN",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.DeleteBlueprint(ctx, bpId)) })
+
+	bpClient, err := client.NewTwoStageL3ClosClient(ctx, bpId)
+	require.NoError(t, err)
+
+	return bpClient
+}
+
+func TestBlueprintD(t testing.TB, ctx context.Context, client *apstra.Client) *apstra.TwoStageL3ClosClient {
+	t.Helper()
+
+	bpId, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
+		RefDesign:  enum.RefDesignDatacenter,
+		Label:      testutils.RandString(5, "hex"),
+		TemplateId: "L2_Virtual_ESI_2x_Links",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, client.DeleteBlueprint(ctx, bpId))
+	})
+
+	bpClient, err := client.NewTwoStageL3ClosClient(ctx, bpId)
+	require.NoError(t, err)
+
+	query := new(apstra.PathQuery).
+		SetBlueprintId(bpId).
+		SetBlueprintType(apstra.BlueprintTypeStaging).
+		SetClient(client).
+		Node([]apstra.QEEAttribute{
+			apstra.NodeTypeSystem.QEEAttribute(),
+			{"system_type", apstra.QEStringVal("switch")},
+			{"role", apstra.QEStringVal("leaf")},
+			{"name", apstra.QEStringVal("n_leaf")},
+		})
+	var response struct {
+		Items []struct {
+			Leaf struct {
+				ID string `json:"id"`
+			} `json:"n_leaf"`
+		} `json:"items"`
+	}
+	require.NoError(t, query.Do(ctx, &response))
+
+	assignments := make(apstra.SystemIdToInterfaceMapAssignment)
+	for _, item := range response.Items {
+		assignments[item.Leaf.ID] = "Juniper_vQFX__AOS-7x10-Leaf"
+	}
+
+	require.NoError(t, bpClient.SetInterfaceMapAssignments(ctx, assignments))
+
+	return bpClient
+}
+
+func TestBlueprintE(t testing.TB, ctx context.Context, client *apstra.Client) *apstra.TwoStageL3ClosClient {
+	bpId, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
+		RefDesign:  enum.RefDesignDatacenter,
+		Label:      testutils.RandString(5, "hex"),
+		TemplateId: "L2_ESI_Access",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.DeleteBlueprint(ctx, bpId)) })
+
+	bpClient, err := client.NewTwoStageL3ClosClient(ctx, bpId)
+	require.NoError(t, err)
+
+	leafQuery := new(apstra.PathQuery).
+		SetBlueprintId(bpId).
+		SetBlueprintType(apstra.BlueprintTypeStaging).
+		SetClient(client).
+		Node([]apstra.QEEAttribute{
+			apstra.NodeTypeSystem.QEEAttribute(),
+			{"system_type", apstra.QEStringVal("switch")},
+			{"role", apstra.QEStringVal("leaf")},
+			{"name", apstra.QEStringVal("n_leaf")},
+		})
+	var leafResponse struct {
+		Items []struct {
+			Leaf struct {
+				ID string `json:"id"`
+			} `json:"n_leaf"`
+		} `json:"items"`
+	}
+	err = leafQuery.Do(ctx, &leafResponse)
+	require.NoError(t, err)
+
+	leafAssignements := make(apstra.SystemIdToInterfaceMapAssignment)
+	for _, item := range leafResponse.Items {
+		leafAssignements[item.Leaf.ID] = "Juniper_vQFX__AOS-7x10-Leaf"
+	}
+	err = bpClient.SetInterfaceMapAssignments(ctx, leafAssignements)
+	require.NoError(t, err)
+
+	accessQuery := new(apstra.PathQuery).
+		SetBlueprintId(bpId).
+		SetBlueprintType(apstra.BlueprintTypeStaging).
+		SetClient(client).
+		Node([]apstra.QEEAttribute{
+			apstra.NodeTypeSystem.QEEAttribute(),
+			{"system_type", apstra.QEStringVal("switch")},
+			{"role", apstra.QEStringVal("access")},
+			{"name", apstra.QEStringVal("n_access")},
+		})
+	var accessResponse struct {
+		Items []struct {
+			Leaf struct {
+				ID string `json:"id"`
+			} `json:"n_access"`
+		} `json:"items"`
+	}
+	require.NoError(t, accessQuery.Do(ctx, &accessResponse))
+
+	accessAssignements := make(apstra.SystemIdToInterfaceMapAssignment)
+	for _, item := range accessResponse.Items {
+		accessAssignements[item.Leaf.ID] = "Juniper_vQFX__AOS-8x10-1"
+	}
+	require.NoError(t, bpClient.SetInterfaceMapAssignments(ctx, accessAssignements))
+
+	return bpClient
+}
+
+func TestBlueprintF(t testing.TB, ctx context.Context, client *apstra.Client) *apstra.TwoStageL3ClosClient {
+	templateId := TestTemplateA(t, ctx, client)
+
+	bpId, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
+		RefDesign:  enum.RefDesignDatacenter,
+		Label:      testutils.RandString(5, "hex"),
+		TemplateId: templateId,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.DeleteBlueprint(ctx, bpId)) })
+
+	bpClient, err := client.NewTwoStageL3ClosClient(ctx, bpId)
+	require.NoError(t, err)
+
+	return bpClient
+}
+
+func TestBlueprintG(t testing.TB, ctx context.Context, client *apstra.Client) *apstra.TwoStageL3ClosClient {
+	t.Helper()
+
+	templateId := TestTemplateB(t, ctx, client)
+
+	bpId, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
+		RefDesign:  enum.RefDesignDatacenter,
+		Label:      testutils.RandString(5, "hex"),
+		TemplateId: templateId,
+		FabricSettings: &apstra.FabricSettings{
+			SpineSuperspineLinks: testutils.ToPtr(apstra.AddressingSchemeIp46),
+			SpineLeafLinks:       testutils.ToPtr(apstra.AddressingSchemeIp46),
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.DeleteBlueprint(ctx, bpId)) })
+
+	bpClient, err := client.NewTwoStageL3ClosClient(ctx, bpId)
+	require.NoError(t, err)
+
+	require.NoError(t, bpClient.SetFabricSettings(ctx, &apstra.FabricSettings{Ipv6Enabled: testutils.ToPtr(true)}))
+
+	return bpClient
+}
+
+// TestBlueprintH creates a test blueprint using client and returns a *TwoStageL3ClosClient.
+// The blueprint will use a dual-stack fabric and have ipv6 enabled.
+func TestBlueprintH(t testing.TB, ctx context.Context, client *apstra.Client) *apstra.TwoStageL3ClosClient {
+	t.Helper()
+
+	bpRequest := apstra.CreateBlueprintFromTemplateRequest{
+		RefDesign:  enum.RefDesignDatacenter,
+		Label:      testutils.RandString(5, "hex"),
+		TemplateId: "L2_Virtual_EVPN",
+		FabricSettings: &apstra.FabricSettings{
+			SpineSuperspineLinks: testutils.ToPtr(apstra.AddressingSchemeIp46),
+			SpineLeafLinks:       testutils.ToPtr(apstra.AddressingSchemeIp46),
+		},
+	}
+
+	bpId, err := client.CreateBlueprintFromTemplate(ctx, &bpRequest)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.DeleteBlueprint(ctx, bpId)) })
+
+	bpClient, err := client.NewTwoStageL3ClosClient(ctx, bpId)
+	require.NoError(t, err)
+
+	// enable IPv6
+	require.NoError(t, bpClient.SetFabricSettings(ctx, &apstra.FabricSettings{Ipv6Enabled: testutils.ToPtr(true)}))
+
+	return bpClient
+}
+
+// TestBlueprintI returns a collapsed fabric which has been committed and has no build errors
+func TestBlueprintI(t testing.TB, ctx context.Context, client *apstra.Client) *apstra.TwoStageL3ClosClient {
+	t.Helper()
+
+	bpId, err := client.CreateBlueprintFromTemplate(ctx, &apstra.CreateBlueprintFromTemplateRequest{
+		RefDesign:  enum.RefDesignDatacenter,
+		Label:      testutils.RandString(5, "hex"),
+		TemplateId: "L3_Collapsed_ESI",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.DeleteBlueprint(ctx, bpId)) })
+
+	bpClient, err := client.NewTwoStageL3ClosClient(ctx, bpId)
+	require.NoError(t, err)
+
+	// assign leaf interface maps
+	leafIds, err := testutils.GetSystemIdsByRole(ctx, bpClient, "leaf")
+	require.NoError(t, err)
+	mappings := make(apstra.SystemIdToInterfaceMapAssignment, len(leafIds))
+	for _, leafId := range leafIds {
+		mappings[leafId.String()] = "Juniper_vQFX__AOS-7x10-Leaf"
+	}
+	err = bpClient.SetInterfaceMapAssignments(ctx, mappings)
+	require.NoError(t, err)
+
+	// set leaf loopback pool
+	err = bpClient.SetResourceAllocation(ctx, &apstra.ResourceGroupAllocation{
+		ResourceGroup: apstra.ResourceGroup{
+			Type: apstra.ResourceTypeIp4Pool,
+			Name: apstra.ResourceGroupNameLeafIp4,
+		},
+		PoolIds: []apstra.ObjectId{"Private-10_0_0_0-8"},
+	})
+	require.NoError(t, err)
+
+	// set leaf-leaf pool
+	err = bpClient.SetResourceAllocation(ctx, &apstra.ResourceGroupAllocation{
+		ResourceGroup: apstra.ResourceGroup{
+			Type: apstra.ResourceTypeIp4Pool,
+			Name: apstra.ResourceGroupNameLeafLeafIp4,
+		},
+		PoolIds: []apstra.ObjectId{"Private-10_0_0_0-8"},
+	})
+	require.NoError(t, err)
+
+	// set leaf ASN pool
+	err = bpClient.SetResourceAllocation(ctx, &apstra.ResourceGroupAllocation{
+		ResourceGroup: apstra.ResourceGroup{
+			Type: apstra.ResourceTypeAsnPool,
+			Name: apstra.ResourceGroupNameLeafAsn,
+		},
+		PoolIds: []apstra.ObjectId{"Private-64512-65534"},
+	})
+	require.NoError(t, err)
+
+	// set VN VNI pool
+	err = bpClient.SetResourceAllocation(ctx, &apstra.ResourceGroupAllocation{
+		ResourceGroup: apstra.ResourceGroup{
+			Type: apstra.ResourceTypeVniPool,
+			Name: apstra.ResourceGroupNameEvpnL3Vni,
+		},
+		PoolIds: []apstra.ObjectId{"Default-10000-20000"},
+	})
+	require.NoError(t, err)
+
+	// set VN VNI pool
+	err = bpClient.SetResourceAllocation(ctx, &apstra.ResourceGroupAllocation{
+		ResourceGroup: apstra.ResourceGroup{
+			Type: apstra.ResourceTypeVniPool,
+			Name: apstra.ResourceGroupNameVxlanVnIds,
+		},
+		PoolIds: []apstra.ObjectId{"Default-10000-20000"},
+	})
+	require.NoError(t, err)
+
+	// commit
+	bpStatus, err := client.GetBlueprintStatus(ctx, bpClient.Id())
+	require.NoError(t, err)
+	_, err = client.DeployBlueprint(ctx, &apstra.BlueprintDeployRequest{
+		Id:          bpClient.Id(),
+		Description: "initial commit in test: " + t.Name(),
+		Version:     bpStatus.Version,
+	})
+	require.NoError(t, err)
+
+	return bpClient
+}

--- a/internal/test_utils/datacenter_test_objects/racks.go
+++ b/internal/test_utils/datacenter_test_objects/racks.go
@@ -8,11 +8,12 @@ package dctestobj
 
 import (
 	"context"
+	"testing"
+
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	testutils "github.com/Juniper/apstra-go-sdk/internal/test_utils"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestRackA(t testing.TB, ctx context.Context, client *apstra.Client) apstra.ObjectId {

--- a/internal/test_utils/datacenter_test_objects/racks.go
+++ b/internal/test_utils/datacenter_test_objects/racks.go
@@ -1,0 +1,41 @@
+// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package dctestobj
+
+import (
+	"context"
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	testutils "github.com/Juniper/apstra-go-sdk/internal/test_utils"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestRackA(t testing.TB, ctx context.Context, client *apstra.Client) apstra.ObjectId {
+	t.Helper()
+
+	request := apstra.RackTypeRequest{
+		DisplayName:              testutils.RandString(5, "hex"),
+		FabricConnectivityDesign: enum.FabricConnectivityDesignL3Clos,
+		LeafSwitches: []apstra.RackElementLeafSwitchRequest{
+			{
+				Label:             testutils.RandString(5, "hex"),
+				LinkPerSpineCount: 1,
+				LinkPerSpineSpeed: "40G",
+				LogicalDeviceId:   "AOS-48x10_6x40-1",
+			},
+		},
+	}
+
+	id, err := client.CreateRackType(ctx, &request)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, client.DeleteRackType(ctx, id))
+	})
+
+	return id
+}

--- a/internal/test_utils/datacenter_test_objects/security_zones.go
+++ b/internal/test_utils/datacenter_test_objects/security_zones.go
@@ -1,0 +1,36 @@
+// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package dctestobj
+
+import (
+	"context"
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	testutils "github.com/Juniper/apstra-go-sdk/internal/test_utils"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestSecurityZoneA(t testing.TB, ctx context.Context, bp *apstra.TwoStageL3ClosClient) apstra.ObjectId {
+	t.Helper()
+
+	rs := testutils.RandString(6, "hex")
+
+	id, err := bp.CreateSecurityZone(ctx, &apstra.SecurityZoneData{
+		Label:            rs,
+		SzType:           apstra.SecurityZoneTypeEVPN,
+		VrfName:          rs,
+		RoutingPolicyId:  "",
+		RouteTarget:      nil,
+		RtPolicy:         nil,
+		VlanId:           nil,
+		VniId:            nil,
+		JunosEvpnIrbMode: nil,
+	})
+	require.NoError(t, err)
+
+	return id
+}

--- a/internal/test_utils/datacenter_test_objects/security_zones.go
+++ b/internal/test_utils/datacenter_test_objects/security_zones.go
@@ -8,10 +8,11 @@ package dctestobj
 
 import (
 	"context"
+	"testing"
+
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	testutils "github.com/Juniper/apstra-go-sdk/internal/test_utils"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestSecurityZoneA(t testing.TB, ctx context.Context, bp *apstra.TwoStageL3ClosClient) apstra.ObjectId {

--- a/internal/test_utils/datacenter_test_objects/templates.go
+++ b/internal/test_utils/datacenter_test_objects/templates.go
@@ -8,10 +8,11 @@ package dctestobj
 
 import (
 	"context"
+	"testing"
+
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	testutils "github.com/Juniper/apstra-go-sdk/internal/test_utils"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestTemplateA(t testing.TB, ctx context.Context, client *apstra.Client) apstra.ObjectId {

--- a/internal/test_utils/datacenter_test_objects/templates.go
+++ b/internal/test_utils/datacenter_test_objects/templates.go
@@ -1,0 +1,82 @@
+// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package dctestobj
+
+import (
+	"context"
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	testutils "github.com/Juniper/apstra-go-sdk/internal/test_utils"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestTemplateA(t testing.TB, ctx context.Context, client *apstra.Client) apstra.ObjectId {
+	t.Helper()
+
+	rackId := TestRackA(t, ctx, client)
+
+	request := apstra.CreateRackBasedTemplateRequest{
+		DisplayName: testutils.RandString(5, "hex"),
+		Spine: &apstra.TemplateElementSpineRequest{
+			Count:         1,
+			LogicalDevice: "AOS-16x40-1",
+		},
+		RackInfos: map[apstra.ObjectId]apstra.TemplateRackBasedRackInfo{
+			rackId: {Count: 1},
+		},
+		AntiAffinityPolicy: &apstra.AntiAffinityPolicy{
+			Algorithm:                apstra.AlgorithmHeuristic,
+			MaxLinksPerPort:          1,
+			MaxLinksPerSlot:          1,
+			MaxPerSystemLinksPerPort: 1,
+			MaxPerSystemLinksPerSlot: 1,
+			Mode:                     apstra.AntiAffinityModeDisabled,
+		},
+		AsnAllocationPolicy:  &apstra.AsnAllocationPolicy{SpineAsnScheme: apstra.AsnAllocationSchemeDistinct},
+		VirtualNetworkPolicy: &apstra.VirtualNetworkPolicy{OverlayControlProtocol: apstra.OverlayControlProtocolEvpn},
+	}
+
+	id, err := client.CreateRackBasedTemplate(ctx, &request)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, client.DeleteTemplate(ctx, id))
+	})
+
+	return id
+}
+
+func TestTemplateB(t testing.TB, ctx context.Context, client *apstra.Client) apstra.ObjectId {
+	t.Helper()
+
+	rbt, err := client.GetRackBasedTemplate(ctx, "L2_Virtual")
+	require.NoError(t, err)
+
+	rbt.Data.DisplayName = testutils.RandString(5, "hex")
+	for k, v := range rbt.Data.RackInfo {
+		v.RackTypeData = nil
+		rbt.Data.RackInfo[k] = v
+	}
+
+	id, err := client.CreateRackBasedTemplate(ctx, &apstra.CreateRackBasedTemplateRequest{
+		DisplayName: rbt.Data.DisplayName,
+		Spine: &apstra.TemplateElementSpineRequest{
+			Count:                  rbt.Data.Spine.Count,
+			LinkPerSuperspineSpeed: rbt.Data.Spine.LinkPerSuperspineSpeed,
+			LogicalDevice:          "AOS-7x10-Spine",
+			LinkPerSuperspineCount: rbt.Data.Spine.LinkPerSuperspineCount,
+		},
+		RackInfos:            rbt.Data.RackInfo,
+		DhcpServiceIntent:    &rbt.Data.DhcpServiceIntent,
+		AntiAffinityPolicy:   rbt.Data.AntiAffinityPolicy,
+		AsnAllocationPolicy:  &rbt.Data.AsnAllocationPolicy,
+		VirtualNetworkPolicy: &rbt.Data.VirtualNetworkPolicy,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.DeleteTemplate(ctx, id)) })
+
+	return id
+}

--- a/internal/test_utils/datacenter_test_objects/virtual_networks.go
+++ b/internal/test_utils/datacenter_test_objects/virtual_networks.go
@@ -8,11 +8,12 @@ package dctestobj
 
 import (
 	"context"
+	"testing"
+
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 	testutils "github.com/Juniper/apstra-go-sdk/internal/test_utils"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestVirtualNetworkA(t testing.TB, ctx context.Context, bp *apstra.TwoStageL3ClosClient, szId apstra.ObjectId) apstra.ObjectId {

--- a/internal/test_utils/datacenter_test_objects/virtual_networks.go
+++ b/internal/test_utils/datacenter_test_objects/virtual_networks.go
@@ -1,0 +1,41 @@
+// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package dctestobj
+
+import (
+	"context"
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	testutils "github.com/Juniper/apstra-go-sdk/internal/test_utils"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestVirtualNetworkA(t testing.TB, ctx context.Context, bp *apstra.TwoStageL3ClosClient, szId apstra.ObjectId) apstra.ObjectId {
+	t.Helper()
+
+	leafIds, err := testutils.GetSystemIdsByRole(ctx, bp, "leaf")
+	require.NoError(t, err)
+
+	vnBindings := make([]apstra.VnBinding, len(leafIds))
+	for i, leafId := range leafIds {
+		vnBindings[i] = apstra.VnBinding{SystemId: leafId}
+	}
+
+	id, err := bp.CreateVirtualNetwork(ctx, &apstra.VirtualNetworkData{
+		Ipv4Enabled:               true,
+		Label:                     testutils.RandString(6, "hex"),
+		SecurityZoneId:            szId,
+		VirtualGatewayIpv4Enabled: true,
+		VnBindings:                vnBindings,
+		VnType:                    enum.VnTypeVxlan,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, bp.DeleteVirtualNetwork(ctx, id)) })
+
+	return id
+}

--- a/internal/test_utils/pointer.go
+++ b/internal/test_utils/pointer.go
@@ -1,0 +1,9 @@
+// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package testutils
+
+func ToPtr[A any](a A) *A {
+	return &a
+}

--- a/internal/test_utils/queries.go
+++ b/internal/test_utils/queries.go
@@ -8,6 +8,7 @@ package testutils
 
 import (
 	"context"
+
 	"github.com/Juniper/apstra-go-sdk/apstra"
 )
 

--- a/internal/test_utils/queries.go
+++ b/internal/test_utils/queries.go
@@ -1,0 +1,44 @@
+// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package testutils
+
+import (
+	"context"
+	"github.com/Juniper/apstra-go-sdk/apstra"
+)
+
+func GetSystemIdsByRole(ctx context.Context, bp *apstra.TwoStageL3ClosClient, role string) ([]apstra.ObjectId, error) {
+	leafQuery := new(apstra.PathQuery).
+		SetClient(bp.Client()).
+		SetBlueprintId(bp.Id()).
+		SetBlueprintType(apstra.BlueprintTypeStaging).
+		Node([]apstra.QEEAttribute{
+			apstra.NodeTypeSystem.QEEAttribute(),
+			{"role", apstra.QEStringVal(role)},
+			{"name", apstra.QEStringVal("n_system")},
+		})
+
+	var leafQueryResult struct {
+		Items []struct {
+			System struct {
+				Id apstra.ObjectId `json:"id"`
+			} `json:"n_system"`
+		} `json:"items"`
+	}
+
+	err := leafQuery.Do(ctx, &leafQueryResult)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]apstra.ObjectId, len(leafQueryResult.Items))
+	for i, item := range leafQueryResult.Items {
+		result[i] = item.System.Id
+	}
+
+	return result, nil
+}

--- a/internal/test_utils/test_client/client.go
+++ b/internal/test_utils/test_client/client.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const envApstraExperimental = "APSTRA_EXPERIMENTAL"
+const EnvApstraExperimental = "APSTRA_EXPERIMENTAL"
 
 type testClientConfig interface {
 	clientConfig() apstra.ClientCfg
@@ -66,7 +66,7 @@ func GetTestClients(t testing.TB, ctx context.Context) []TestClient {
 		return testClients
 	}
 
-	experimental, err := strconv.ParseBool(os.Getenv(envApstraExperimental))
+	experimental, err := strconv.ParseBool(os.Getenv(EnvApstraExperimental))
 	require.NoError(t, err)
 
 	// create logfile


### PR DESCRIPTION
First example of converting an existing test to use packages with new test functions.

This work needs to be done one-file-at-a-time because the package name in the test file changes from `apstra` to `apstra_test` to avoid import cycles.

Depends on #550 - there's little reason to look at this one until that one is merged.

Tested with 4.2.0 and 6.0.0 - needs further testing.