### PR TITLE
CT test requires RZ with IPv4 + IPv6 support in Apstra 6.1

### DIFF
--- a/apstra/two_stage_l3_clos_endpoint_policies_status_integration_test.go
+++ b/apstra/two_stage_l3_clos_endpoint_policies_status_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/Juniper/apstra-go-sdk/compatibility"
 	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/stretchr/testify/require"
 )
@@ -81,11 +82,17 @@ func TestGetAllConnectivityTemplateStatus(t *testing.T) {
 			topLevel:    true,
 		}
 
+		var as *enum.AddressingScheme
+		if compatibility.SecurityZoneAddressingSupported.Check(bp.client.apiVersion) {
+			as = &enum.AddressingSchemeIPv46
+		}
+
 		szLabel := randString(6, "hex")
 		szId, err := bp.CreateSecurityZone(ctx, SecurityZone{
-			Label:   szLabel,
-			Type:    enum.SecurityZoneTypeEVPN,
-			VRFName: szLabel,
+			Label:             szLabel,
+			Type:              enum.SecurityZoneTypeEVPN,
+			VRFName:           szLabel,
+			AddressingSupport: as,
 		})
 		require.NoError(t, err)
 


### PR DESCRIPTION
CTs could not be applied without setting `addressing_support` attribute of Security Zone in Apstra 6.1

Closes #658