### PR TITLE
Ensure test selects a VLAN ID in the range 11-99

### DIFF
--- a/apstra/two_stage_l3_clos_virtual_network_bindings_integration_test.go
+++ b/apstra/two_stage_l3_clos_virtual_network_bindings_integration_test.go
@@ -276,7 +276,7 @@ func TestUpdateVirtualNetworkLeafBindings(t *testing.T) {
 			vnPrefix := randomPrefix(t, "10.0.0.0/8", 24)
 			vnBinding := VnBinding{
 				SystemId: fixedLeafId,
-				VlanId:   toPtr(Vlan(rand.Intn(97) + 2)),
+				VlanId:   toPtr(Vlan(rand.Intn(89) + 11)),
 			}
 			sviIp := SviIp{
 				SystemId: fixedLeafId,


### PR DESCRIPTION
A test failed recently because the VLAN ID selection range began at 2, and the test randomly selected 2.

But a VRF was already using that value.

This PR ensures the selection range is 11-99, leaving room for VRFs at the bottom and test cases which begin at 100.

Closes #620