### PR TITLE
More test migrations

### DIFF
--- a/apstra/api_design_templates.go
+++ b/apstra/api_design_templates.go
@@ -65,14 +65,16 @@ const (
 	TemplateTypeRackBased = TemplateType(iota)
 	TemplateTypePodBased
 	TemplateTypeL3Collapsed
+	TemplateTypeRailCollapsed
 	TemplateTypeNone
 	TemplateTypeUnknown = "unknown template type '%s'"
 
-	templateTypeRackBased   = templateType("rack_based")
-	templateTypePodBased    = templateType("pod_based")
-	templateTypeL3Collapsed = templateType("l3_collapsed")
-	templateTypeNone        = templateType("")
-	templateTypeUnknown     = "unknown template type '%d'"
+	templateTypeRackBased     = templateType("rack_based")
+	templateTypePodBased      = templateType("pod_based")
+	templateTypeL3Collapsed   = templateType("l3_collapsed")
+	templateTypeRailCollapsed = templateType("rail_collapsed")
+	templateTypeNone          = templateType("")
+	templateTypeUnknown       = "unknown template type '%d'"
 )
 
 const (
@@ -539,6 +541,8 @@ func (o *template) polish() (Template, error) {
 			return nil, err
 		}
 		return t.polish()
+	case templateTypeRailCollapsed:
+		return nil, nil // todo: not currently supported
 	}
 	return nil, fmt.Errorf(TemplateTypeUnknown, t)
 }

--- a/apstra/api_design_templates_integration_test.go
+++ b/apstra/api_design_templates_integration_test.go
@@ -4,346 +4,292 @@
 
 //go:build integration
 
-package apstra
+package apstra_test
 
 import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/stretchr/testify/require"
 	"log"
 	"math/rand"
 	"strings"
 	"testing"
+
+	testutils "github.com/Juniper/apstra-go-sdk/internal/test_utils"
+	testclient "github.com/Juniper/apstra-go-sdk/internal/test_utils/test_client"
 )
 
 func TestGetTemplate(t *testing.T) {
-	clients, err := getTestClients(context.Background(), t)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ctx := testutils.WrapCtxWithTestId(t, context.Background())
+	clients := testclient.GetTestClients(t, ctx)
 
-	for clientName, client := range clients {
-		log.Printf("testing listAllTemplateIds() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		templateIds, err := client.client.listAllTemplateIds(context.TODO())
-		if err != nil {
-			t.Fatal(err)
-		}
-		log.Printf("fetching %d templateIds...", len(templateIds))
+	for _, client := range clients {
+		t.Run(client.Name(), func(t *testing.T) {
+			t.Parallel()
+			ctx = testutils.WrapCtxWithTestId(t, ctx)
 
-		for _, i := range sampleIndexes(t, len(templateIds)) {
-			templateId := templateIds[i]
-			log.Printf("testing getTemplate(%s) against %s %s (%s)", templateId, client.clientType, clientName, client.client.ApiVersion())
-			x, err := client.client.getTemplate(context.TODO(), templateId)
-			if err != nil {
-				t.Fatal(err)
-			}
+			templateIds, err := client.Client.ListAllTemplateIds(ctx)
+			require.NoError(t, err)
 
-			var name string
-			tType, err := x.templateType()
-			if err != nil {
-				t.Fatal(err)
-			}
-			switch tType {
-			case templateTypeRackBased:
-				rbt := &rawTemplateRackBased{}
-				err = json.Unmarshal(x, rbt)
-				if err != nil {
-					t.Fatal(err)
-				}
-				name = rbt.DisplayName
-				rbt2, err := client.client.GetRackBasedTemplate(context.TODO(), templateId)
-				if err != nil {
-					t.Fatal(err)
-				}
-				if templateId != rbt2.Id {
-					t.Fatalf("template ID mismatch: '%s' vs. '%s", templateId, rbt2.Id)
-				}
-				if name != rbt2.Data.DisplayName {
-					t.Fatalf("template ID mismatch: '%s' vs. '%s", name, rbt2.Data.DisplayName)
-				}
-			case templateTypePodBased:
-				rbt := &rawTemplatePodBased{}
-				err = json.Unmarshal(x, rbt)
-				if err != nil {
-					t.Fatal(err)
-				}
-				name = rbt.DisplayName
-				rbt2, err := client.client.GetPodBasedTemplate(context.TODO(), templateId)
-				if err != nil {
-					t.Fatal(err)
-				}
-				if templateId != rbt2.Id {
-					t.Fatalf("template ID mismatch: '%s' vs. '%s", templateId, rbt2.Id)
-				}
-				if name != rbt2.Data.DisplayName {
-					t.Fatalf("template ID mismatch: '%s' vs. '%s", name, rbt2.Data.DisplayName)
-				}
-			case templateTypeL3Collapsed:
-				rbt := &rawTemplateL3Collapsed{}
-				err = json.Unmarshal(x, rbt)
-				if err != nil {
-					t.Fatal(err)
-				}
-				name = rbt.DisplayName
-				rbt2, err := client.client.GetL3CollapsedTemplate(context.TODO(), templateId)
-				if err != nil {
-					t.Fatal(err)
-				}
-				if templateId != rbt2.Id {
-					t.Fatalf("template ID mismatch: '%s' vs. '%s", templateId, rbt2.Id)
-				}
-				if name != rbt2.Data.DisplayName {
-					t.Fatalf("template ID mismatch: '%s' vs. '%s", name, rbt2.Data.DisplayName)
+			templates, err := client.Client.GetAllTemplates(ctx)
+			require.NoError(t, err)
+
+			require.Equal(t, len(templateIds), len(templates))
+
+			log.Printf("fetching %d templateIds...", len(templates))
+
+			for _, i := range testutils.SampleIndexes(t, len(templates)) {
+				switch templates[i].Type() {
+				case apstra.TemplateTypeRackBased:
+					template, err := client.Client.GetRackBasedTemplate(ctx, templates[i].ID())
+					require.NoError(t, err)
+					require.Equal(t, templates[i].ID(), template.ID())
+				case apstra.TemplateTypePodBased:
+					template, err := client.Client.GetPodBasedTemplate(ctx, templates[i].ID())
+					require.NoError(t, err)
+					require.Equal(t, templates[i].ID(), template.ID())
+				case apstra.TemplateTypeL3Collapsed:
+					template, err := client.Client.GetL3CollapsedTemplate(ctx, templates[i].ID())
+					require.NoError(t, err)
+					require.Equal(t, templates[i].ID(), template.ID())
+				default:
+					tt := templates[i].Type()
+					t.Fatalf("unknown template type: %d (%s)", tt, tt)
 				}
 			}
-			log.Printf("template '%s' '%s'", templateId, name)
-		}
+		})
 	}
 }
 
 func TestGetTemplateMethods(t *testing.T) {
+	ctx := testutils.WrapCtxWithTestId(t, context.Background())
+	clients := testclient.GetTestClients(t, ctx)
+
 	var n int
 
-	clients, err := getTestClients(context.Background(), t)
-	if err != nil {
-		t.Fatal(err)
-	}
+	for _, client := range clients {
+		t.Run(client.Name(), func(t *testing.T) {
+			t.Parallel()
+			ctx = testutils.WrapCtxWithTestId(t, ctx)
 
-	for clientName, client := range clients {
-		log.Printf("testing getAllTemplates() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		templates, err := client.client.getAllTemplates(context.TODO())
-		if err != nil {
-			t.Fatal(err)
-		}
+			templates, err := client.Client.GetAllTemplates(ctx)
+			require.NoError(t, err)
+			log.Printf("got %d templates", len(templates))
 
-		log.Printf("got %d templates", len(templates))
+			// rack-based templates
+			rackBasedTemplates, err := client.Client.GetAllRackBasedTemplates(ctx)
+			require.NoError(t, err)
+			log.Printf("    got %d rack-based templates\n", len(rackBasedTemplates))
 
-		// rack-based templates
-		log.Printf("testing getAllRackBasedTemplates() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		rackBasedTemplates, err := client.client.getAllRackBasedTemplates(context.TODO())
-		if err != nil {
-			t.Fatal(err)
-		}
-		log.Printf("    got %d rack-based templates\n", len(rackBasedTemplates))
+			n = rand.Intn(len(rackBasedTemplates))
+			log.Printf("  using randomly-selected index %d from the %d available\n", n, len(rackBasedTemplates))
+			rackBasedTemplate, err := client.Client.GetRackBasedTemplate(ctx, rackBasedTemplates[n].Id)
+			require.NoError(t, err)
+			log.Printf("    got template type '%s', ID '%s'\n", rackBasedTemplate.Type, rackBasedTemplate.Id)
 
-		n = rand.Intn(len(rackBasedTemplates))
-		log.Printf("testing getRackBasedTemplate() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		log.Printf("  using randomly-selected index %d from the %d available\n", n, len(rackBasedTemplates))
-		rackBasedTemplate, err := client.client.getRackBasedTemplate(context.TODO(), rackBasedTemplates[n].Id)
-		if err != nil {
-			t.Fatal(err)
-		}
-		log.Printf("    got template type '%s', ID '%s'\n", rackBasedTemplate.Type, rackBasedTemplate.Id)
+			// pod-based templates
+			podBasedTemplates, err := client.Client.GetAllPodBasedTemplates(ctx)
+			require.NoError(t, err)
+			log.Printf("    got %d pod-based templates\n", len(podBasedTemplates))
 
-		// pod-based templates
-		log.Printf("testing getAllPodBasedTemplates() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		podBasedTemplates, err := client.client.getAllPodBasedTemplates(context.TODO())
-		if err != nil {
-			t.Fatal(err)
-		}
-		log.Printf("    got %d pod-based templates\n", len(podBasedTemplates))
+			n = rand.Intn(len(podBasedTemplates))
+			log.Printf("  using randomly-selected index %d from the %d available\n", n, len(podBasedTemplates))
+			podBasedTemplate, err := client.Client.GetPodBasedTemplate(ctx, podBasedTemplates[n].Id)
+			require.NoError(t, err)
+			log.Printf("    got template type '%s', ID '%s'\n", podBasedTemplate.Type, podBasedTemplate.Id)
 
-		n = rand.Intn(len(podBasedTemplates))
-		log.Printf("testing getPodBasedTemplate() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		log.Printf("  using randomly-selected index %d from the %d available\n", n, len(podBasedTemplates))
-		podBasedTemplate, err := client.client.getPodBasedTemplate(context.TODO(), podBasedTemplates[n].Id)
-		if err != nil {
-			t.Fatal(err)
-		}
-		log.Printf("    got template type '%s', ID '%s'\n", podBasedTemplate.Type, podBasedTemplate.Id)
+			// l3-collapsed templates
+			l3CollapsedTemplates, err := client.Client.GetAllL3CollapsedTemplates(ctx)
+			require.NoError(t, err)
+			log.Printf("  got %d pod-based templates\n", len(l3CollapsedTemplates))
 
-		// l3-collapsed templates
-		log.Printf("testing getAllL3CollapsedTemplates() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		l3CollapsedTemplates, err := client.client.getAllL3CollapsedTemplates(context.TODO())
-		if err != nil {
-			t.Fatal(err)
-		}
-		log.Printf("  got %d pod-based templates\n", len(l3CollapsedTemplates))
+			n = rand.Intn(len(l3CollapsedTemplates))
+			log.Printf("  using randomly-selected index %d from the %d available\n", n, len(l3CollapsedTemplates))
+			l3CollapsedTemplate, err := client.Client.GetL3CollapsedTemplate(ctx, l3CollapsedTemplates[n].Id)
+			require.NoError(t, err)
+			log.Printf("    got template type '%s', ID '%s'\n", l3CollapsedTemplate.Type(), l3CollapsedTemplate.Id)
 
-		n = rand.Intn(len(l3CollapsedTemplates))
-		log.Printf("testing getL3CollapsedTemplate() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		log.Printf("  using randomly-selected index %d from the %d available\n", n, len(l3CollapsedTemplates))
-		l3CollapsedTemplate, err := client.client.getL3CollapsedTemplate(context.TODO(), l3CollapsedTemplates[n].Id)
-		if err != nil {
-			t.Fatal(err)
-		}
-		log.Printf("    got template type '%s', ID '%s'\n", l3CollapsedTemplate.Type, l3CollapsedTemplate.Id)
+			require.Equal(t, len(templates), len(rackBasedTemplates), len(l3CollapsedTemplates)+len(podBasedTemplates)+len(l3CollapsedTemplates))
+		})
 	}
 }
 
 func TestGetTemplateType(t *testing.T) {
-	ctx := context.Background()
-
-	clients, err := getTestClients(ctx, t)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ctx := testutils.WrapCtxWithTestId(t, context.Background())
+	clients := testclient.GetTestClients(t, ctx)
 
 	type testData struct {
-		templateId   ObjectId
-		templateType templateType
+		templateId   apstra.ObjectId
+		templateType apstra.TemplateType
 	}
 
 	data := []testData{
-		{"pod1", templateTypeRackBased},
-		{"L2_superspine_multi_plane", templateTypePodBased},
-		{"L3_Collapsed_ACS", templateTypeL3Collapsed},
+		{"pod1", apstra.TemplateTypeRackBased},
+		{"L2_superspine_multi_plane", apstra.TemplateTypePodBased},
+		{"L3_Collapsed_ACS", apstra.TemplateTypeL3Collapsed},
 	}
 
-	for clientName, client := range clients {
-		for _, d := range data {
-			log.Printf("testing getTemplateType(%s) against %s %s (%s)", d.templateType, client.clientType, clientName, client.client.ApiVersion())
-			ttype, err := client.client.getTemplateType(ctx, d.templateId)
-			if err != nil {
-				t.Fatal(err)
+	for _, client := range clients {
+		t.Run(client.Name(), func(t *testing.T) {
+			t.Parallel()
+			ctx = testutils.WrapCtxWithTestId(t, ctx)
+
+			for _, d := range data {
+				t.Run(d.templateId.String(), func(t *testing.T) {
+					t.Parallel()
+					ctx = testutils.WrapCtxWithTestId(t, ctx)
+
+					ttype, err := client.Client.GetTemplateType(ctx, d.templateId)
+					require.NoError(t, err)
+					require.Equal(t, d.templateType, ttype)
+				})
 			}
-			if ttype != d.templateType {
-				t.Fatalf("expected '%s', got '%s'", ttype.string(), d.templateType)
-			}
-		}
+		})
 	}
 }
 
 func TestGetTemplateIdsTypesByName(t *testing.T) {
-	ctx := context.Background()
+	ctx := testutils.WrapCtxWithTestId(t, context.Background())
+	clients := testclient.GetTestClients(t, ctx)
 
-	clients, err := getTestClients(ctx, t)
-	if err != nil {
-		t.Fatal(err)
-	}
+	templateName := testutils.RandString(10, "hex")
+	for _, client := range clients {
+		t.Run(client.Name(), func(t *testing.T) {
+			t.Parallel()
+			ctx = testutils.WrapCtxWithTestId(t, ctx)
 
-	templateName := randString(10, "hex")
-	for clientName, client := range clients {
-		// fetch all template IDs
-		templateIds, err := client.client.listAllTemplateIds(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
+			// fetch all template IDs
+			templateIds, err := client.Client.ListAllTemplateIds(ctx)
+			require.NoError(t, err)
 
-		// choose a random template for cloning
-		cloneMeId := templateIds[rand.Intn(len(templateIds))]
-		cloneMeType, err := client.client.getTemplateType(ctx, cloneMeId)
-		if err != nil {
-			t.Fatal(err)
-		}
+			// choose a random template for cloning
+			cloneMeId := templateIds[rand.Intn(len(templateIds))]
+			cloneMeType, err := client.Client.GetTemplateType(ctx, cloneMeId)
+			require.NoError(t, err)
 
-		log.Printf("cloning template '%s' (%s) for this test", cloneMeId, cloneMeType)
+			log.Printf("cloning template '%s' (%s) for this test", cloneMeId, cloneMeType)
 
-		cloneCount := rand.Intn(5) + 2
-		cloneIds := make([]ObjectId, cloneCount)
-		for i := 0; i < cloneCount; i++ {
-			switch cloneMeType {
-			case templateTypeRackBased:
-				cloneMe, err := client.client.getRackBasedTemplate(ctx, cloneMeId)
+			cloneCount := rand.Intn(5) + 2
+			cloneIds := make([]apstra.ObjectId, cloneCount)
+			for i := 0; i < cloneCount; i++ {
+				switch cloneMeType {
+				case apstra.TemplateTypeRackBased:
+					cloneMe, err := client.Client.GetRackBasedTemplate(ctx, cloneMeId)
+					if err != nil {
+						t.Fatal(err)
+					}
+					id, err := client.Client.CreateRackBasedTemplate(ctx, &apstra.CreateRackBasedTemplateRequest{
+						DisplayName: fmt.Sprintf("%s-%d", templateName, i),
+						Spine: &apstra.TemplateElementSpineRequest{
+							Count:                  cloneMe.Data.Spine.Count,
+							LinkPerSuperspineSpeed: cloneMe.Data.Spine.LinkPerSuperspineSpeed,
+							LogicalDevice:          cloneMe.Data.Spine.LogicalDevice,
+							LinkPerSuperspineCount: 0,
+							Tags:                   nil,
+						},
+						RackTypes:            cloneMe.Data.RackTypes,
+						RackTypeCounts:       cloneMe.Data.RackTypeCounts,
+						DhcpServiceIntent:    cloneMe.Data.DhcpServiceIntent,
+						AntiAffinityPolicy:   cloneMe.Data.AntiAffinityPolicy,
+						AsnAllocationPolicy:  cloneMe.Data.AsnAllocationPolicy,
+						VirtualNetworkPolicy: cloneMe.Data.VirtualNetworkPolicy,
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					cloneIds[i] = id
+				case apstra.TemplateTypePodBased:
+					cloneMe, err := client.Client.GetPodBasedTemplate(ctx, cloneMeId)
+					if err != nil {
+						t.Fatal(err)
+					}
+					id, err := client.Client.CreatePodBasedTemplate(ctx, &apstra.CreatePodBasedTemplateRequest{
+						DisplayName:             fmt.Sprintf("%s-%d", templateName, i),
+						Superspine:              cloneMe.Superspine,
+						RackBasedTemplates:      cloneMe.RackBasedTemplates,
+						RackBasedTemplateCounts: cloneMe.RackBasedTemplateCounts,
+						AntiAffinityPolicy:      cloneMe.AntiAffinityPolicy,
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					cloneIds[i] = id
+				case apstra.TemplateTypeL3Collapsed:
+					cloneMe, err := client.Client.GetL3CollapsedTemplate(ctx, cloneMeId)
+					if err != nil {
+						t.Fatal(err)
+					}
+					id, err := client.Client.CreateL3CollapsedTemplate(ctx, &apstra.CreateL3CollapsedTemplateRequest{
+						DisplayName:          fmt.Sprintf("%s-%d", templateName, i),
+						MeshLinkCount:        cloneMe.MeshLinkCount,
+						MeshLinkSpeed:        *cloneMe.MeshLinkSpeed,
+						RackTypes:            cloneMe.RackTypes,
+						RackTypeCounts:       cloneMe.RackTypeCounts,
+						DhcpServiceIntent:    cloneMe.DhcpServiceIntent,
+						AntiAffinityPolicy:   cloneMe.AntiAffinityPolicy,
+						VirtualNetworkPolicy: cloneMe.VirtualNetworkPolicy,
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					cloneIds[i] = id
+				}
+			}
+			clones := make([]string, len(cloneIds))
+			for i, clone := range cloneIds {
+				clones[i] = string(clone)
+			}
+			log.Printf("clone IDs: '%s'", strings.Join(clones, ", "))
+
+			templateIdsToType := make(map[ObjectId]TemplateType)
+			for i := 0; i < cloneCount; i++ {
+				log.Printf("testing getTemplateIdsTypesByName(%s) against %s %s (%s)", templateName, client.ClientType, clientName, client.Client.ApiVersion())
+				temp, err := client.Client.getTemplateIdsTypesByName(ctx, fmt.Sprintf("%s-%d", templateName, i))
 				if err != nil {
 					t.Fatal(err)
 				}
-				id, err := client.client.createRackBasedTemplate(ctx, &rawCreateRackBasedTemplateRequest{
-					Type:                 cloneMe.Type,
-					DisplayName:          fmt.Sprintf("%s-%d", templateName, i),
-					Spine:                cloneMe.Spine,
-					RackTypes:            cloneMe.RackTypes,
-					RackTypeCounts:       cloneMe.RackTypeCounts,
-					DhcpServiceIntent:    cloneMe.DhcpServiceIntent,
-					AntiAffinityPolicy:   cloneMe.AntiAffinityPolicy,
-					AsnAllocationPolicy:  cloneMe.AsnAllocationPolicy,
-					VirtualNetworkPolicy: cloneMe.VirtualNetworkPolicy,
-				})
-				if err != nil {
-					t.Fatal(err)
+				for k, v := range temp {
+					templateIdsToType[k] = v
 				}
-				cloneIds[i] = id
-			case templateTypePodBased:
-				cloneMe, err := client.client.getPodBasedTemplate(ctx, cloneMeId)
-				if err != nil {
-					t.Fatal(err)
-				}
-				id, err := client.client.createPodBasedTemplate(ctx, &rawCreatePodBasedTemplateRequest{
-					Type:                    cloneMe.Type,
-					DisplayName:             fmt.Sprintf("%s-%d", templateName, i),
-					Superspine:              cloneMe.Superspine,
-					RackBasedTemplates:      cloneMe.RackBasedTemplates,
-					RackBasedTemplateCounts: cloneMe.RackBasedTemplateCounts,
-					AntiAffinityPolicy:      cloneMe.AntiAffinityPolicy,
-				})
-				if err != nil {
-					t.Fatal(err)
-				}
-				cloneIds[i] = id
-			case templateTypeL3Collapsed:
-				cloneMe, err := client.client.getL3CollapsedTemplate(ctx, cloneMeId)
-				if err != nil {
-					t.Fatal(err)
-				}
-				id, err := client.client.createL3CollapsedTemplate(ctx, &rawCreateL3CollapsedTemplateRequest{
-					Type:                 cloneMe.Type,
-					DisplayName:          fmt.Sprintf("%s-%d", templateName, i),
-					MeshLinkCount:        cloneMe.MeshLinkCount,
-					MeshLinkSpeed:        *cloneMe.MeshLinkSpeed,
-					RackTypes:            cloneMe.RackTypes,
-					RackTypeCounts:       cloneMe.RackTypeCounts,
-					DhcpServiceIntent:    cloneMe.DhcpServiceIntent,
-					AntiAffinityPolicy:   cloneMe.AntiAffinityPolicy,
-					VirtualNetworkPolicy: cloneMe.VirtualNetworkPolicy,
-				})
-				if err != nil {
-					t.Fatal(err)
-				}
-				cloneIds[i] = id
 			}
-		}
-		clones := make([]string, len(cloneIds))
-		for i, clone := range cloneIds {
-			clones[i] = string(clone)
-		}
-		log.Printf("clone IDs: '%s'", strings.Join(clones, ", "))
 
-		templateIdsToType := make(map[ObjectId]TemplateType)
-		for i := 0; i < cloneCount; i++ {
-			log.Printf("testing getTemplateIdsTypesByName(%s) against %s %s (%s)", templateName, client.clientType, clientName, client.client.ApiVersion())
-			temp, err := client.client.getTemplateIdsTypesByName(ctx, fmt.Sprintf("%s-%d", templateName, i))
-			if err != nil {
-				t.Fatal(err)
+			if cloneCount != len(templateIdsToType) {
+				t.Fatalf("expected %d, got %d", cloneCount, len(templateIdsToType))
 			}
-			for k, v := range temp {
-				templateIdsToType[k] = v
-			}
-		}
-
-		if cloneCount != len(templateIdsToType) {
-			t.Fatalf("expected %d, got %d", cloneCount, len(templateIdsToType))
-		}
-		for _, v := range templateIdsToType {
-			parsed, err := cloneMeType.parse()
-			if err != nil {
-				t.Fatal(err)
-			}
-			if parsed != v.Int() {
-				t.Fatalf("expected %d, got %d", parsed, v.Int())
-			}
-		}
-
-		for i, cloneId := range cloneIds {
-			name := fmt.Sprintf("%s-%d", templateName, i)
-			if i+1 == len(cloneIds) { // last one before they're all deleted
-				log.Printf("testing getTemplateIdTypeByName(%s) against %s %s (%s)", name, client.clientType, clientName, client.client.ApiVersion())
-				tId, tType, err := client.client.getTemplateIdTypeByName(ctx, name)
+			for _, v := range templateIdsToType {
+				parsed, err := cloneMeType.parse()
 				if err != nil {
 					t.Fatal(err)
 				}
-				if cloneId != tId {
-					t.Fatalf("expected template id '%s', got '%s'", cloneIds, tId)
+				if parsed != v.Int() {
+					t.Fatalf("expected %d, got %d", parsed, v.Int())
 				}
-				if cloneMeType != templateType(tType.String()) {
-					t.Fatalf("expected template type '%s', got '%s'", cloneMeType, tType.String())
-				}
+			}
 
+			for i, cloneId := range cloneIds {
+				name := fmt.Sprintf("%s-%d", templateName, i)
+				if i+1 == len(cloneIds) { // last one before they're all deleted
+					log.Printf("testing getTemplateIdTypeByName(%s) against %s %s (%s)", name, client.ClientType, clientName, client.Client.ApiVersion())
+					tId, tType, err := client.Client.getTemplateIdTypeByName(ctx, name)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if cloneId != tId {
+						t.Fatalf("expected template id '%s', got '%s'", cloneIds, tId)
+					}
+					if cloneMeType != templateType(tType.String()) {
+						t.Fatalf("expected template type '%s', got '%s'", cloneMeType, tType.String())
+					}
+
+				}
+				log.Printf("deleting clone '%s'", cloneId)
+				err = client.Client.DeleteTemplate(ctx, cloneId)
+				if err != nil {
+					t.Fatal(err)
+				}
 			}
-			log.Printf("deleting clone '%s'", cloneId)
-			err = client.client.deleteTemplate(ctx, cloneId)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}
+		})
 	}
 }

--- a/apstra/api_design_templates_integration_test.go
+++ b/apstra/api_design_templates_integration_test.go
@@ -13,9 +13,9 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
-	"github.com/stretchr/testify/require"
 	testutils "github.com/Juniper/apstra-go-sdk/internal/test_utils"
 	testclient "github.com/Juniper/apstra-go-sdk/internal/test_utils/test_client"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetTemplate(t *testing.T) {

--- a/apstra/api_design_templates_pod_based_integration_test.go
+++ b/apstra/api_design_templates_pod_based_integration_test.go
@@ -4,126 +4,108 @@
 
 //go:build integration
 
-package apstra
+package apstra_test
 
 import (
 	"context"
-	"log"
 	"testing"
+
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	testutils "github.com/Juniper/apstra-go-sdk/internal/test_utils"
+	testclient "github.com/Juniper/apstra-go-sdk/internal/test_utils/test_client"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateGetDeletePodBasedTemplate(t *testing.T) {
-	ctx := context.Background()
+	ctx := testutils.WrapCtxWithTestId(t, context.Background())
+	clients := testclient.GetTestClients(t, ctx)
 
-	clients, err := getTestClients(ctx, t)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	dn := randString(5, "hex")
+	dn := testutils.RandString(5, "hex")
 
 	rbtdn := "rbtr-" + dn
-	rbtr := CreateRackBasedTemplateRequest{
+	rbtr := apstra.CreateRackBasedTemplateRequest{
 		DisplayName: rbtdn,
-		Spine: &TemplateElementSpineRequest{
+		Spine: &apstra.TemplateElementSpineRequest{
 			Count:                  2,
 			LinkPerSuperspineSpeed: "10G",
 			LogicalDevice:          "AOS-7x10-Spine",
 			LinkPerSuperspineCount: 1,
 			Tags:                   nil,
 		},
-		RackInfos: map[ObjectId]TemplateRackBasedRackInfo{
+		RackInfos: map[apstra.ObjectId]apstra.TemplateRackBasedRackInfo{
 			"access_switch": {
 				Count: 1,
 			},
 		},
-		DhcpServiceIntent:    &DhcpServiceIntent{Active: true},
-		AntiAffinityPolicy:   &AntiAffinityPolicy{Algorithm: AlgorithmHeuristic},
-		AsnAllocationPolicy:  &AsnAllocationPolicy{SpineAsnScheme: AsnAllocationSchemeSingle},
-		VirtualNetworkPolicy: &VirtualNetworkPolicy{},
+		DhcpServiceIntent:    &apstra.DhcpServiceIntent{Active: true},
+		AntiAffinityPolicy:   &apstra.AntiAffinityPolicy{Algorithm: apstra.AlgorithmHeuristic},
+		AsnAllocationPolicy:  &apstra.AsnAllocationPolicy{SpineAsnScheme: apstra.AsnAllocationSchemeSingle},
+		VirtualNetworkPolicy: &apstra.VirtualNetworkPolicy{},
 	}
 
-	for clientName, client := range clients {
-		log.Printf("testing CreateRackBasedTemplate() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		rbtid, err := client.client.CreateRackBasedTemplate(ctx, &rbtr)
-		if err != nil {
-			t.Fatal(err)
-		}
+	for _, client := range clients {
+		t.Run(client.Name(), func(t *testing.T) {
+			t.Parallel()
+			ctx := testutils.WrapCtxWithTestId(t, ctx)
 
-		pbtdn := "pbtr-" + dn
-		pbtr := CreatePodBasedTemplateRequest{
-			DisplayName: pbtdn,
-			Superspine: &TemplateElementSuperspineRequest{
-				PlaneCount:         1,
-				Tags:               nil,
-				SuperspinePerPlane: 4,
-				LogicalDeviceId:    "AOS-4x40_8x10-1",
-			},
-			PodInfos: map[ObjectId]TemplatePodBasedInfo{
-				rbtid: {
-					Count: 1,
+			rbtid, err := client.Client.CreateRackBasedTemplate(ctx, &rbtr)
+			require.NoError(t, err)
+
+			pbtdn := "pbtr-" + dn
+			pbtr := apstra.CreatePodBasedTemplateRequest{
+				DisplayName: pbtdn,
+				Superspine: &apstra.TemplateElementSuperspineRequest{
+					PlaneCount:         1,
+					Tags:               nil,
+					SuperspinePerPlane: 4,
+					LogicalDeviceId:    "AOS-4x40_8x10-1",
 				},
-			},
-			AntiAffinityPolicy: &AntiAffinityPolicy{
-				Algorithm:                AlgorithmHeuristic,
-				MaxLinksPerPort:          1,
-				MaxLinksPerSlot:          1,
-				MaxPerSystemLinksPerPort: 1,
-				MaxPerSystemLinksPerSlot: 1,
-				Mode:                     AntiAffinityModeDisabled,
-			},
-		}
+				PodInfos: map[apstra.ObjectId]apstra.TemplatePodBasedInfo{
+					rbtid: {
+						Count: 1,
+					},
+				},
+				AntiAffinityPolicy: &apstra.AntiAffinityPolicy{
+					Algorithm:                apstra.AlgorithmHeuristic,
+					MaxLinksPerPort:          1,
+					MaxLinksPerSlot:          1,
+					MaxPerSystemLinksPerPort: 1,
+					MaxPerSystemLinksPerSlot: 1,
+					Mode:                     apstra.AntiAffinityModeDisabled,
+				},
+			}
 
-		log.Printf("testing CreatePodBasedTemplate() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		pbtid, err := client.client.CreatePodBasedTemplate(ctx, &pbtr)
-		if err != nil {
-			t.Fatal(err)
-		}
+			pbtid, err := client.Client.CreatePodBasedTemplate(ctx, &pbtr)
+			require.NoError(t, err)
 
-		log.Printf("testing GetPodBasedTemplate() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		pbt, err := client.client.GetPodBasedTemplate(ctx, pbtid)
-		if err != nil {
-			t.Fatal(err)
-		}
+			pbt, err := client.Client.GetPodBasedTemplate(ctx, pbtid)
+			require.NoError(t, err)
 
-		if pbt.Data.DisplayName != pbtdn {
-			t.Fatalf("new template displayname mismatch: '%s' vs. '%s'", dn, pbt.Data.DisplayName)
-		}
+			require.Equal(t, pbtdn, pbt.Data.DisplayName)
 
-		log.Printf("testing DeleteTemplate() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		err = client.client.DeleteTemplate(ctx, pbtid)
-		if err != nil {
-			t.Fatal(err)
-		}
+			err = client.Client.DeleteTemplate(ctx, pbtid)
+			require.NoError(t, err)
 
-		log.Printf("testing DeleteTemplate() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		err = client.client.DeleteTemplate(ctx, rbtid)
-		if err != nil {
-			t.Fatal(err)
-		}
+			err = client.Client.DeleteTemplate(ctx, rbtid)
+			require.NoError(t, err)
+		})
 	}
 }
 
 func TestGetPodBasedTemplateByName(t *testing.T) {
-	ctx := context.Background()
-
-	clients, err := getTestClients(ctx, t)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ctx := testutils.WrapCtxWithTestId(t, context.Background())
+	clients := testclient.GetTestClients(t, ctx)
 
 	name := "L2 superspine single plane"
 
 	for _, client := range clients {
-		pbt, err := client.client.GetPodBasedTemplateByName(ctx, name)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if pbt.templateType.String() != templateTypePodBased.string() {
-			t.Fatalf("expected '%s', got '%s'", pbt.templateType.String(), templateTypePodBased)
-		}
-		if pbt.Data.DisplayName != name {
-			t.Fatalf("expected '%s', got '%s'", name, pbt.Data.DisplayName)
-		}
+		t.Run(client.Name(), func(t *testing.T) {
+			t.Parallel()
+			ctx := testutils.WrapCtxWithTestId(t, ctx)
+
+			pbt, err := client.Client.GetPodBasedTemplateByName(ctx, name)
+			require.NoError(t, err)
+			require.Equal(t, name, pbt.Data.DisplayName)
+		})
 	}
 }

--- a/apstra/client.go
+++ b/apstra/client.go
@@ -1251,13 +1251,15 @@ func (o *Client) GetAllTemplates(ctx context.Context) ([]Template, error) {
 	if err != nil {
 		return nil, err
 	}
-	result := make([]Template, len(templates))
-	for i, raw := range templates {
+	result := make([]Template, 0, len(templates))
+	for _, raw := range templates {
 		polished, err := raw.polish()
 		if err != nil {
 			return nil, err
 		}
-		result[i] = polished
+		if polished != nil { // todo: 'rail_collapsed' templates not currently supported
+			result = append(result, polished)
+		}
 	}
 	return result, nil
 }

--- a/internal/test_utils/compare/rack_type.go
+++ b/internal/test_utils/compare/rack_type.go
@@ -114,6 +114,7 @@ func mlagInfo(t testing.TB, a, b *apstra.LeafMlagInfo) {
 			require.Zero(t, b.LeafLeafLinkPortChannelId)
 			require.Zero(t, b.LeafLeafLinkSpeed)
 		}
+		require.Nil(t, b)
 		return
 	}
 


### PR DESCRIPTION
This PR continues the migration of integration tests to use the `apstra_test` package.

In particular this one migrates template and rack_type testing.

Odds and ends:

- Added awareness of the `rail_collapsed` template type because `GetAll....()` functions will encounter it. No handling of those types is included here. The functions just ignore them for now.