### PR TITLE
Don't send timestamps when creating pod-based templates

### DIFF
--- a/apstra/api_design_templates_pod_based.go
+++ b/apstra/api_design_templates_pod_based.go
@@ -175,6 +175,8 @@ func (o *TemplateElementSuperspineRequest) raw(ctx context.Context, client *Clie
 	if err != nil {
 		return nil, err
 	}
+	logicalDevice.CreatedAt = nil
+	logicalDevice.LastModifiedAt = nil
 
 	return &rawSuperspine{
 		PlaneCount:         o.PlaneCount,
@@ -297,9 +299,17 @@ func (o *CreatePodBasedTemplateRequest) raw(ctx context.Context, client *Client)
 		if err != nil {
 			return nil, err
 		}
+		// Clear timestamp values retrieved from the API so we don't send them
+		// when creating the template. Required by Apstra 6.1.
+		rbt.CreatedAt = nil
+		rbt.LastModifiedAt = nil
+		rbt.Spine.LogicalDevice.CreatedAt = nil
+		rbt.Spine.LogicalDevice.LastModifiedAt = nil
 		for j := range rbt.RackTypes {
+			rbt.RackTypes[j].CreatedAt = nil
+			rbt.RackTypes[j].LastModifiedAt = nil
 			for jj := range rbt.RackTypes[j].LogicalDevices {
-				// Clear these values retrieved from the API so we don't send them
+				// Clear timestamp values retrieved from the API so we don't send them
 				// when creating the template. Required by Apstra 6.1.
 				rbt.RackTypes[j].LogicalDevices[jj].CreatedAt = nil
 				rbt.RackTypes[j].LogicalDevices[jj].LastModifiedAt = nil

--- a/apstra/api_design_templates_rack_based.go
+++ b/apstra/api_design_templates_rack_based.go
@@ -20,8 +20,8 @@ var _ Template = &TemplateRackBased{}
 
 type TemplateRackBased struct {
 	Id             ObjectId
-	CreatedAt      time.Time
-	LastModifiedAt time.Time
+	CreatedAt      *time.Time
+	LastModifiedAt *time.Time
 	templateType   TemplateType
 	Data           *TemplateRackBasedData
 }
@@ -46,8 +46,8 @@ type rawTemplateRackBased struct {
 	Type                 templateType            `json:"type"`
 	DisplayName          string                  `json:"display_name"`
 	AntiAffinityPolicy   *rawAntiAffinityPolicy  `json:"anti_affinity_policy,omitempty"`
-	CreatedAt            time.Time               `json:"created_at"`
-	LastModifiedAt       time.Time               `json:"last_modified_at"`
+	CreatedAt            *time.Time              `json:"created_at,omitempty"`
+	LastModifiedAt       *time.Time              `json:"last_modified_at,omitempty"`
 	VirtualNetworkPolicy rawVirtualNetworkPolicy `json:"virtual_network_policy"`
 	AsnAllocationPolicy  rawAsnAllocationPolicy  `json:"asn_allocation_policy"`
 	Capability           templateCapability      `json:"capability,omitempty"`


### PR DESCRIPTION
Similar problem for rack-based templates was solved recently.

The old way we create a pod-based template involves pulling embedded objects (rack-based templates, logical devices) by ID and then embedding them in our pod-base payload.

Apstra 6.1.0 doesn't want to see the old timestamps.

This PR ensures that the timestamps are pointers (making them optional), that they're omitted by the JSON marshaling function when `nil`, and that they are `nil` in this context.