### PR TITLE
Remove `design.logicalDeviceIDer` interface

### DIFF
--- a/design/interfaces.go
+++ b/design/interfaces.go
@@ -10,10 +10,6 @@ import (
 	timeutils "github.com/Juniper/apstra-go-sdk/internal/time_utils"
 )
 
-type logicalDeviceIDer interface {
-	logicalDeviceID() *string
-}
-
 type Template interface {
 	timeutils.Stamper
 	internal.IDer

--- a/design/rack_type_access_switch.go
+++ b/design/rack_type_access_switch.go
@@ -16,9 +16,8 @@ import (
 )
 
 var (
-	_ logicalDeviceIDer = (*AccessSwitch)(nil)
-	_ json.Marshaler    = (*AccessSwitch)(nil)
-	_ json.Unmarshaler  = (*AccessSwitch)(nil)
+	_ json.Marshaler   = (*AccessSwitch)(nil)
+	_ json.Unmarshaler = (*AccessSwitch)(nil)
 )
 
 type AccessSwitch struct {

--- a/design/rack_type_generic_system.go
+++ b/design/rack_type_generic_system.go
@@ -16,9 +16,8 @@ import (
 )
 
 var (
-	_ logicalDeviceIDer = (*GenericSystem)(nil)
-	_ json.Marshaler    = (*GenericSystem)(nil)
-	_ json.Unmarshaler  = (*GenericSystem)(nil)
+	_ json.Marshaler   = (*GenericSystem)(nil)
+	_ json.Unmarshaler = (*GenericSystem)(nil)
 )
 
 type GenericSystem struct {

--- a/design/rack_type_leaf_switch.go
+++ b/design/rack_type_leaf_switch.go
@@ -16,9 +16,8 @@ import (
 )
 
 var (
-	_ logicalDeviceIDer = (*LeafSwitch)(nil)
-	_ json.Marshaler    = (*LeafSwitch)(nil)
-	_ json.Unmarshaler  = (*LeafSwitch)(nil)
+	_ json.Marshaler   = (*LeafSwitch)(nil)
+	_ json.Unmarshaler = (*LeafSwitch)(nil)
 )
 
 type LeafSwitch struct {


### PR DESCRIPTION
The `design.logicalDeviceIDer` was a development crutch I used to make sure I implemented some required functions.

It does not need to be part of the released package.

This PR removes it.