### PR TITLE
Use dedicated RZ for leaf loopback testing

### DIFF
--- a/apstra/two_stage_l3_clos_security_zone_loopbacks_integration_test.go
+++ b/apstra/two_stage_l3_clos_security_zone_loopbacks_integration_test.go
@@ -133,7 +133,7 @@ func TestTwoStageL3ClosClient_SetSecurityZoneLoopbacks(t *testing.T) {
 				bindings[i] = VnBinding{SystemId: leafID}
 			}
 
-			// create a VN with IPv4 and IPv6 enabled
+			// create a VN with IPv4 and IPv6 enabled so that the VRF is rendered on switches and loopbacks will be assigned
 			_, err = bpClient.CreateVirtualNetwork(ctx, &VirtualNetworkData{
 				Ipv4Enabled:               true,
 				VirtualGatewayIpv4Enabled: true,


### PR DESCRIPTION
With Apstra 6.1 leaf loopbacks cannot be assigned in the default VRF.

This PR amends the `TestTwoStageL3ClosClient_SetSecurityZoneLoopbacks()` test so that it works with a dedicated VRF which supports both IPv4 and IPv6, rather than the default VRF.