### PR TITLE
Fix string split constant name and usage

### DIFF
--- a/internal/test_utils/test_client/client_api_ops.go
+++ b/internal/test_utils/test_client/client_api_ops.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	envAPIOpsTopologyURLList = "API_OPS_URLS"
-	envAPIOpsURLSep          = ";"
+	envAPIOpsTopologyURLSep  = ";"
 )
 
 var _ Config = (*APIOpsConfig)(nil)
@@ -78,7 +78,7 @@ func getAPIOpsClientCfgs(t testing.TB, ctx context.Context, testConfig TestConfi
 	if len(topologyIDs) == 0 {
 		list := os.Getenv(envAPIOpsTopologyURLList)
 		if len(list) != 0 {
-			topologyIDs = strings.Split(list, envAPIOpsTopologyURLList)
+			topologyIDs = strings.Split(list, envAPIOpsTopologyURLSep)
 		}
 	}
 


### PR DESCRIPTION
When reading api-ops topology URLs from the environment, we were splitting the string on the wrong values.

Rather than using `;`, we were splitting on `API_OPS_URLS` (the name of the environment variable which holds them)

Furthermore, the constant name didn't match the constants for the other types.

This PR brings the api-ops test client into line with the other types, which use:

```go
	envAWSInstanceIDList = "APSTRA_AWS_INSTANCE_IDS"
	envAWSTopologyIDSep  = ":"
	envCloudlabsTopologyIDList = "CLOUDLABS_TOPOLOGIES"
	envCloudlabsTopologyIDSep  = ":"
	envSlicerTopologyIDList = "SLICER_TOPOLOGIES"
	envSlicerTopologyIDSep  = ":"
```

The api-ops stands out because it splits on `;` rather than `:` because it's splitting URLs (which contain `:`)

Closes #595