### PR TITLE
add error matching condition

### DIFF
--- a/apstra/talk_to_apstra.go
+++ b/apstra/talk_to_apstra.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2022-2025.
+// Copyright (c) Juniper Networks, Inc., 2022-2026.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
Apstra 6.1.0 returns a new error when attempting to create VXLAN name collisions.

This PR detects the "overlaps with" text along with the old "not unique" text.

```json
{
  "api_response": null,
  "config_blueprint_version": 0,
  "errors": {
    "nodes": {
      "flAnNeHlW6UDvRWMmQ": [
        {
          "severity": "critical",
          "display_category": "unknown",
          "resolutions": [],
          "message": "Virtual Network name \"test-9c7ef\" overlaps with a VXLAN name",
          "error_type": "VN_NAME_VXLAN_OVERLAPS",
          "entity_type": "unknown"
        }
      ]
    },
    "relationships": {}
  },
  "error_code": 422
}
```

Closes #670