### PR TITLE
Clean up stuff identified by `go vet`

### DIFF
--- a/apstra/two_stage_l3_clos_endpoint_policies_status_integration_test.go
+++ b/apstra/two_stage_l3_clos_endpoint_policies_status_integration_test.go
@@ -55,7 +55,7 @@ func TestGetAllConnectivityTemplateStatus(t *testing.T) {
 			Items []struct {
 				Interface struct {
 					Id ObjectId `json:"id"`
-				} `json:"server_interface""`
+				} `json:"server_interface"`
 			} `json:"items"`
 		}
 

--- a/internal/test_utils/datacenter_test_objects/blueprints.go
+++ b/internal/test_utils/datacenter_test_objects/blueprints.go
@@ -97,9 +97,9 @@ func TestBlueprintD(t testing.TB, ctx context.Context, client *apstra.Client) *a
 		SetClient(client).
 		Node([]apstra.QEEAttribute{
 			apstra.NodeTypeSystem.QEEAttribute(),
-			{"system_type", apstra.QEStringVal("switch")},
-			{"role", apstra.QEStringVal("leaf")},
-			{"name", apstra.QEStringVal("n_leaf")},
+			{Key: "system_type", Value: apstra.QEStringVal("switch")},
+			{Key: "role", Value: apstra.QEStringVal("leaf")},
+			{Key: "name", Value: apstra.QEStringVal("n_leaf")},
 		})
 	var response struct {
 		Items []struct {
@@ -140,9 +140,9 @@ func TestBlueprintE(t testing.TB, ctx context.Context, client *apstra.Client) *a
 		SetClient(client).
 		Node([]apstra.QEEAttribute{
 			apstra.NodeTypeSystem.QEEAttribute(),
-			{"system_type", apstra.QEStringVal("switch")},
-			{"role", apstra.QEStringVal("leaf")},
-			{"name", apstra.QEStringVal("n_leaf")},
+			{Key: "system_type", Value: apstra.QEStringVal("switch")},
+			{Key: "role", Value: apstra.QEStringVal("leaf")},
+			{Key: "name", Value: apstra.QEStringVal("n_leaf")},
 		})
 	var leafResponse struct {
 		Items []struct {
@@ -167,9 +167,9 @@ func TestBlueprintE(t testing.TB, ctx context.Context, client *apstra.Client) *a
 		SetClient(client).
 		Node([]apstra.QEEAttribute{
 			apstra.NodeTypeSystem.QEEAttribute(),
-			{"system_type", apstra.QEStringVal("switch")},
-			{"role", apstra.QEStringVal("access")},
-			{"name", apstra.QEStringVal("n_access")},
+			{Key: "system_type", Value: apstra.QEStringVal("switch")},
+			{Key: "role", Value: apstra.QEStringVal("access")},
+			{Key: "name", Value: apstra.QEStringVal("n_access")},
 		})
 	var accessResponse struct {
 		Items []struct {

--- a/internal/test_utils/queries.go
+++ b/internal/test_utils/queries.go
@@ -19,8 +19,8 @@ func GetSystemIdsByRole(ctx context.Context, bp *apstra.TwoStageL3ClosClient, ro
 		SetBlueprintType(apstra.BlueprintTypeStaging).
 		Node([]apstra.QEEAttribute{
 			apstra.NodeTypeSystem.QEEAttribute(),
-			{"role", apstra.QEStringVal(role)},
-			{"name", apstra.QEStringVal("n_system")},
+			{Key: "role", Value: apstra.QEStringVal(role)},
+			{Key: "name", Value: apstra.QEStringVal("n_system")},
 		})
 
 	var leafQueryResult struct {


### PR DESCRIPTION
- One stray `"` in a struct tag
- Several un-keyed struct elements