### PR TITLE
Update third party license compliance

### DIFF
--- a/.ci/scripts/compliance.sh
+++ b/.ci/scripts/compliance.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+# Copyright (c) Juniper Networks, Inc., 2025-2025.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 TPC=Third_Party_Code

--- a/.ci/scripts/compliance.sh
+++ b/.ci/scripts/compliance.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TPC=Third_Party_Code
+
+IGNORE=()
+IGNORE+=(--ignore)
+IGNORE+=(github.com/Juniper) # don't bother with Juniper licenses
+
+go run github.com/google/go-licenses/v2 save   ${IGNORE[@]} --save_path "${TPC}" --force ./...
+go run github.com/google/go-licenses/v2 report ${IGNORE[@]} --template .notices.tpl ./... > "${TPC}/NOTICES.md"
+
+# The `save` command above collects only license and notice files from packages with licenses identified as
+# `RestrictionsShareLicense` and collects the entire source tree when the license is identified as
+# `RestrictionsShareCode`.
+#
+# It's true that some licenses require us to "make available" the upstream source code, but I'm not sure
+# that doing so as *part of this repository* is appropriate.
+# 1. The go package system makes it perfectly clear what we're using and where we got it.
+# 2. If somebody wants to really push the issue, we'll find a way to deliver the source independent of this repository.
+#
+# The line below deletes "saved" files other than those beginning with "LICENSE" and "NOTICE"
+find "$TPC" -type f ! -name 'LICENSE*' ! -name 'NOTICE*' -print0 | xargs -0 rm --
+
+# We now likely have some empty directories. Get rid of 'em.
+find "$TPC" -depth -type d -empty -exec rmdir -- "{}" \;

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,7 @@ check-repo-clean:
 	git update-index --refresh && git diff-index --quiet HEAD --
 
 compliance:
-	go run github.com/chrismarget-j/go-licenses save   --ignore github.com/Juniper --save_path Third_Party_Code --force ./... || exit 1 ;\
-	go run github.com/chrismarget-j/go-licenses report --ignore github.com/Juniper --template .notices.tpl ./... > Third_Party_Code/NOTICES.md || exit 1 ;\
+	@sh -c "$(CURDIR)/.ci/scripts/compliance.sh"
 
 compliance-check: compliance check-repo-clean
 

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.17.8
 	github.com/aws/aws-sdk-go-v2/config v1.18.21
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.19.3
-	github.com/chrismarget-j/go-licenses v0.0.0-20240224210557-f22f3e06d3d4
 	github.com/gertd/go-pluralize v0.2.1
+	github.com/google/go-licenses/v2 v2.0.0-alpha.1
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/hcl/v2 v2.19.1

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,6 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.18.9/go.mod h1:yyW88BEPXA2fGFyI2KCcZ
 github.com/aws/smithy-go v1.13.5 h1:hgz0X/DX0dGqTYpGALqXJoRKRj5oQ7150i5FdTePzO8=
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chrismarget-j/go-licenses v0.0.0-20240224210557-f22f3e06d3d4 h1:nFogSDBo0cmCwO2JX2gl+2onPk4Fw63VreG+HX9U5n0=
-github.com/chrismarget-j/go-licenses v0.0.0-20240224210557-f22f3e06d3d4/go.mod h1:RxJksUf3IJIwpKhrrGOUOVD7qQQj1tlJtXYhmsyLVlE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
@@ -78,6 +76,8 @@ github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-licenses/v2 v2.0.0-alpha.1 h1:2EMzW/1PWYvgOxBXsWl7b350vI0c/kf5Fh7z4AR1skM=
+github.com/google/go-licenses/v2 v2.0.0-alpha.1/go.mod h1:HlMUpsa+mbs8EqdlY0BDfCn0ZK7Y7NQoRCGYhNoox64=
 github.com/google/go-replayers/httpreplay v1.2.0 h1:VM1wEyyjaoU53BwrOnaf9VhAyQQEEioJvFYxYcLRKzk=
 github.com/google/go-replayers/httpreplay v1.2.0/go.mod h1:WahEFFZZ7a1P4VM1qEeHy+tME4bwyqPcwWbNlUI1Mcg=
 github.com/google/licenseclassifier/v2 v2.0.0 h1:1Y57HHILNf4m0ABuMVb6xk4vAJYEUO0gDxNpog0pyeA=

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2023-2024.
+// Copyright (c) Juniper Networks, Inc., 2023-2025.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -8,7 +8,7 @@ package tools
 
 import (
 	// license compliance
-	_ "github.com/chrismarget-j/go-licenses"
+	_ "github.com/google/go-licenses/v2"
 
 	// opinionated code formatting
 	_ "mvdan.cc/gofumpt"


### PR DESCRIPTION
We'd been using `github.com/chrismarget-j/go-licenses` to collect 3rd party licenses. It is a custom fork of `github.com/google/go-licenses`.

The main difference between them: The fork doesn't collect the 3rd party source code, even when the license might require us to "make available" the source.

This PR drops the dependency on the custom fork and instead uses the latest upstream `github.com/google/go-licenses/v2`.

After running the `save` command, a new script deletes the unwanted source which may have been downloaded, so the end result is the same.