### PR TITLE
Don't count templates with Apstra 6+ (temporary)

### DIFF
--- a/apstra/api_design_templates.go
+++ b/apstra/api_design_templates.go
@@ -542,7 +542,7 @@ func (o *template) polish() (Template, error) {
 		}
 		return t.polish()
 	case templateTypeRailCollapsed:
-		return nil, nil // todo: not currently supported
+		return nil, nil // todo: not currently supported - fix TestGetTemplate() when support is added
 	}
 	return nil, fmt.Errorf(TemplateTypeUnknown, t)
 }

--- a/apstra/api_design_templates_integration_test.go
+++ b/apstra/api_design_templates_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/Juniper/apstra-go-sdk/apstra/compatibility"
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	testutils "github.com/Juniper/apstra-go-sdk/internal/test_utils"
 	testclient "github.com/Juniper/apstra-go-sdk/internal/test_utils/test_client"
@@ -33,7 +34,10 @@ func TestGetTemplate(t *testing.T) {
 			templates, err := client.Client.GetAllTemplates(ctx)
 			require.NoError(t, err)
 
-			require.Equal(t, len(templateIds), len(templates))
+			// skip this check with Apstra 6+ until we add support for rail collapsed templates
+			if !compatibility.RailCollapsedSupport.Check(client.APIVersion()) {
+				require.Equal(t, len(templateIds), len(templates))
+			}
 
 			log.Printf("fetching %d templateIds...", len(templates))
 

--- a/apstra/compatibility/constraints.go
+++ b/apstra/compatibility/constraints.go
@@ -32,6 +32,9 @@ var (
 	PatchNodeSupportsUnsafeArg = Constraint{
 		constraints: version.MustConstraints(version.NewConstraint(">=" + apstra500)),
 	}
+	RailCollapsedSupport = Constraint{
+		constraints: version.MustConstraints(version.NewConstraint(">=" + apstra600)),
+	}
 	RoutingPolicyExportHasL3EdgeLinks = Constraint{
 		constraints: version.MustConstraints(version.NewConstraint("<" + apstra500)),
 	}


### PR DESCRIPTION
This PR fixes a test failure with Apstra 6+:

- `ListAllTemplateIds()` returns all template IDs, including those for (unsupported) `rail_collapsed` design
- `GetAllTemplates()` returns only those template we currently support

We shouldn't be comparing these quantities with Apstra 6 until support for `rail_collapsed` templates is added.