### PR TITLE
Remove parameter from format string for `go vet`

### DIFF
--- a/internal/test_utils/compare/freeform/aggregate_link_endpoint_group.go
+++ b/internal/test_utils/compare/freeform/aggregate_link_endpoint_group.go
@@ -43,7 +43,6 @@ func AggregateLinkEndpointGroup(t testing.TB, req, resp apstra.FreeformAggregate
 		respEp, ok := respEndpoints[reqEp.SystemID]
 		require.True(t, ok, msg)
 
-		msg := testmessage.Add(msg, "Comparing Endpoint")
 		AggregateLinkEndpoint(t, reqEp, respEp, msg...)
 	}
 }


### PR DESCRIPTION
This is what I should have done in #684