### PR TITLE
Use 1m timeout for config template integration test API calls

### DIFF
--- a/design/config_template_integration_test.go
+++ b/design/config_template_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// Copyright (c) Juniper Networks, Inc., 2025-2026.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
Two issues with the Config Template API in 6.1.0:

1. Verified with sniffer: When under load (all tests running), Apstra 6.1.0 consistently takes > 10s to return config template API requests.

This PR wraps each of those calls with a context which allows 60s.

2. Our test cases use the same template name. This hasn't been a problem before (old template deleted before new one installed), but 6.1.0 is detecting name collisions under load.

This PR ensures that each test case uses a different template name.