### PR TITLE
Resolve deadlock issue in test code

### DIFF
--- a/apstra/client_integration_test.go
+++ b/apstra/client_integration_test.go
@@ -80,10 +80,18 @@ func TestLoginBadPassword(t *testing.T) {
 				t.Skipf("skipping test - api-ops type clients do not log in or out")
 			}
 
-			c := *client.Client
-			c.SetPassword(testutils.RandString(10, "hex"))
+			// extract the configuration and create a new client based on it
+			cfg := client.Client.Config()
+			clone, err := cfg.NewClient(ctx)
+			require.NoError(t, err)
 
-			err := c.Login(ctx)
+			// login with the correct password must work
+			err = clone.Login(ctx)
+			require.NoError(t, err)
+
+			// login with bad password must fail
+			clone.SetPassword(testutils.RandString(10, "hex"))
+			err = clone.Login(ctx)
 			require.Error(t, err)
 		})
 	}

--- a/apstra/client_integration_test.go
+++ b/apstra/client_integration_test.go
@@ -110,13 +110,18 @@ func TestLogoutAuthFail(t *testing.T) {
 				t.Skipf("skipping test - api-ops type clients do not log in or out")
 			}
 
-			c := *client.Client
-
-			err := c.Login(ctx)
+			// extract the configuration and create a new client based on it
+			cfg := client.Client.Config()
+			clone, err := cfg.NewClient(ctx)
 			require.NoError(t, err)
 
-			client.Client.SetAuthtoken(testutils.RandJWT())
-			err = c.Logout(ctx)
+			// login with the correct password must work
+			err = clone.Login(ctx)
+			require.NoError(t, err)
+
+			// logout with bad token must fail
+			clone.SetAuthtoken(testutils.RandJWT())
+			err = clone.Logout(ctx)
 			require.Error(t, err)
 		})
 	}

--- a/apstra/client_integration_test.go
+++ b/apstra/client_integration_test.go
@@ -50,9 +50,18 @@ func TestLoginEmptyPassword(t *testing.T) {
 				t.Skipf("skipping test - api-ops type clients do not log in or out")
 			}
 
-			c := *client.Client // don't use iterator variable because it points to the shared client object
-			c.SetPassword("")
-			err := c.Login(ctx)
+			// extract the configuration and create a new client based on it
+			cfg := client.Client.Config()
+			clone, err := cfg.NewClient(ctx)
+			require.NoError(t, err)
+
+			// login with the correct password must work
+			err = clone.Login(ctx)
+			require.NoError(t, err)
+
+			// login with empty password must fail
+			clone.SetPassword("")
+			err = clone.Login(ctx)
 			require.Error(t, err)
 		})
 	}


### PR DESCRIPTION
It's not safe to create a copy of a `client.Client` structure and then call the `Logout()` method on either `client.Client`.

Both copies would be depending on the task monitor goroutine, but only the copy which called `Logout()` would be aware that it stopped.

Some tests which ensure that `Logout()` and related functions really work _were creating copies_ in an attempt to not disturb the client objects in other tests. This strategy backfired.

With this PR, rather than copying the `client.Client`, those tests create an entirely new object using the original client's configuration. The new client will have its own task monitor goroutine, channels, pointers, etc...

Closes #568