### PR TITLE
Don't send Logical Device timestamps when creating Template

### DIFF
--- a/apstra/api_design_templates_l3_collapsed.go
+++ b/apstra/api_design_templates_l3_collapsed.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// Copyright (c) Juniper Networks, Inc., 2025-2026.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/apstra/api_design_templates_pod_based.go
+++ b/apstra/api_design_templates_pod_based.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// Copyright (c) Juniper Networks, Inc., 2025-2026.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/apstra/api_design_templates_rack_based.go
+++ b/apstra/api_design_templates_rack_based.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// Copyright (c) Juniper Networks, Inc., 2025-2026.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
The legacy design package does two unfortunate things:
- retrieves existing objects by ID (rather than requiring the caller to embed objects)
- sends non-nil timestamps (those embedded in the objects retrieved above) when POST-ing to create a new Template

Apstra versions prior to 6.1 ignored the timestamps, but 6.1 does not (and returns an error).

This PR clears the retrieved timestamps from embedded logical devices prior to sending template creation payload.

Closes #662