### PR TITLE
Remove parameter from format string for `go vet`

### DIFF
--- a/internal/test_utils/compare/freeform/aggregate_link_endpoint_group.go
+++ b/internal/test_utils/compare/freeform/aggregate_link_endpoint_group.go
@@ -7,7 +7,6 @@
 package comparefreeform
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
@@ -40,11 +39,11 @@ func AggregateLinkEndpointGroup(t testing.TB, req, resp apstra.FreeformAggregate
 		respEndpoints[ep.SystemID] = ep
 	}
 
-	for sysID, reqEp := range req.Endpoints {
+	for _, reqEp := range req.Endpoints {
 		respEp, ok := respEndpoints[reqEp.SystemID]
 		require.True(t, ok, msg)
 
-		msg := testmessage.Add(msg, fmt.Sprintf("Comparing Endpoint on system %q", sysID))
+		msg := testmessage.Add(msg, "Comparing Endpoint on system %q")
 		AggregateLinkEndpoint(t, reqEp, respEp, msg...)
 	}
 }


### PR DESCRIPTION
Remove variable from format string to avoid this problem in `compare` test helper package:

```
% go test --tags=integration,requiretestutils github.com/Juniper/apstra-go-sdk/internal/test_utils/compare/freeform/...
# github.com/Juniper/apstra-go-sdk/internal/test_utils/compare/freeform
internal/test_utils/compare/freeform/aggregate_link_endpoint_group.go:47:31: non-constant format string in call to github.com/Juniper/apstra-go-sdk/internal/test_utils/test_message.Add
FAIL    github.com/Juniper/apstra-go-sdk/internal/test_utils/compare/freeform [build failed]
FAIL
```

Note that it's not directly observable as a format string, but values passed to `testmessage.Add()` are used as format strings, so it's buried in there somewhere.