### PR TITLE
Roll back go 1.24

### DIFF
--- a/.github/workflows/go_tools.yml
+++ b/.github/workflows/go_tools.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: '1.25.0'
+          go-version: '1.24.6'
 
       - name: go generate
         run: |

--- a/apstra/api_design_rack_types_integration_test.go
+++ b/apstra/api_design_rack_types_integration_test.go
@@ -1,0 +1,153 @@
+// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package apstra_test
+
+import (
+	"context"
+	"log"
+	"testing"
+
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/apstra/enum"
+	testutils "github.com/Juniper/apstra-go-sdk/internal/test_utils"
+	"github.com/Juniper/apstra-go-sdk/internal/test_utils/compare"
+	testclient "github.com/Juniper/apstra-go-sdk/internal/test_utils/test_client"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListGetOneRackType(t *testing.T) {
+	ctx := testutils.WrapCtxWithTestId(t, context.Background())
+	clients := testclient.GetTestClients(t, ctx)
+
+	for _, client := range clients {
+		t.Run(client.Name(), func(t *testing.T) {
+			t.Parallel()
+			ctx = testutils.WrapCtxWithTestId(t, ctx)
+
+			rtIds, err := client.Client.ListRackTypeIds(ctx)
+			require.NoError(t, err)
+			require.NotZero(t, len(rtIds))
+
+			id := rtIds[0]
+
+			rt, err := client.Client.GetRackType(ctx, id)
+			require.NoError(t, err)
+
+			log.Println(rt.Id)
+		})
+	}
+}
+
+func TestListGetAllGetRackType(t *testing.T) {
+	ctx := testutils.WrapCtxWithTestId(t, context.Background())
+	clients := testclient.GetTestClients(t, ctx)
+
+	for _, client := range clients {
+		t.Run(client.Name(), func(t *testing.T) {
+			t.Parallel()
+			ctx = testutils.WrapCtxWithTestId(t, ctx)
+
+			rackTypeIds, err := client.Client.ListRackTypeIds(ctx)
+			require.NoError(t, err)
+			require.NotZero(t, len(rackTypeIds))
+
+			rackTypes, err := client.Client.GetAllRackTypes(ctx)
+			require.NoError(t, err)
+			require.NotZero(t, len(rackTypes))
+
+			require.Equal(t, len(rackTypeIds), len(rackTypes))
+
+			for _, i := range testutils.SampleIndexes(t, len(rackTypeIds)) {
+				id := rackTypeIds[i]
+
+				rt, err := client.Client.GetRackType(ctx, id)
+				require.NoError(t, err)
+
+				require.Contains(t, rackTypeIds, rt.Id)
+
+				log.Println(rt.Id)
+			}
+		})
+	}
+}
+
+func TestCreateGetRackDeleteRackType(t *testing.T) {
+	ctx := testutils.WrapCtxWithTestId(t, context.Background())
+	clients := testclient.GetTestClients(t, ctx)
+
+	leafLabel := "ll-" + testutils.RandString(10, "hex")
+
+	testCases := map[string]apstra.RackTypeRequest{
+		"leaf_only_no_tags": {
+			DisplayName:              "rdn " + testutils.RandString(5, "hex"),
+			FabricConnectivityDesign: enum.FabricConnectivityDesignL3Clos,
+			LeafSwitches: []apstra.RackElementLeafSwitchRequest{
+				{
+					Label:             leafLabel,
+					LogicalDeviceId:   "AOS-48x10_6x40-leaf_spine",
+					LinkPerSpineCount: 2,
+					LinkPerSpineSpeed: "10G",
+				},
+			},
+		},
+		"leaf_generic_with_tags": {
+			DisplayName:              "rdn " + testutils.RandString(5, "hex"),
+			FabricConnectivityDesign: enum.FabricConnectivityDesignL3Clos,
+			LeafSwitches: []apstra.RackElementLeafSwitchRequest{
+				{
+					Label:             leafLabel,
+					LogicalDeviceId:   "AOS-48x10_6x40-leaf_spine",
+					LinkPerSpineCount: 2,
+					LinkPerSpineSpeed: "10G",
+					Tags:              []apstra.ObjectId{"hypervisor", "bare_metal"},
+				},
+			},
+			GenericSystems: []apstra.RackElementGenericSystemRequest{
+				{
+					Count: 5,
+					Label: "some generic system",
+					Links: []apstra.RackLinkRequest{
+						{
+							Label:              "foo",
+							LinkPerSwitchCount: 1,
+							LinkSpeed:          "10G",
+							TargetSwitchLabel:  leafLabel,
+							AttachmentType:     apstra.RackLinkAttachmentTypeSingle,
+							LagMode:            apstra.RackLinkLagModeNone,
+							Tags:               []apstra.ObjectId{"firewall"},
+						},
+					},
+					LogicalDeviceId: "AOS-1x10-1",
+					Tags:            []apstra.ObjectId{"firewall"},
+				},
+			},
+			AccessSwitches: nil,
+		},
+	}
+
+	for _, client := range clients {
+		t.Run(client.Name(), func(t *testing.T) {
+			t.Parallel()
+			ctx = testutils.WrapCtxWithTestId(t, ctx)
+
+			for _, tCase := range testCases {
+				id, err := client.Client.CreateRackType(ctx, &tCase)
+				require.NoError(t, err)
+
+				rt, err := client.Client.GetRackType(ctx, id)
+				require.NoError(t, err)
+
+				require.Equal(t, rt.Id, id)
+				require.NotNil(t, rt.Data)
+				compare.RackType(t, tCase, *rt.Data)
+
+				err = client.Client.DeleteRackType(ctx, id)
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/apstra/api_design_rack_types_test.go
+++ b/apstra/api_design_rack_types_test.go
@@ -2,89 +2,11 @@
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build integration
-
 package apstra
 
 import (
-	"context"
-	"log"
-	"math/rand"
 	"testing"
-
-	"github.com/Juniper/apstra-go-sdk/apstra/enum"
 )
-
-func TestListGetOneRackType(t *testing.T) {
-	clients, err := getTestClients(context.Background(), t)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for clientName, client := range clients {
-		log.Printf("testing listRackTypeIds() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		rtIds, err := client.client.listRackTypeIds(context.TODO())
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// id := rtIds[rand.Intn(len(rtIds))]
-		id := rtIds[0]
-
-		log.Printf("testing getRackType(%s) against %s %s (%s)", id, client.clientType, clientName, client.client.ApiVersion())
-		rt, err := client.client.GetRackType(context.TODO(), id)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		log.Println(rt.Id)
-	}
-}
-
-func TestListGetAllGetRackType(t *testing.T) {
-	clients, err := getTestClients(context.Background(), t)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for clientName, client := range clients {
-		log.Printf("testing listRackTypeIds() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		rackTypeIds, err := client.client.listRackTypeIds(context.TODO())
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		for _, i := range sampleIndexes(t, len(rackTypeIds)) {
-			id := rackTypeIds[i]
-			log.Printf("testing getRackType(%s) against %s %s (%s)", id, client.clientType, clientName, client.client.ApiVersion())
-			rt, err := client.client.GetRackType(context.TODO(), id)
-			if err != nil {
-				t.Fatal(err)
-			}
-			log.Println(rt.Id)
-		}
-
-		log.Printf("testing getAllRackTypes() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		rackTypes, err := client.client.getAllRackTypes(context.TODO())
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(rackTypeIds) != len(rackTypes) {
-			t.Fatalf("got %d rack type IDs but %d rack types", len(rackTypeIds), len(rackTypes))
-		}
-
-		randRackid := rackTypeIds[rand.Intn(len(rackTypeIds))]
-		log.Printf("testing getRackType() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-		rt, err := client.client.GetRackType(context.TODO(), randRackid)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		log.Printf("randomly selected rack type '%s' (%s) has %d leaf switches, %d access switches, and %d generic systems",
-			rt.Data.DisplayName, rt.Id, len(rt.Data.LeafSwitches), len(rt.Data.AccessSwitches), len(rt.Data.GenericSystems))
-	}
-}
 
 func TestRackTypeStrings(t *testing.T) {
 	type apiStringIota interface {
@@ -102,6 +24,7 @@ func TestRackTypeStrings(t *testing.T) {
 		intType    apiStringIota
 		stringType apiIotaString
 	}
+
 	testData := []stringTestData{
 		{stringVal: "", intType: LeafRedundancyProtocolNone, stringType: leafRedundancyProtocolNone},
 		{stringVal: "mlag", intType: LeafRedundancyProtocolMlag, stringType: leafRedundancyProtocolMlag},
@@ -132,89 +55,6 @@ func TestRackTypeStrings(t *testing.T) {
 			td.stringType.string() != td.stringVal {
 			t.Fatalf("test index %d mismatch: %d %d '%s' '%s' '%s'",
 				i, ii, sp, is, ss, td.stringVal)
-		}
-	}
-}
-
-func TestCreateGetRackDeleteRackType(t *testing.T) {
-	clients, err := getTestClients(context.Background(), t)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	leafLabel := "ll-" + randString(10, "hex")
-
-	testCases := map[string]RackTypeRequest{
-		"leaf_only_no_tags": {
-			DisplayName:              "rdn " + randString(5, "hex"),
-			FabricConnectivityDesign: enum.FabricConnectivityDesignL3Clos,
-			LeafSwitches: []RackElementLeafSwitchRequest{
-				{
-					Label:             leafLabel,
-					LogicalDeviceId:   "AOS-48x10_6x40-leaf_spine",
-					LinkPerSpineCount: 2,
-					LinkPerSpineSpeed: "10G",
-				},
-			},
-		},
-		"leaf_generic_with_tags": {
-			DisplayName:              "rdn " + randString(5, "hex"),
-			FabricConnectivityDesign: enum.FabricConnectivityDesignL3Clos,
-			LeafSwitches: []RackElementLeafSwitchRequest{
-				{
-					Label:             leafLabel,
-					LogicalDeviceId:   "AOS-48x10_6x40-leaf_spine",
-					LinkPerSpineCount: 2,
-					LinkPerSpineSpeed: "10G",
-					Tags:              []ObjectId{"hypervisor", "bare_metal"},
-				},
-			},
-			GenericSystems: []RackElementGenericSystemRequest{
-				{
-					Count: 5,
-					Label: "some generic system",
-					Links: []RackLinkRequest{
-						{
-							Label:              "foo",
-							LinkPerSwitchCount: 1,
-							LinkSpeed:          "10G",
-							TargetSwitchLabel:  leafLabel,
-							AttachmentType:     RackLinkAttachmentTypeSingle,
-							LagMode:            RackLinkLagModeNone,
-							Tags:               []ObjectId{"firewall"},
-						},
-					},
-					LogicalDeviceId: "AOS-1x10-1",
-					Tags:            []ObjectId{"firewall"},
-				},
-			},
-			AccessSwitches: nil,
-		},
-	}
-
-	for clientName, client := range clients {
-		for _, tCase := range testCases {
-			log.Printf("testing CreateRackType() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-			id, err := client.client.CreateRackType(context.TODO(), &tCase)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			log.Printf("testing GetRackType() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-			rt, err := client.client.GetRackType(context.TODO(), id)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if id != rt.Id {
-				t.Fatalf("expected %q, got %q", id, rt.Id)
-			}
-
-			log.Printf("testing DeleteRackType() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-			err = client.client.DeleteRackType(context.TODO(), id)
-			if err != nil {
-				t.Fatal(err)
-			}
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Juniper/apstra-go-sdk
 
-go 1.25.0
+go 1.24.6
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.17.8

--- a/internal/test_utils/compare/rack_type.go
+++ b/internal/test_utils/compare/rack_type.go
@@ -1,0 +1,48 @@
+// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package compare
+
+import (
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func RackType(t testing.TB, req apstra.RackTypeRequest, data apstra.RackTypeData) {
+	t.Helper()
+
+	require.Equal(t, req.Description, data.Description)
+	require.Equal(t, req.DisplayName, data.DisplayName)
+	require.Equal(t, req.FabricConnectivityDesign, data.FabricConnectivityDesign)
+}
+
+func rackElementLeafSwitch(t testing.TB, req apstra.RackElementLeafSwitchRequest, data apstra.RackElementLeafSwitch) {
+	t.Helper()
+
+	require.Equal(t, req.Label, data.Label)
+	mlagInfo(t, req.MlagInfo, data.MlagInfo)
+	require.Equal(t, req.LinkPerSpineCount, data.LinkPerSpineCount)
+	require.Equal(t, req.LinkPerSpineSpeed, data.LinkPerSpineSpeed)
+	require.Equal(t, req.RedundancyProtocol, data.RedundancyProtocol)
+	require.Equal(t, len(req.Tags), len(data.Tags))
+}
+
+func mlagInfo(t testing.TB, a, b *apstra.LeafMlagInfo) {
+	t.Helper()
+
+	if a == nil {
+		require.Nil(t, b)
+		return
+	}
+
+	require.NotNil(t, a)
+	require.NotNil(t, b)
+	require.Equal(t, a.LeafLeafL3LinkCount, b.LeafLeafL3LinkCount)
+	require.Equal(t, a.LeafLeafL3LinkPortChannelId, b.LeafLeafL3LinkPortChannelId)
+	require.Equal(t, a.LeafLeafL3LinkCount, b.LeafLeafL3LinkCount)
+	require.Equal(t, a.LeafLeafLinkPortChannelId, b.LeafLeafLinkPortChannelId)
+	require.Equal(t, a.LeafLeafLinkSpeed, b.LeafLeafLinkSpeed)
+	require.Equal(t, a.LeafLeafLinkSpeed, b.LeafLeafLinkSpeed)
+}

--- a/internal/test_utils/compare/rack_type.go
+++ b/internal/test_utils/compare/rack_type.go
@@ -5,9 +5,10 @@
 package compare
 
 import (
+	"testing"
+
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func RackType(t testing.TB, req apstra.RackTypeRequest, data apstra.RackTypeData) {


### PR DESCRIPTION
Some deeply nested dependency on `golang.org/x/tools@v0.21.0` in the terraform provider project is creating a problem with Go 1.25.

The error is:

```
../../../go/pkg/mod/golang.org/x/tools@v0.21.0/internal/tokeninternal/tokeninternal.go:64:9: invalid array length -delta * delta (constant -256 of type int64)
```

[This commit](https://go.googlesource.com/tools/+/2815c8bd92cb4ed1b4ef79260efaab44c6237172) in `golang.org/x/tools` addresses the issue. That change is available from v0.34.0 of `golang.org/x/tools`.

Rather than untangling that mess, I'm rolling back our dependency on Go 1.25. It was introduced for the `synctest` package which we haven't wound up using.