### PR TITLE
Remove the `Replicator` interface

### DIFF
--- a/design/logical_device.go
+++ b/design/logical_device.go
@@ -16,11 +16,10 @@ import (
 )
 
 var (
-	_ internal.IDSetter                  = (*LogicalDevice)(nil)
-	_ internal.Replicator[LogicalDevice] = (*LogicalDevice)(nil)
-	_ json.Marshaler                     = (*LogicalDevice)(nil)
-	_ json.Unmarshaler                   = (*LogicalDevice)(nil)
-	_ timeutils.Stamper                  = (*LogicalDevice)(nil)
+	_ internal.IDSetter = (*LogicalDevice)(nil)
+	_ json.Marshaler    = (*LogicalDevice)(nil)
+	_ json.Unmarshaler  = (*LogicalDevice)(nil)
+	_ timeutils.Stamper = (*LogicalDevice)(nil)
 )
 
 type LogicalDevice struct {

--- a/design/rack_type.go
+++ b/design/rack_type.go
@@ -19,11 +19,10 @@ import (
 )
 
 var (
-	_ internal.IDSetter             = (*RackType)(nil)
-	_ internal.Replicator[RackType] = (*RackType)(nil)
-	_ json.Marshaler                = (*RackType)(nil)
-	_ json.Unmarshaler              = (*RackType)(nil)
-	_ timeutils.Stamper             = (*RackType)(nil)
+	_ internal.IDSetter = (*RackType)(nil)
+	_ json.Marshaler    = (*RackType)(nil)
+	_ json.Unmarshaler  = (*RackType)(nil)
+	_ timeutils.Stamper = (*RackType)(nil)
 )
 
 type RackType struct {

--- a/design/rack_type_access_switch.go
+++ b/design/rack_type_access_switch.go
@@ -10,17 +10,15 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/Juniper/apstra-go-sdk/internal"
 	"github.com/Juniper/apstra-go-sdk/internal/pointer"
 	"github.com/Juniper/apstra-go-sdk/internal/zero"
 	"github.com/Juniper/apstra-go-sdk/speed"
 )
 
 var (
-	_ logicalDeviceIDer                 = (*AccessSwitch)(nil)
-	_ internal.Replicator[AccessSwitch] = (*AccessSwitch)(nil)
-	_ json.Marshaler                    = (*AccessSwitch)(nil)
-	_ json.Unmarshaler                  = (*AccessSwitch)(nil)
+	_ logicalDeviceIDer = (*AccessSwitch)(nil)
+	_ json.Marshaler    = (*AccessSwitch)(nil)
+	_ json.Unmarshaler  = (*AccessSwitch)(nil)
 )
 
 type AccessSwitch struct {

--- a/design/rack_type_access_switch_esilag_info.go
+++ b/design/rack_type_access_switch_esilag_info.go
@@ -5,11 +5,8 @@
 package design
 
 import (
-	"github.com/Juniper/apstra-go-sdk/internal"
 	"github.com/Juniper/apstra-go-sdk/speed"
 )
-
-var _ internal.Replicator[RackTypeAccessSwitchESILAGInfo] = (*RackTypeAccessSwitchESILAGInfo)(nil)
 
 type RackTypeAccessSwitchESILAGInfo struct {
 	LinkCount        int         `json:"access_access_link_count"`

--- a/design/rack_type_generic_system.go
+++ b/design/rack_type_generic_system.go
@@ -11,16 +11,14 @@ import (
 	"slices"
 
 	"github.com/Juniper/apstra-go-sdk/enum"
-	"github.com/Juniper/apstra-go-sdk/internal"
 	"github.com/Juniper/apstra-go-sdk/internal/pointer"
 	"github.com/Juniper/apstra-go-sdk/internal/zero"
 )
 
 var (
-	_ logicalDeviceIDer                  = (*GenericSystem)(nil)
-	_ internal.Replicator[GenericSystem] = (*GenericSystem)(nil)
-	_ json.Marshaler                     = (*GenericSystem)(nil)
-	_ json.Unmarshaler                   = (*GenericSystem)(nil)
+	_ logicalDeviceIDer = (*GenericSystem)(nil)
+	_ json.Marshaler    = (*GenericSystem)(nil)
+	_ json.Unmarshaler  = (*GenericSystem)(nil)
 )
 
 type GenericSystem struct {

--- a/design/rack_type_leaf_switch.go
+++ b/design/rack_type_leaf_switch.go
@@ -11,16 +11,14 @@ import (
 	"slices"
 
 	"github.com/Juniper/apstra-go-sdk/enum"
-	"github.com/Juniper/apstra-go-sdk/internal"
 	"github.com/Juniper/apstra-go-sdk/internal/pointer"
 	"github.com/Juniper/apstra-go-sdk/speed"
 )
 
 var (
-	_ logicalDeviceIDer               = (*LeafSwitch)(nil)
-	_ internal.Replicator[LeafSwitch] = (*LeafSwitch)(nil)
-	_ json.Marshaler                  = (*LeafSwitch)(nil)
-	_ json.Unmarshaler                = (*LeafSwitch)(nil)
+	_ logicalDeviceIDer = (*LeafSwitch)(nil)
+	_ json.Marshaler    = (*LeafSwitch)(nil)
+	_ json.Unmarshaler  = (*LeafSwitch)(nil)
 )
 
 type LeafSwitch struct {

--- a/design/rack_type_leaf_switch_mlag_info.go
+++ b/design/rack_type_leaf_switch_mlag_info.go
@@ -5,11 +5,8 @@
 package design
 
 import (
-	"github.com/Juniper/apstra-go-sdk/internal"
 	"github.com/Juniper/apstra-go-sdk/speed"
 )
-
-var _ internal.Replicator[RackTypeLeafSwitchMLAGInfo] = (*RackTypeLeafSwitchMLAGInfo)(nil)
 
 type RackTypeLeafSwitchMLAGInfo struct {
 	LeafLeafL3LinkCount         int         `json:"leaf_leaf_l3_link_count"`

--- a/design/rack_type_link.go
+++ b/design/rack_type_link.go
@@ -10,16 +10,14 @@ import (
 	"sort"
 
 	"github.com/Juniper/apstra-go-sdk/enum"
-	"github.com/Juniper/apstra-go-sdk/internal"
 	"github.com/Juniper/apstra-go-sdk/internal/pointer"
 	"github.com/Juniper/apstra-go-sdk/internal/zero"
 	"github.com/Juniper/apstra-go-sdk/speed"
 )
 
 var (
-	_ internal.Replicator[RackTypeLink] = (*RackTypeLink)(nil)
-	_ json.Marshaler                    = (*RackTypeLink)(nil)
-	_ json.Unmarshaler                  = (*RackTypeLink)(nil)
+	_ json.Marshaler   = (*RackTypeLink)(nil)
+	_ json.Unmarshaler = (*RackTypeLink)(nil)
 )
 
 type RackTypeLink struct {

--- a/design/tag.go
+++ b/design/tag.go
@@ -16,11 +16,10 @@ import (
 )
 
 var (
-	_ internal.IDSetter        = (*Tag)(nil)
-	_ internal.Replicator[Tag] = (*Tag)(nil)
-	_ json.Marshaler           = (*Tag)(nil)
-	_ json.Unmarshaler         = (*Tag)(nil)
-	_ timeutils.Stamper        = (*Tag)(nil)
+	_ internal.IDSetter = (*Tag)(nil)
+	_ json.Marshaler    = (*Tag)(nil)
+	_ json.Unmarshaler  = (*Tag)(nil)
+	_ timeutils.Stamper = (*Tag)(nil)
 )
 
 type Tag struct {

--- a/design/template_common.go
+++ b/design/template_common.go
@@ -5,7 +5,6 @@
 package design
 
 import (
-	"github.com/Juniper/apstra-go-sdk/internal"
 	"github.com/Juniper/apstra-go-sdk/speed"
 )
 
@@ -18,8 +17,6 @@ type PodWithCount struct {
 	Count int
 	Pod   TemplateRackBased
 }
-
-var _ internal.Replicator[Spine] = (*Spine)(nil)
 
 type Spine struct {
 	Count                  int           `json:"count"`

--- a/design/template_rack_based.go
+++ b/design/template_rack_based.go
@@ -19,11 +19,10 @@ import (
 )
 
 var (
-	_ Template                               = (*TemplateRackBased)(nil)
-	_ internal.IDSetter                      = (*TemplateRackBased)(nil)
-	_ internal.Replicator[TemplateRackBased] = (*TemplateRackBased)(nil)
-	_ json.Marshaler                         = (*TemplateRackBased)(nil)
-	_ json.Unmarshaler                       = (*TemplateRackBased)(nil)
+	_ Template          = (*TemplateRackBased)(nil)
+	_ internal.IDSetter = (*TemplateRackBased)(nil)
+	_ json.Marshaler    = (*TemplateRackBased)(nil)
+	_ json.Unmarshaler  = (*TemplateRackBased)(nil)
 )
 
 type TemplateRackBased struct {

--- a/internal/interfaces.go
+++ b/internal/interfaces.go
@@ -13,7 +13,3 @@ type IDSetter interface {
 	SetID(string) error
 	MustSetID(string)
 }
-
-type Replicator[T any] interface {
-	Replicate() T
-}


### PR DESCRIPTION
This PR removes the `internal.Replicator` interface because nothing uses it directly.

Each object which previously implemented `internal.Replicator` still has the `Replicate()` method.