### PR TITLE
Breaking Change: Rename elements within `apstra.CablingMapLink`

### DIFF
--- a/apstra/test_helpers.go
+++ b/apstra/test_helpers.go
@@ -192,7 +192,7 @@ func countSystemLinkTypes(ctx context.Context, systemId ObjectId, client *TwoSta
 	for _, link := range links {
 		if link.Type != nil {
 			result[*link.Type]++
-			if *link.Type == enum.LinkTypeEthernet && link.AggregateLinkId != nil && *link.AggregateLinkId != "" {
+			if *link.Type == enum.LinkTypeEthernet && link.AggregateLinkID != nil && *link.AggregateLinkID != "" {
 				lagMembers++
 			}
 		}

--- a/apstra/two_stage_l3_clos_cabling_map.go
+++ b/apstra/two_stage_l3_clos_cabling_map.go
@@ -28,7 +28,7 @@ type CablingMapLink struct {
 	ID              string                    `json:"id,omitempty"`
 	TagLabels       []string                  `json:"tags,omitempty"`
 	Speed           *enum.LinkSpeed           `json:"speed,omitempty"`
-	AggregateLinkId *string                   `json:"aggregate_link_id,omitempty"`
+	AggregateLinkID *string                   `json:"aggregate_link_id,omitempty"`
 	GroupLabel      *string                   `json:"group_label,omitempty"`
 	Label           *string                   `json:"label,omitempty"`
 	Role            *enum.LinkRole            `json:"role,omitempty"`
@@ -47,9 +47,9 @@ var _ json.Marshaler = (*CablingMapLinkEndpointInterface)(nil)
 type CablingMapLinkEndpointInterface struct {
 	Description    *string                       `json:"description,omitempty"`
 	TagLabels      []string                      `json:"tags,omitempty"`
-	IfType         *enum.InterfaceType           `json:"if_type,omitempty"`
+	Type           *enum.InterfaceType           `json:"if_type,omitempty"`
 	OperationState *enum.InterfaceOperationState `json:"operation_state,omitempty"`
-	IfName         *string                       `json:"if_name,omitempty"`
+	Name           *string                       `json:"if_name,omitempty"`
 	PortChannelID  *int                          `json:"port_channel_id,omitempty"`
 	ID             string                        `json:"id"`
 	LAGMode        *enum.LAGMode                 `json:"lag_mode,omitempty"`
@@ -62,17 +62,17 @@ type CablingMapLinkEndpointInterface struct {
 func (c CablingMapLinkEndpointInterface) MarshalJSON() ([]byte, error) {
 	raw := struct {
 		ID       string          `json:"id"`
-		IfName   json.RawMessage `json:"if_name,omitempty"`
+		Name     json.RawMessage `json:"if_name,omitempty"`
 		IPv4Addr json.RawMessage `json:"ipv4_addr,omitempty"`
 		IPv6Addr json.RawMessage `json:"ipv6_addr,omitempty"`
 	}{ID: c.ID}
 
 	// Clear value from API by sending `null` if value is a pointer to an empty string.
-	if c.IfName != nil {
-		if *c.IfName == "" {
-			raw.IfName = []byte("null")
+	if c.Name != nil {
+		if *c.Name == "" {
+			raw.Name = []byte("null")
 		} else {
-			raw.IfName, _ = json.Marshal(c.IfName)
+			raw.Name, _ = json.Marshal(c.Name)
 		}
 	}
 
@@ -108,11 +108,11 @@ type CablingMapLinkEndpointSystem struct {
 // or "def456:eth0"
 // If any of the required elements are nil, nil is returned.
 func (o CablingMapLinkEndpoint) Digest() *string {
-	if o.System == nil || o.Interface.IfName == nil {
+	if o.System == nil || o.Interface.Name == nil {
 		return nil
 	}
 
-	result := o.System.ID + ":" + *o.Interface.IfName
+	result := o.System.ID + ":" + *o.Interface.Name
 	return &result
 }
 
@@ -224,8 +224,8 @@ func (o *TwoStageL3ClosClient) PatchCablingMapLinks(ctx context.Context, in []Ca
 				{Interface: CablingMapLinkEndpointInterface{ID: link.Endpoints[1].Interface.ID}},
 			},
 		}
-		if link.Endpoints[0].Interface.IfName != nil {
-			payload.Links[i].Endpoints[0].Interface.IfName = link.Endpoints[0].Interface.IfName
+		if link.Endpoints[0].Interface.Name != nil {
+			payload.Links[i].Endpoints[0].Interface.Name = link.Endpoints[0].Interface.Name
 		}
 		if link.Endpoints[0].Interface.IPv4Addr != nil {
 			payload.Links[i].Endpoints[0].Interface.IPv4Addr = link.Endpoints[0].Interface.IPv4Addr
@@ -233,8 +233,8 @@ func (o *TwoStageL3ClosClient) PatchCablingMapLinks(ctx context.Context, in []Ca
 		if link.Endpoints[0].Interface.IPv6Addr != nil {
 			payload.Links[i].Endpoints[0].Interface.IPv6Addr = link.Endpoints[0].Interface.IPv6Addr
 		}
-		if link.Endpoints[1].Interface.IfName != nil {
-			payload.Links[i].Endpoints[1].Interface.IfName = link.Endpoints[1].Interface.IfName
+		if link.Endpoints[1].Interface.Name != nil {
+			payload.Links[i].Endpoints[1].Interface.Name = link.Endpoints[1].Interface.Name
 		}
 		if link.Endpoints[1].Interface.IPv4Addr != nil {
 			payload.Links[i].Endpoints[1].Interface.IPv4Addr = link.Endpoints[1].Interface.IPv4Addr

--- a/apstra/two_stage_l3_clos_cabling_map_integration_test.go
+++ b/apstra/two_stage_l3_clos_cabling_map_integration_test.go
@@ -100,12 +100,12 @@ func TestPatchCablingMapLinks(t *testing.T) {
 	// This test assumes that specific IPv4 and IPv6 pools have been assigned, checks for those prefixes.
 	compareLinks := func(t *testing.T, req, resp CablingMapLink) {
 		require.Equal(t, req.Endpoints[0].Interface.ID, resp.Endpoints[0].Interface.ID)
-		if req.Endpoints[0].Interface.IfName != nil { // IF Name must match or be nil
-			if *req.Endpoints[0].Interface.IfName == "" {
-				require.Nil(t, resp.Endpoints[0].Interface.IfName)
+		if req.Endpoints[0].Interface.Name != nil { // IF Name must match or be nil
+			if *req.Endpoints[0].Interface.Name == "" {
+				require.Nil(t, resp.Endpoints[0].Interface.Name)
 			} else {
-				require.NotNil(t, resp.Endpoints[0].Interface.IfName)
-				require.Equal(t, *req.Endpoints[0].Interface.IfName, *resp.Endpoints[0].Interface.IfName)
+				require.NotNil(t, resp.Endpoints[0].Interface.Name)
+				require.Equal(t, *req.Endpoints[0].Interface.Name, *resp.Endpoints[0].Interface.Name)
 			}
 		}
 		if req.Endpoints[0].Interface.IPv4Addr != nil { // IPv4 Addr must match or come from pool
@@ -126,12 +126,12 @@ func TestPatchCablingMapLinks(t *testing.T) {
 		}
 
 		require.Equal(t, req.Endpoints[1].Interface.ID, resp.Endpoints[1].Interface.ID)
-		if req.Endpoints[1].Interface.IfName != nil { // IF Name must match or be nil
-			if *req.Endpoints[1].Interface.IfName == "" {
-				require.Nil(t, resp.Endpoints[1].Interface.IfName)
+		if req.Endpoints[1].Interface.Name != nil { // IF Name must match or be nil
+			if *req.Endpoints[1].Interface.Name == "" {
+				require.Nil(t, resp.Endpoints[1].Interface.Name)
 			} else {
-				require.NotNil(t, resp.Endpoints[1].Interface.IfName)
-				require.Equal(t, *req.Endpoints[1].Interface.IfName, *resp.Endpoints[1].Interface.IfName)
+				require.NotNil(t, resp.Endpoints[1].Interface.Name)
+				require.Equal(t, *req.Endpoints[1].Interface.Name, *resp.Endpoints[1].Interface.Name)
 			}
 		}
 		if req.Endpoints[1].Interface.IPv4Addr != nil { // IPv4 Addr must match or come from pool
@@ -204,10 +204,10 @@ func TestPatchCablingMapLinks(t *testing.T) {
 			ipv6Base := ipv6Addr.Masked()
 			ipv4Next := netip.PrefixFrom(ipv4Base.Addr().Next(), ipv4Base.Bits())
 			ipv6Next := netip.PrefixFrom(ipv6Base.Addr().Next(), ipv6Base.Bits())
-			req.Endpoints[0].Interface.IfName = pointer.To(randString(6, "hex"))
+			req.Endpoints[0].Interface.Name = pointer.To(randString(6, "hex"))
 			req.Endpoints[0].Interface.IPv4Addr = pointer.To(ipv4Base)
 			req.Endpoints[0].Interface.IPv6Addr = pointer.To(ipv6Base)
-			req.Endpoints[1].Interface.IfName = pointer.To(randString(6, "hex"))
+			req.Endpoints[1].Interface.Name = pointer.To(randString(6, "hex"))
 			req.Endpoints[1].Interface.IPv4Addr = pointer.To(ipv4Next)
 			req.Endpoints[1].Interface.IPv6Addr = pointer.To(ipv6Next)
 
@@ -228,10 +228,10 @@ func TestPatchCablingMapLinks(t *testing.T) {
 			compareLinks(t, *req, *resp)
 
 			// patch the link with a minimal (no-op) patch to ensure that nothing changes
-			req.Endpoints[0].Interface.IfName = nil   //    do not modify this field
+			req.Endpoints[0].Interface.Name = nil     //    do not modify this field
 			req.Endpoints[0].Interface.IPv4Addr = nil //  do not modify this field
 			req.Endpoints[0].Interface.IPv6Addr = nil //  do not modify this field
-			req.Endpoints[1].Interface.IfName = nil   //    do not modify this field
+			req.Endpoints[1].Interface.Name = nil     //    do not modify this field
 			req.Endpoints[1].Interface.IPv4Addr = nil //  do not modify this field
 			req.Endpoints[1].Interface.IPv6Addr = nil //  do not modify this field
 			err = bpClient.PatchCablingMapLinks(ctx, []CablingMapLink{*req})
@@ -250,10 +250,10 @@ func TestPatchCablingMapLinks(t *testing.T) {
 			compareLinks(t, *req, *resp)
 
 			// clear the values from the patchable fields using our non-nil empty value signals.
-			req.Endpoints[0].Interface.IfName = pointer.To("")
+			req.Endpoints[0].Interface.Name = pointer.To("")
 			req.Endpoints[0].Interface.IPv4Addr = new(netip.Prefix)
 			req.Endpoints[0].Interface.IPv6Addr = new(netip.Prefix)
-			req.Endpoints[1].Interface.IfName = pointer.To("")
+			req.Endpoints[1].Interface.Name = pointer.To("")
 			req.Endpoints[1].Interface.IPv4Addr = new(netip.Prefix)
 			req.Endpoints[1].Interface.IPv6Addr = new(netip.Prefix)
 

--- a/apstra/two_stage_l3_clos_cabling_map_test.go
+++ b/apstra/two_stage_l3_clos_cabling_map_test.go
@@ -24,7 +24,7 @@ func TestCablingMapLinkEndpointInterface_MarshalJSON(t *testing.T) {
 		"everything_null": {
 			data: apstra.CablingMapLinkEndpointInterface{
 				ID:       "abc",
-				IfName:   pointer.To(""),
+				Name:     pointer.To(""),
 				IPv4Addr: new(netip.Prefix),
 				IPv6Addr: new(netip.Prefix),
 			},
@@ -33,7 +33,7 @@ func TestCablingMapLinkEndpointInterface_MarshalJSON(t *testing.T) {
 		"everything_populated": {
 			data: apstra.CablingMapLinkEndpointInterface{
 				ID:       "abc",
-				IfName:   pointer.To("def"),
+				Name:     pointer.To("def"),
 				IPv4Addr: pointer.To(netip.MustParsePrefix("192.0.2.55/24")),
 				IPv6Addr: pointer.To(netip.MustParsePrefix("3fff::1:2:3/64")),
 			},


### PR DESCRIPTION
This PR renames a few objects within the `apstra.CablingMapLink` struct:
- `AggregateLinkId` -> `AggregateLinkID`
- `CablingMapLinkEndpointInterface.IfType` -> `CablingMapLinkEndpointInterface.Type`
- `CablingMapLinkEndpointInterface.IfName` -> `CablingMapLinkEndpointInterface.Name`