### PR TITLE
Refactor `TestGetInterfaceMapDigestsByDeviceProfile()` for longer timeouts

### DIFF
--- a/apstra/api_design_interface_map_digests_integration_test.go
+++ b/apstra/api_design_interface_map_digests_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2022-2025.
+// Copyright (c) Juniper Networks, Inc., 2022-2026.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
Apstra 6.1.0 on CloudLabs cannot complete `GetDeviceProfiles()` within the default timeout interval.

This PR refactors `GetDeviceProfiles()` into individual subtests with appropriate timeouts where needed.