### PR TITLE
Bugfix: Cabling Map Endpoint should omit zero values when marshaling JSON

### DIFF
--- a/apstra/two_stage_l3_clos_cabling_map.go
+++ b/apstra/two_stage_l3_clos_cabling_map.go
@@ -62,30 +62,36 @@ type CablingMapLinkEndpointInterface struct {
 func (c CablingMapLinkEndpointInterface) MarshalJSON() ([]byte, error) {
 	raw := struct {
 		ID       string          `json:"id"`
-		IfName   json.RawMessage `json:"if_name"`
-		IPv4Addr json.RawMessage `json:"ipv4_addr"`
-		IPv6Addr json.RawMessage `json:"ipv6_addr"`
+		IfName   json.RawMessage `json:"if_name,omitempty"`
+		IPv4Addr json.RawMessage `json:"ipv4_addr,omitempty"`
+		IPv6Addr json.RawMessage `json:"ipv6_addr,omitempty"`
 	}{ID: c.ID}
 
 	// Clear value from API by sending `null` if value is a pointer to an empty string.
-	if c.IfName != nil && *c.IfName == "" {
-		raw.IfName = []byte("null")
-	} else {
-		raw.IfName, _ = json.Marshal(c.IfName)
+	if c.IfName != nil {
+		if *c.IfName == "" {
+			raw.IfName = []byte("null")
+		} else {
+			raw.IfName, _ = json.Marshal(c.IfName)
+		}
 	}
 
-	// Clear value from API by sending `null` if value is a pointer to an invalid prefix.
-	if c.IPv4Addr != nil && !c.IPv4Addr.IsValid() {
-		raw.IPv4Addr = []byte("null")
-	} else {
-		raw.IPv4Addr, _ = json.Marshal(c.IPv4Addr)
+	// Clear IPv4 value from API by sending `null` if value is a pointer to an invalid prefix.
+	if c.IPv4Addr != nil {
+		if c.IPv4Addr.IsValid() {
+			raw.IPv4Addr, _ = json.Marshal(c.IPv4Addr)
+		} else {
+			raw.IPv4Addr = []byte("null")
+		}
 	}
 
-	// Clear value from API by sending `null` if value is a pointer to an invalid prefix.
-	if c.IPv6Addr != nil && !c.IPv6Addr.IsValid() {
-		raw.IPv6Addr = []byte("null")
-	} else {
-		raw.IPv6Addr, _ = json.Marshal(c.IPv6Addr)
+	// Clear IPv6 value from API by sending `null` if value is a pointer to an invalid prefix.
+	if c.IPv6Addr != nil {
+		if c.IPv6Addr.IsValid() {
+			raw.IPv6Addr, _ = json.Marshal(c.IPv6Addr)
+		} else {
+			raw.IPv6Addr = []byte("null")
+		}
 	}
 
 	return json.Marshal(raw)

--- a/apstra/two_stage_l3_clos_cabling_map_integration_test.go
+++ b/apstra/two_stage_l3_clos_cabling_map_integration_test.go
@@ -227,6 +227,28 @@ func TestPatchCablingMapLinks(t *testing.T) {
 			require.NotNil(t, resp)
 			compareLinks(t, *req, *resp)
 
+			// patch the link with a minimal (no-op) patch to ensure that nothing changes
+			req.Endpoints[0].Interface.IfName = nil   //    do not modify this field
+			req.Endpoints[0].Interface.IPv4Addr = nil //  do not modify this field
+			req.Endpoints[0].Interface.IPv6Addr = nil //  do not modify this field
+			req.Endpoints[1].Interface.IfName = nil   //    do not modify this field
+			req.Endpoints[1].Interface.IPv4Addr = nil //  do not modify this field
+			req.Endpoints[1].Interface.IPv6Addr = nil //  do not modify this field
+			err = bpClient.PatchCablingMapLinks(ctx, []CablingMapLink{*req})
+			require.NoError(t, err)
+
+			// retrieve and check the no-op patched link
+			links, err = bpClient.GetCablingMapLinks(ctx)
+			require.NoError(t, err)
+			for _, v := range links {
+				if v.ID == linkID {
+					resp = &v
+					break
+				}
+			}
+			require.NotNil(t, resp)
+			compareLinks(t, *req, *resp)
+
 			// clear the values from the patchable fields using our non-nil empty value signals.
 			req.Endpoints[0].Interface.IfName = pointer.To("")
 			req.Endpoints[0].Interface.IPv4Addr = new(netip.Prefix)

--- a/apstra/two_stage_l3_clos_cabling_map_test.go
+++ b/apstra/two_stage_l3_clos_cabling_map_test.go
@@ -1,0 +1,52 @@
+package apstra_test
+
+import (
+	"encoding/json"
+	"net/netip"
+	"testing"
+
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/internal/pointer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCablingMapLinkEndpointInterface_MarshalJSON(t *testing.T) {
+	type TestCase struct {
+		data     apstra.CablingMapLinkEndpointInterface
+		expected string
+	}
+
+	testCases := map[string]TestCase{
+		"everything_null": {
+			data: apstra.CablingMapLinkEndpointInterface{
+				ID:       "abc",
+				IfName:   pointer.To(""),
+				IPv4Addr: new(netip.Prefix),
+				IPv6Addr: new(netip.Prefix),
+			},
+			expected: `{"id":"abc","if_name":null,"ipv4_addr":null,"ipv6_addr":null}`,
+		},
+		"everything_populated": {
+			data: apstra.CablingMapLinkEndpointInterface{
+				ID:       "abc",
+				IfName:   pointer.To("def"),
+				IPv4Addr: pointer.To(netip.MustParsePrefix("192.0.2.55/24")),
+				IPv6Addr: pointer.To(netip.MustParsePrefix("3fff::1:2:3/64")),
+			},
+			expected: `{"id":"abc","if_name":"def","ipv4_addr":"192.0.2.55/24","ipv6_addr":"3fff::1:2:3/64"}`,
+		},
+		"everyting_omitted": {
+			data:     apstra.CablingMapLinkEndpointInterface{ID: "abc"},
+			expected: `{"id":"abc"}`,
+		},
+	}
+
+	for tName, tCase := range testCases {
+		t.Run(tName, func(t *testing.T) {
+			t.Parallel()
+			result, err := json.Marshal(tCase.data)
+			require.NoError(t, err)
+			require.JSONEq(t, tCase.expected, string(result))
+		})
+	}
+}

--- a/apstra/two_stage_l3_clos_cabling_map_test.go
+++ b/apstra/two_stage_l3_clos_cabling_map_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2026-2026.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package apstra_test
 
 import (


### PR DESCRIPTION
Prior to this PR, it was possible to set and clear cabling map endpoint values:

Set example:
```json
{
  "id": "abc",
  "if_name": "def",
  "ipv4_addr": "192.0.2.55/24",
  "ipv6_addr": "3fff::1:2:3/64"
}
```

Clear example:
```json
{
  "id": "abc",
  "if_name": null,
  "ipv4_addr": null,
  "ipv6_addr": null
}
```

But it wasn't possible to omit values we didn't want to modify:
```json
{
  "id": "abc"
}
```

This PR changes the marshal logic, introduces unit tests, and introduces a no-op `PATCH` integration test with omitted values.