### PR TITLE
Bugfix: use `clientCfg` rather than `testClientCfg.clientConfig()` when creating test client

### DIFF
--- a/internal/test_utils/test_client/client.go
+++ b/internal/test_utils/test_client/client.go
@@ -98,7 +98,7 @@ func GetTestClients(t testing.TB, ctx context.Context) []TestClient {
 		clientCfg.Experimental = experimental
 		clientCfg.Logger = log.New(logFile, "", log.LstdFlags)
 
-		client, err := testClientCfg.clientConfig().NewClient(ctx)
+		client, err := clientCfg.NewClient(ctx)
 		require.NoError(t, err)
 
 		testClients[i] = TestClient{


### PR DESCRIPTION
One-line bugfix in test code: Prior to this PR, we configured `clientCfg` with a logger and the _experimental_ flag, but didn't use it when creating our `Client` object.

This PR ensures that the correct configuration is used to create the client.