### PR TITLE
Introduce CI validation of `requiretestutils` build constraint for `internal/test_utils/`

### DIFF
--- a/.github/workflows/go_tools.yml
+++ b/.github/workflows/go_tools.yml
@@ -36,3 +36,6 @@ jobs:
 
       - name: compliance
         run: make compliance-check
+
+      - name: build-tags
+        run: make check-build-tags

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@
 # All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-all: compliance-check license-header-check verify unit-tests integration-tests
+all: check-build-tags compliance-check license-header-check verify unit-tests integration-tests
+
+check-build-tags:
+	@sh -c "go run github.com/chrismarget/go-build-tag-required -recursive -dir internal/test_utils -tag requiretestutils"
 
 check-repo-clean:
 	git update-index --refresh && git diff-index --quiet HEAD --

--- a/go.mod
+++ b/go.mod
@@ -6,13 +6,14 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.17.8
 	github.com/aws/aws-sdk-go-v2/config v1.18.21
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.19.3
+	github.com/chrismarget/go-build-tag-required v0.0.3
 	github.com/gertd/go-pluralize v0.2.1
 	github.com/google/go-licenses/v2 v2.0.0-alpha.1
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/hcl/v2 v2.19.1
 	github.com/orsinium-labs/enum v1.3.0
-	github.com/stretchr/testify v1.8.1
+	github.com/stretchr/testify v1.11.1
 	golang.org/x/tools v0.34.0
 	google.golang.org/protobuf v1.33.0
 	mvdan.cc/gofumpt v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.18.9/go.mod h1:yyW88BEPXA2fGFyI2KCcZ
 github.com/aws/smithy-go v1.13.5 h1:hgz0X/DX0dGqTYpGALqXJoRKRj5oQ7150i5FdTePzO8=
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/chrismarget/go-build-tag-required v0.0.3 h1:dF5UQYWxS5XXZH5pOcnGiB9IDcdis2dCroBWThBvbF4=
+github.com/chrismarget/go-build-tag-required v0.0.3/go.mod h1:W9ekJoIvSF6w/pNz7gN3acGlRKp5nSB4U4glrk34Stc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
@@ -133,8 +135,9 @@ github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpE
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/zclconf/go-cty v1.13.0 h1:It5dfKTTZHe9aeppbNOda3mN7Ag7sg6QkBNm6TkyFa0=
 github.com/zclconf/go-cty v1.13.0/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=

--- a/internal/test_utils/context.go
+++ b/internal/test_utils/context.go
@@ -2,7 +2,7 @@
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build requiretestutils
+//go:build requiretestutil
 
 package testutils
 

--- a/internal/test_utils/context.go
+++ b/internal/test_utils/context.go
@@ -2,7 +2,7 @@
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build requiretestutil
+//go:build requiretestutils
 
 package testutils
 

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -7,6 +7,9 @@
 package tools
 
 import (
+	// build constraint validation
+	_ "github.com/chrismarget/go-build-tag-required"
+
 	// license compliance
 	_ "github.com/google/go-licenses/v2"
 


### PR DESCRIPTION
This PR introduces:

- `make check-build-tags` which ensures that files under `internal/test_utils/` all have the `requiretestutils` build constraint
- a CI job which runs `make check-build-tags`
- a dependency on an external tool which does the checking