### PR TITLE
Finish rack type test helper functions

### DIFF
--- a/apstra/api_design_rack_types_integration_test.go
+++ b/apstra/api_design_rack_types_integration_test.go
@@ -134,19 +134,23 @@ func TestCreateGetRackDeleteRackType(t *testing.T) {
 			t.Parallel()
 			ctx = testutils.WrapCtxWithTestId(t, ctx)
 
-			for _, tCase := range testCases {
-				id, err := client.Client.CreateRackType(ctx, &tCase)
-				require.NoError(t, err)
+			for tName, tCase := range testCases {
+				t.Run(tName, func(t *testing.T) {
+					ctx = testutils.WrapCtxWithTestId(t, ctx)
 
-				rt, err := client.Client.GetRackType(ctx, id)
-				require.NoError(t, err)
+					id, err := client.Client.CreateRackType(ctx, &tCase)
+					require.NoError(t, err)
 
-				require.Equal(t, rt.Id, id)
-				require.NotNil(t, rt.Data)
-				compare.RackType(t, tCase, *rt.Data)
+					rt, err := client.Client.GetRackType(ctx, id)
+					require.NoError(t, err)
 
-				err = client.Client.DeleteRackType(ctx, id)
-				require.NoError(t, err)
+					require.Equal(t, rt.Id, id)
+					require.NotNil(t, rt.Data)
+					compare.RackType(t, tCase, *rt.Data)
+
+					err = client.Client.DeleteRackType(ctx, id)
+					require.NoError(t, err)
+				})
 			}
 		})
 	}

--- a/internal/test_utils/compare/rack_type.go
+++ b/internal/test_utils/compare/rack_type.go
@@ -17,6 +17,18 @@ func RackType(t testing.TB, req apstra.RackTypeRequest, data apstra.RackTypeData
 	require.Equal(t, req.Description, data.Description)
 	require.Equal(t, req.DisplayName, data.DisplayName)
 	require.Equal(t, req.FabricConnectivityDesign, data.FabricConnectivityDesign)
+	require.Equal(t, len(req.LeafSwitches), len(data.LeafSwitches))
+	for i := range data.LeafSwitches {
+		rackElementLeafSwitch(t, req.LeafSwitches[i], data.LeafSwitches[i])
+	}
+	require.Equal(t, len(req.AccessSwitches), len(data.AccessSwitches))
+	for i := range data.AccessSwitches {
+		rackElementAccessSwitch(t, req.AccessSwitches[i], data.AccessSwitches[i])
+	}
+	require.Equal(t, len(req.GenericSystems), len(data.GenericSystems))
+	for i := range data.GenericSystems {
+		rackElementGenericSystem(t, req.GenericSystems[i], data.GenericSystems[i])
+	}
 }
 
 func rackElementLeafSwitch(t testing.TB, req apstra.RackElementLeafSwitchRequest, data apstra.RackElementLeafSwitch) {
@@ -30,11 +42,78 @@ func rackElementLeafSwitch(t testing.TB, req apstra.RackElementLeafSwitchRequest
 	require.Equal(t, len(req.Tags), len(data.Tags))
 }
 
-func mlagInfo(t testing.TB, a, b *apstra.LeafMlagInfo) {
+func rackElementAccessSwitch(t testing.TB, req apstra.RackElementAccessSwitchRequest, data apstra.RackElementAccessSwitch) {
+	t.Helper()
+
+	require.Equal(t, req.InstanceCount, data.InstanceCount)
+	require.Equal(t, req.RedundancyProtocol, data.RedundancyProtocol)
+	require.Equal(t, len(req.Links), len(data.Links))
+	for i := range data.Links {
+		rackLink(t, req.Links[i], data.Links[i])
+	}
+	require.Equal(t, req.Label, data.Label)
+	// cannot compare logical device
+	require.Equal(t, len(req.Tags), len(data.Tags))
+	esiLagInfo(t, req.EsiLagInfo, data.EsiLagInfo)
+}
+
+func rackElementGenericSystem(t testing.TB, req apstra.RackElementGenericSystemRequest, data apstra.RackElementGenericSystem) {
+	t.Helper()
+
+	require.Equal(t, req.Count, data.Count)
+	require.Equal(t, req.AsnDomain, data.AsnDomain)
+	require.Equal(t, req.ManagementLevel, data.ManagementLevel)
+	require.Equal(t, req.PortChannelIdMin, data.PortChannelIdMin)
+	require.Equal(t, req.PortChannelIdMax, data.PortChannelIdMax)
+	require.Equal(t, req.Loopback, data.Loopback)
+	require.Equal(t, len(req.Tags), len(data.Tags))
+	require.Equal(t, req.Label, data.Label)
+	require.Equal(t, len(req.Links), len(data.Links))
+	for i := range data.Links {
+		rackLink(t, req.Links[i], data.Links[i])
+	}
+	// cannot compare logical device
+}
+
+func rackLink(t testing.TB, req apstra.RackLinkRequest, data apstra.RackLink) {
+	t.Helper()
+
+	require.Equal(t, req.Label, data.Label)
+	require.Equal(t, len(req.Tags), len(data.Tags))
+	require.Equal(t, req.LinkPerSwitchCount, data.LinkPerSwitchCount)
+	require.Equal(t, req.LinkSpeed, data.LinkSpeed)
+	require.Equal(t, req.TargetSwitchLabel, data.TargetSwitchLabel)
+	require.Equal(t, req.AttachmentType, data.AttachmentType)
+	require.Equal(t, req.LagMode, data.LagMode)
+	require.Equal(t, req.SwitchPeer, data.SwitchPeer)
+}
+
+func esiLagInfo(t testing.TB, a, b *apstra.EsiLagInfo) {
 	t.Helper()
 
 	if a == nil {
 		require.Nil(t, b)
+		return
+	}
+
+	require.NotNil(t, a)
+	require.NotNil(t, b)
+	require.Equal(t, a.AccessAccessLinkCount, b.AccessAccessLinkCount)
+	require.Equal(t, a.AccessAccessLinkSpeed, b.AccessAccessLinkSpeed)
+}
+
+func mlagInfo(t testing.TB, a, b *apstra.LeafMlagInfo) {
+	t.Helper()
+
+	if a == nil {
+		if b != nil {
+			require.Zero(t, b.LeafLeafL3LinkCount)
+			require.Zero(t, b.LeafLeafL3LinkPortChannelId)
+			require.Zero(t, b.LeafLeafL3LinkSpeed)
+			require.Zero(t, b.LeafLeafLinkCount)
+			require.Zero(t, b.LeafLeafLinkPortChannelId)
+			require.Zero(t, b.LeafLeafLinkSpeed)
+		}
 		return
 	}
 


### PR DESCRIPTION
#556 mistakenly included some rack type test changes which, while didn't introduce any problem, weren't fully baked.

This PR fleshes out the missing bits from the rack type test code.