### PR TITLE
Refactor EVPN interconnect group struct and methods for minimial PATCH

### DIFF
--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"math"
 	"math/rand"
 	"net"
 	"net/netip"
@@ -86,89 +85,6 @@ func netIpToNetIpAddr(t *testing.T, ip net.IP) netip.Addr {
 	result, err := netip.ParseAddr(ip.String())
 	require.NoError(t, err)
 	return result
-}
-
-// randomHardwareAddr returns a net.HardwareAddr. The set and unset arguments
-// allow the caller to specify certain bits which must be set or must be unset
-// in the result.
-// For example, to get a random mac with only the LAA bit set, you'd invoke the
-// function with arguments indicating that LAA must be set and all other bits
-// in the first byte must be unset:
-//
-//	set:   []byte{2},
-//	unset: []byte{253},
-func randomHardwareAddr(set []byte, unset []byte) net.HardwareAddr {
-	result := net.HardwareAddr{
-		byte(rand.Intn(math.MaxUint8 + 1)),
-		byte(rand.Intn(math.MaxUint8 + 1)),
-		byte(rand.Intn(math.MaxUint8 + 1)),
-		byte(rand.Intn(math.MaxUint8 + 1)),
-		byte(rand.Intn(math.MaxUint8 + 1)),
-		byte(rand.Intn(math.MaxUint8 + 1)),
-	}
-
-	for i := range min(len(set), len(result)) {
-		result[i] = result[i] | set[i]
-	}
-
-	for i := range min(len(unset), len(result)) {
-		result[i] = result[i] & ^unset[i]
-	}
-
-	return result
-}
-
-func TestRandomHardwareAddr(t *testing.T) {
-	type testCase struct {
-		set   []byte
-		unset []byte
-	}
-
-	testCases := map[string]testCase{
-		"laa": {
-			set: []byte{2},
-		},
-		"group": {
-			set: []byte{1},
-		},
-		"laa_and_not_group": {
-			set:   []byte{2},
-			unset: []byte{1},
-		},
-		"group_and_not_laa": {
-			set:   []byte{1},
-			unset: []byte{2},
-		},
-		"laa_and_group": {
-			set: []byte{3},
-		},
-		"last_byte_128": {
-			set:   []byte{0, 0, 0, 0, 0, 128},
-			unset: []byte{0, 0, 0, 0, 0, 127},
-		},
-		"last_byte_high": {
-			set: []byte{0, 0, 0, 0, 0, 128},
-		},
-		"last_byte_low": {
-			unset: []byte{0, 0, 0, 0, 0, 128},
-		},
-	}
-
-	for tName, tCase := range testCases {
-		t.Run(tName, func(t *testing.T) {
-			t.Parallel()
-
-			result := randomHardwareAddr(tCase.set, tCase.unset)
-
-			for i, setByte := range tCase.set {
-				require.Equal(t, setByte, result[i]&setByte)
-			}
-
-			for i, unsetByte := range tCase.unset {
-				require.Equal(t, ^unsetByte, result[i]|^unsetByte)
-			}
-		})
-	}
 }
 
 // randomIntsN fills the supplied slice with non-negative pseudo-random values in the half-open interval [0,n)

--- a/apstra/two_stage_l3_clos_evpn_interconnect_group.go
+++ b/apstra/two_stage_l3_clos_evpn_interconnect_group.go
@@ -10,6 +10,10 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+
+	sdk "github.com/Juniper/apstra-go-sdk"
+	"github.com/Juniper/apstra-go-sdk/internal"
+	"github.com/Juniper/apstra-go-sdk/internal/str"
 )
 
 const (
@@ -18,77 +22,102 @@ const (
 	apiUrlBlueprintEvpnInterconnectGroupById    = apiUrlBlueprintEvpnInterconnectGroupsPrefix + "%s"
 )
 
-var _ json.Unmarshaler = (*EvpnInterconnectGroup)(nil)
-
-type EvpnInterconnectGroup struct {
-	Id   ObjectId
-	Data *EvpnInterconnectGroupData
+type InterconnectVirtualNetwork struct {
+	L2Enabled      bool    `json:"l2"`
+	L3Enabled      bool    `json:"l3"`
+	TranslationVNI *uint32 `json:"translation_vni,omitempty"`
 }
 
-func (o *EvpnInterconnectGroup) UnmarshalJSON(bytes []byte) error {
-	var raw struct {
-		Id                        ObjectId                                  `json:"id"`
-		Label                     string                                    `json:"label"`
-		RouteTarget               string                                    `json:"interconnect_route_target"`
-		EsiMac                    *string                                   `json:"interconnect_esi_mac"`
-		InterconnectSecurityZones map[ObjectId]InterconnectSecurityZoneData `json:"interconnect_security_zones"`
+type InterconnectSecurityZone struct {
+	L3Enabled       bool    `json:"enabled_for_l3"`
+	RouteTarget     *string `json:"interconnect_route_target"`
+	RoutingPolicyId *string `json:"routing_policy_id"`
+}
+
+var (
+	_ internal.IDer    = (*EVPNInterconnectGroup)(nil)
+	_ json.Marshaler   = (*EVPNInterconnectGroup)(nil)
+	_ json.Unmarshaler = (*EVPNInterconnectGroup)(nil)
+)
+
+type EVPNInterconnectGroup struct {
+	Label                       *string                               `json:"label,omitempty"`
+	RouteTarget                 *string                               `json:"interconnect_route_target,omitempty"`
+	ESIMAC                      net.HardwareAddr                      `json:"interconnect_esi_mac,omitempty"`
+	InterconnectSecurityZones   map[string]InterconnectSecurityZone   `json:"interconnect_security_zones,omitempty"`
+	InterconnectVirtualNetworks map[string]InterconnectVirtualNetwork `json:"interconnect_virtual_networks,omitempty"`
+
+	id string
+}
+
+func (e EVPNInterconnectGroup) ID() *string {
+	if e.id == "" {
+		return nil
+	}
+	return &e.id
+}
+
+func (e *EVPNInterconnectGroup) SetID(id string) error {
+	if e.id != "" {
+		return sdk.ErrIDAlreadySet(fmt.Sprintf("id already has value %q", e.id))
 	}
 
-	if err := json.Unmarshal(bytes, &raw); err != nil {
+	e.id = id
+	return nil
+}
+
+func (e EVPNInterconnectGroup) MarshalJSON() ([]byte, error) {
+	type Alias EVPNInterconnectGroup
+
+	return json.Marshal(&struct {
+		EsiMac string `json:"interconnect_esi_mac,omitempty"`
+		*Alias
+	}{
+		EsiMac: func() string {
+			if e.ESIMAC == nil {
+				return ""
+			}
+			return e.ESIMAC.String()
+		}(),
+		Alias: (*Alias)(&e),
+	})
+
+}
+
+func (e *EVPNInterconnectGroup) UnmarshalJSON(bytes []byte) error {
+	type Alias EVPNInterconnectGroup
+
+	aux := &struct {
+		ID     string `json:"id"`
+		ESIMAC string `json:"interconnect_esi_mac"`
+		*Alias
+	}{
+		Alias: (*Alias)(e),
+	}
+
+	if err := json.Unmarshal(bytes, aux); err != nil {
 		return err
 	}
 
-	o.Id = raw.Id
-	o.Data = new(EvpnInterconnectGroupData)
-	o.Data.Label = raw.Label
-	o.Data.RouteTarget = raw.RouteTarget
-	if raw.EsiMac != nil {
-		esiMac, err := net.ParseMAC(*raw.EsiMac)
+	e.id = aux.ID
+
+	if aux.ESIMAC != "" {
+		hw, err := net.ParseMAC(aux.ESIMAC)
 		if err != nil {
-			return fmt.Errorf("parsing interconnect esi mac: %s", err)
+			return err
 		}
-		o.Data.EsiMac = esiMac
+		e.ESIMAC = hw
+	} else {
+		e.ESIMAC = nil
 	}
-	o.Data.InterconnectSecurityZones = raw.InterconnectSecurityZones
 
 	return nil
 }
 
-type InterconnectSecurityZoneData struct {
-	RoutingPolicyId *ObjectId `json:"routing_policy_id"`
-	RouteTarget     *string   `json:"interconnect_route_target"`
-	L3Enabled       bool      `json:"enabled_for_l3"`
-}
-
-var _ json.Marshaler = (*EvpnInterconnectGroupData)(nil)
-
-type EvpnInterconnectGroupData struct {
-	Label                     string
-	RouteTarget               string
-	EsiMac                    net.HardwareAddr
-	InterconnectSecurityZones map[ObjectId]InterconnectSecurityZoneData
-}
-
-func (o EvpnInterconnectGroupData) MarshalJSON() ([]byte, error) {
-	var raw struct {
-		Label                     string                                    `json:"label"`
-		RouteTarget               string                                    `json:"interconnect_route_target"`
-		EsiMac                    string                                    `json:"interconnect_esi_mac,omitempty"`
-		InterconnectSecurityZones map[ObjectId]InterconnectSecurityZoneData `json:"interconnect_security_zones"`
+func (o *TwoStageL3ClosClient) CreateEVPNInterconnectGroup(ctx context.Context, in EVPNInterconnectGroup) (string, error) {
+	var response struct {
+		ID string `json:"id"`
 	}
-
-	raw.Label = o.Label
-	raw.RouteTarget = o.RouteTarget
-	if o.EsiMac != nil {
-		raw.EsiMac = o.EsiMac.String()
-	}
-	raw.InterconnectSecurityZones = o.InterconnectSecurityZones
-
-	return json.Marshal(raw)
-}
-
-func (o *TwoStageL3ClosClient) CreateEvpnInterconnectGroup(ctx context.Context, in *EvpnInterconnectGroupData) (ObjectId, error) {
-	var response objectIdResponse
 
 	err := o.client.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodPost,
@@ -100,11 +129,11 @@ func (o *TwoStageL3ClosClient) CreateEvpnInterconnectGroup(ctx context.Context, 
 		return "", convertTtaeToAceWherePossible(err)
 	}
 
-	return response.Id, nil
+	return response.ID, nil
 }
 
-func (o *TwoStageL3ClosClient) GetEvpnInterconnectGroup(ctx context.Context, id ObjectId) (*EvpnInterconnectGroup, error) {
-	var response EvpnInterconnectGroup
+func (o *TwoStageL3ClosClient) GetEVPNInterconnectGroup(ctx context.Context, id string) (EVPNInterconnectGroup, error) {
+	var response EVPNInterconnectGroup
 
 	err := o.client.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodGet,
@@ -112,15 +141,15 @@ func (o *TwoStageL3ClosClient) GetEvpnInterconnectGroup(ctx context.Context, id 
 		apiResponse: &response,
 	})
 	if err != nil {
-		return nil, convertTtaeToAceWherePossible(err)
+		return EVPNInterconnectGroup{}, convertTtaeToAceWherePossible(err)
 	}
 
-	return &response, nil
+	return response, nil
 }
 
-func (o *TwoStageL3ClosClient) GetAllEvpnInterconnectGroups(ctx context.Context) ([]EvpnInterconnectGroup, error) {
+func (o *TwoStageL3ClosClient) GetAllEVPNInterconnectGroups(ctx context.Context) ([]EVPNInterconnectGroup, error) {
 	var response struct {
-		Items []EvpnInterconnectGroup `json:"evpn_interconnect_groups"`
+		Items []EVPNInterconnectGroup `json:"evpn_interconnect_groups"`
 	}
 
 	err := o.client.talkToApstra(ctx, &talkToApstraIn{
@@ -135,19 +164,19 @@ func (o *TwoStageL3ClosClient) GetAllEvpnInterconnectGroups(ctx context.Context)
 	return response.Items, nil
 }
 
-func (o *TwoStageL3ClosClient) GetEvpnInterconnectGroupByName(ctx context.Context, name string) (*EvpnInterconnectGroup, error) {
-	items, err := o.GetAllEvpnInterconnectGroups(ctx)
+func (o *TwoStageL3ClosClient) GetEVPNInterconnectGroupByName(ctx context.Context, name string) (EVPNInterconnectGroup, error) {
+	items, err := o.GetAllEVPNInterconnectGroups(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("GetAllEvpnInterconnectGroups: %w", err)
+		return EVPNInterconnectGroup{}, fmt.Errorf("GetAllEVPNInterconnectGroups: %w", err)
 	}
 
-	var evpnInterconnectGroup *EvpnInterconnectGroup
+	var evpnInterconnectGroup *EVPNInterconnectGroup
 	for _, item := range items {
-		if item.Data.Label == name {
+		if item.Label != nil && *item.Label == name {
 			if evpnInterconnectGroup == nil {
 				evpnInterconnectGroup = &item
 			} else {
-				return nil, ClientErr{
+				return EVPNInterconnectGroup{}, ClientErr{
 					errType: ErrMultipleMatch,
 					err:     fmt.Errorf("found multiple EVPN Interconnect Groups with label %q", name),
 				}
@@ -156,20 +185,24 @@ func (o *TwoStageL3ClosClient) GetEvpnInterconnectGroupByName(ctx context.Contex
 	}
 
 	if evpnInterconnectGroup == nil {
-		return nil, ClientErr{
+		return EVPNInterconnectGroup{}, ClientErr{
 			errType: ErrNotfound,
 			err:     fmt.Errorf("EVPN Interconnect Group with label %q not found", name),
 		}
 	}
 
-	return evpnInterconnectGroup, nil
+	return *evpnInterconnectGroup, nil
 }
 
-func (o *TwoStageL3ClosClient) UpdateEvpnInterconnectGroup(ctx context.Context, id ObjectId, cfg *EvpnInterconnectGroupData) error {
+func (o *TwoStageL3ClosClient) UpdateEVPNInterconnectGroup(ctx context.Context, v EVPNInterconnectGroup) error {
+	if v.ID() == nil {
+		return fmt.Errorf("id is required in %s", str.FuncName())
+	}
+
 	err := o.client.talkToApstra(ctx, &talkToApstraIn{
 		method:   http.MethodPatch,
-		urlStr:   fmt.Sprintf(apiUrlBlueprintEvpnInterconnectGroupById, o.Id(), id),
-		apiInput: cfg,
+		urlStr:   fmt.Sprintf(apiUrlBlueprintEvpnInterconnectGroupById, o.Id(), *v.ID()),
+		apiInput: &v,
 	})
 	if err != nil {
 		return convertTtaeToAceWherePossible(err)
@@ -178,7 +211,7 @@ func (o *TwoStageL3ClosClient) UpdateEvpnInterconnectGroup(ctx context.Context, 
 	return nil
 }
 
-func (o *TwoStageL3ClosClient) DeleteEvpnInterconnectGroup(ctx context.Context, id ObjectId) error {
+func (o *TwoStageL3ClosClient) DeleteEVPNInterconnectGroup(ctx context.Context, id string) error {
 	err := o.client.talkToApstra(ctx, &talkToApstraIn{
 		method: http.MethodDelete,
 		urlStr: fmt.Sprintf(apiUrlBlueprintEvpnInterconnectGroupById, o.Id(), id),

--- a/apstra/two_stage_l3_clos_evpn_interconnect_group.go
+++ b/apstra/two_stage_l3_clos_evpn_interconnect_group.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// Copyright (c) Juniper Networks, Inc., 2025-2026.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -81,7 +81,6 @@ func (e EVPNInterconnectGroup) MarshalJSON() ([]byte, error) {
 		}(),
 		Alias: (*Alias)(&e),
 	})
-
 }
 
 func (e *EVPNInterconnectGroup) UnmarshalJSON(bytes []byte) error {

--- a/apstra/two_stage_l3_clos_evpn_interconnect_group_integration_test.go
+++ b/apstra/two_stage_l3_clos_evpn_interconnect_group_integration_test.go
@@ -4,7 +4,7 @@
 
 //go:build integration
 
-package apstra
+package apstra_test
 
 import (
 	"context"
@@ -14,113 +14,86 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/apstra-go-sdk/enum"
+	"github.com/Juniper/apstra-go-sdk/internal/pointer"
+	testutils "github.com/Juniper/apstra-go-sdk/internal/test_utils"
+	"github.com/Juniper/apstra-go-sdk/internal/test_utils/compare"
+	comparedatacenter "github.com/Juniper/apstra-go-sdk/internal/test_utils/compare/datacenter"
+	dctestobj "github.com/Juniper/apstra-go-sdk/internal/test_utils/datacenter_test_objects"
+	testclient "github.com/Juniper/apstra-go-sdk/internal/test_utils/test_client"
 	"github.com/stretchr/testify/require"
 )
 
 func TestEvpnInterconnectGroup(t *testing.T) {
+	ctx := testutils.ContextWithTestID(context.Background(), t)
+	clients := testclient.GetTestClients(t, ctx)
+
 	securityZoneCount := 3
 	routingPolicyCount := 3
 
-	ctx := context.Background()
-
-	clients, err := getTestClients(ctx, t)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// in order to "wipe out" the association between a security zone and a
 	// routing policy the map entry for that security zone must be present.
-	populateMissingSZIDs := func(data *EvpnInterconnectGroupData, ids []ObjectId) {
+	populateMissingSZIDs := func(data apstra.EVPNInterconnectGroup, ids []string) {
 		if data.InterconnectSecurityZones == nil {
-			data.InterconnectSecurityZones = make(map[ObjectId]InterconnectSecurityZoneData)
+			data.InterconnectSecurityZones = make(map[string]apstra.InterconnectSecurityZone)
 		}
 		for _, id := range ids {
 			if _, ok := data.InterconnectSecurityZones[id]; ok {
 				continue
 			}
 
-			data.InterconnectSecurityZones[id] = InterconnectSecurityZoneData{}
+			data.InterconnectSecurityZones[id] = apstra.InterconnectSecurityZone{}
 		}
 	}
 
-	compareSecurityZoneData := func(t *testing.T, a, b InterconnectSecurityZoneData) {
-		require.Equal(t, a.RoutingPolicyId, b.RoutingPolicyId)
-		require.Equal(t, a.RouteTarget, b.RouteTarget)
-		require.Equal(t, a.L3Enabled, b.L3Enabled)
-	}
-
-	compare := func(t *testing.T, a, b *EvpnInterconnectGroupData) {
-		t.Helper()
-
-		require.NotNil(t, a)
-		require.NotNil(t, b)
-
-		require.Equal(t, a.Label, b.Label)
-
-		require.NotNil(t, b.EsiMac)
-		if a.EsiMac != nil {
-			require.Equal(t, a.EsiMac, b.EsiMac)
-		}
-
-		require.Equal(t, a.RouteTarget, b.RouteTarget)
-
-		require.Equal(t, len(a.InterconnectSecurityZones), len(b.InterconnectSecurityZones))
-		for k, va := range a.InterconnectSecurityZones {
-			vb, ok := b.InterconnectSecurityZones[k]
-			if !ok {
-				t.Fatalf("a has InterconnectSecurityZone %q, but b does not", k)
-			}
-			compareSecurityZoneData(t, va, vb)
-		}
-	}
-
-	for clientName, client := range clients {
-		t.Run(clientName, func(t *testing.T) {
+	for _, client := range clients {
+		t.Run(client.Name(), func(t *testing.T) {
 			t.Parallel()
+			ctx := testutils.ContextWithTestID(ctx, t)
 
 			t.Logf("Creating blueprint")
-			bpClient := testBlueprintA(ctx, t, client.client)
+			bpClient := dctestobj.TestBlueprintA(t, ctx, client.Client)
 			fs, err := bpClient.GetFabricSettings(ctx)
 			require.NoError(t, err)
 
-			fs.EsiMacMsb = toPtr(uint8((rand.Int() & 254) | 2))
+			fs.EsiMacMsb = pointer.To(uint8((rand.Int() & 254) | 2))
 			t.Logf("Setting blueprint ESI MAC MSB to %d", *fs.EsiMacMsb)
 			err = bpClient.SetFabricSettings(ctx, fs)
 			require.NoError(t, err)
 
-			securityZoneIDs := make([]ObjectId, securityZoneCount)
+			securityZoneIDs := make([]string, securityZoneCount)
 			for i := range securityZoneIDs {
-				vrfName := randString(6, "hex")
-				id, err := bpClient.CreateSecurityZone(ctx, SecurityZone{
+				vrfName := testutils.RandString(6, "hex")
+				id, err := bpClient.CreateSecurityZone(ctx, apstra.SecurityZone{
 					Label:   vrfName,
 					Type:    enum.SecurityZoneTypeEVPN,
 					VRFName: vrfName,
 				})
 				require.NoError(t, err)
-				securityZoneIDs[i] = ObjectId(id)
+				securityZoneIDs[i] = id
 			}
 
-			routingPolicyIDs := make([]ObjectId, routingPolicyCount)
-			importPolicies := []DcRoutingPolicyImportPolicy{
-				DcRoutingPolicyImportPolicyAll,
-				DcRoutingPolicyImportPolicyDefaultOnly,
-				DcRoutingPolicyImportPolicyExtraOnly,
+			routingPolicyIDs := make([]string, routingPolicyCount)
+			importPolicies := []apstra.DcRoutingPolicyImportPolicy{
+				apstra.DcRoutingPolicyImportPolicyAll,
+				apstra.DcRoutingPolicyImportPolicyDefaultOnly,
+				apstra.DcRoutingPolicyImportPolicyExtraOnly,
 			}
 			for i := range routingPolicyIDs {
 				importPolicy := importPolicies[i%len(importPolicies)]
-				id, err := bpClient.CreateRoutingPolicy(ctx, &DcRoutingPolicyData{
-					Label:        randString(6, "hex"),
-					PolicyType:   DcRoutingPolicyTypeUser,
+				id, err := bpClient.CreateRoutingPolicy(ctx, &apstra.DcRoutingPolicyData{
+					Label:        testutils.RandString(6, "hex"),
+					PolicyType:   apstra.DcRoutingPolicyTypeUser,
 					ImportPolicy: importPolicy,
-					ExportPolicy: DcRoutingExportPolicy{},
+					ExportPolicy: apstra.DcRoutingExportPolicy{},
 				})
 				require.NoError(t, err)
-				routingPolicyIDs[i] = id
+				routingPolicyIDs[i] = string(id)
 			}
 
 			type testStep struct {
-				config EvpnInterconnectGroupData
+				config apstra.EVPNInterconnectGroup
 			}
 
 			type testCase struct {
@@ -131,53 +104,53 @@ func TestEvpnInterconnectGroup(t *testing.T) {
 				"start_minimal": {
 					steps: []testStep{
 						{
-							config: EvpnInterconnectGroupData{
-								Label:       "a" + randString(6, "hex"),
-								RouteTarget: fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1),
+							config: apstra.EVPNInterconnectGroup{
+								Label:       pointer.To("a" + testutils.RandString(6, "hex")),
+								RouteTarget: pointer.To(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
 							},
 						},
 						{
-							config: EvpnInterconnectGroupData{
-								Label:       "a" + randString(6, "hex"),
-								RouteTarget: fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1),
-								EsiMac:      randomHardwareAddr([]byte{*fs.EsiMacMsb}, []byte{^*fs.EsiMacMsb}), // match policy MAC MSB
-								InterconnectSecurityZones: map[ObjectId]InterconnectSecurityZoneData{
+							config: apstra.EVPNInterconnectGroup{
+								Label:       pointer.To("a" + testutils.RandString(6, "hex")),
+								RouteTarget: pointer.To(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
+								ESIMAC:      testutils.RandomHardwareAddr([]byte{*fs.EsiMacMsb}, []byte{^*fs.EsiMacMsb}), // match policy MAC MSB
+								InterconnectSecurityZones: map[string]apstra.InterconnectSecurityZone{
 									securityZoneIDs[0]: {
 										RoutingPolicyId: &routingPolicyIDs[0],
-										RouteTarget:     toPtr(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
+										RouteTarget:     pointer.To(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
 										L3Enabled:       true,
 									},
 									securityZoneIDs[1]: {
 										RoutingPolicyId: &routingPolicyIDs[1],
-										RouteTarget:     toPtr(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
+										RouteTarget:     pointer.To(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
 										L3Enabled:       false,
 									},
 								},
 							},
 						},
 						{
-							config: EvpnInterconnectGroupData{
-								Label:       "a" + randString(6, "hex"),
-								RouteTarget: fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1),
-								EsiMac:      randomHardwareAddr([]byte{*fs.EsiMacMsb}, []byte{^*fs.EsiMacMsb}), // match policy MAC MSB
-								InterconnectSecurityZones: map[ObjectId]InterconnectSecurityZoneData{
+							config: apstra.EVPNInterconnectGroup{
+								Label:       pointer.To("a" + testutils.RandString(6, "hex")),
+								RouteTarget: pointer.To(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
+								ESIMAC:      testutils.RandomHardwareAddr([]byte{*fs.EsiMacMsb}, []byte{^*fs.EsiMacMsb}), // match policy MAC MSB
+								InterconnectSecurityZones: map[string]apstra.InterconnectSecurityZone{
 									securityZoneIDs[2]: {
 										RoutingPolicyId: &routingPolicyIDs[2],
-										RouteTarget:     toPtr(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
+										RouteTarget:     pointer.To(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
 										L3Enabled:       false,
 									},
 									securityZoneIDs[1]: {
 										RoutingPolicyId: &routingPolicyIDs[1],
-										RouteTarget:     toPtr(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
+										RouteTarget:     pointer.To(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
 										L3Enabled:       true,
 									},
 								},
 							},
 						},
 						{
-							config: EvpnInterconnectGroupData{
-								Label:       "a" + randString(6, "hex"),
-								RouteTarget: fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1),
+							config: apstra.EVPNInterconnectGroup{
+								Label:       pointer.To("a" + testutils.RandString(6, "hex")),
+								RouteTarget: pointer.To(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
 							},
 						},
 					},
@@ -185,44 +158,44 @@ func TestEvpnInterconnectGroup(t *testing.T) {
 				"start_maximal": {
 					steps: []testStep{
 						{
-							config: EvpnInterconnectGroupData{
-								Label:       "a" + randString(6, "hex"),
-								RouteTarget: fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1),
-								EsiMac:      randomHardwareAddr([]byte{*fs.EsiMacMsb}, []byte{^*fs.EsiMacMsb}), // match policy MAC MSB
-								InterconnectSecurityZones: map[ObjectId]InterconnectSecurityZoneData{
+							config: apstra.EVPNInterconnectGroup{
+								Label:       pointer.To("a" + testutils.RandString(6, "hex")),
+								RouteTarget: pointer.To(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
+								ESIMAC:      testutils.RandomHardwareAddr([]byte{*fs.EsiMacMsb}, []byte{^*fs.EsiMacMsb}), // match policy MAC MSB
+								InterconnectSecurityZones: map[string]apstra.InterconnectSecurityZone{
 									securityZoneIDs[0]: {
 										RoutingPolicyId: &routingPolicyIDs[0],
-										RouteTarget:     toPtr(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
+										RouteTarget:     pointer.To(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
 										L3Enabled:       true,
 									},
 									securityZoneIDs[1]: {
 										RoutingPolicyId: &routingPolicyIDs[1],
-										RouteTarget:     toPtr(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
+										RouteTarget:     pointer.To(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
 										L3Enabled:       false,
 									},
 								},
 							},
 						},
 						{
-							config: EvpnInterconnectGroupData{
-								Label:       "a" + randString(6, "hex"),
-								RouteTarget: fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1),
+							config: apstra.EVPNInterconnectGroup{
+								Label:       pointer.To("a" + testutils.RandString(6, "hex")),
+								RouteTarget: pointer.To(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
 							},
 						},
 						{
-							config: EvpnInterconnectGroupData{
-								Label:       "a" + randString(6, "hex"),
-								RouteTarget: fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1),
-								EsiMac:      randomHardwareAddr([]byte{*fs.EsiMacMsb}, []byte{^*fs.EsiMacMsb}), // match policy MAC MSB
-								InterconnectSecurityZones: map[ObjectId]InterconnectSecurityZoneData{
+							config: apstra.EVPNInterconnectGroup{
+								Label:       pointer.To("a" + testutils.RandString(6, "hex")),
+								RouteTarget: pointer.To(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
+								ESIMAC:      testutils.RandomHardwareAddr([]byte{*fs.EsiMacMsb}, []byte{^*fs.EsiMacMsb}), // match policy MAC MSB
+								InterconnectSecurityZones: map[string]apstra.InterconnectSecurityZone{
 									securityZoneIDs[0]: {
 										RoutingPolicyId: &routingPolicyIDs[0],
-										RouteTarget:     toPtr(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
+										RouteTarget:     pointer.To(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
 										L3Enabled:       true,
 									},
 									securityZoneIDs[1]: {
 										RoutingPolicyId: &routingPolicyIDs[1],
-										RouteTarget:     toPtr(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
+										RouteTarget:     pointer.To(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
 										L3Enabled:       false,
 									},
 								},
@@ -232,7 +205,7 @@ func TestEvpnInterconnectGroup(t *testing.T) {
 				},
 			}
 
-			var createdIds []ObjectId
+			var createdIds []string
 			idMutex := new(sync.Mutex)
 
 			wg := sync.WaitGroup{}
@@ -245,49 +218,51 @@ func TestEvpnInterconnectGroup(t *testing.T) {
 
 					// use the first config/step for initial creation
 					config := tCase.steps[0].config
-					populateMissingSZIDs(&config, securityZoneIDs)
+					populateMissingSZIDs(config, securityZoneIDs)
 
 					require.Greater(t, len(tCase.steps), 0)
-					if config.EsiMac == nil {
+					if config.ESIMAC == nil {
 						t.Log("creating EVPN Interconnect Group with unspecified ESI MAC")
 					} else {
-						t.Logf("creating EVPN Interconnect Group with ESI MAC %s", config.EsiMac)
+						t.Logf("creating EVPN Interconnect Group with ESI MAC %s", config.ESIMAC)
 					}
 
-					id, err := bpClient.CreateEvpnInterconnectGroup(ctx, &config)
+					id, err := bpClient.CreateEVPNInterconnectGroup(ctx, config)
 					require.NoError(t, err)
 					idMutex.Lock()
 					createdIds = append(createdIds, id)
 					idMutex.Unlock()
 
-					get, err := bpClient.GetEvpnInterconnectGroup(ctx, id)
+					get, err := bpClient.GetEVPNInterconnectGroup(ctx, id)
 					require.NoError(t, err)
-					require.Equal(t, id, get.Id)
-					require.NotNil(t, get.Data)
-					compare(t, &config, get.Data)
+					require.NotNil(t, get.ID())
+					require.Equal(t, id, *get.ID())
+					comparedatacenter.EVPNInterconnectGroup(t, config, get)
 
 					for i, step := range tCase.steps {
-						populateMissingSZIDs(&step.config, securityZoneIDs)
+						require.NoError(t, step.config.SetID(id))
+						populateMissingSZIDs(step.config, securityZoneIDs)
 						t.Logf("%s update step %d", tName, i)
-						if step.config.EsiMac == nil {
+						if step.config.ESIMAC == nil {
 							t.Log("updating EVPN Interconnect Group with unspecified ESI MAC")
 						} else {
-							t.Logf("updating EVPN Interconnect Group with ESI MAC %s", step.config.EsiMac)
+							t.Logf("updating EVPN Interconnect Group with ESI MAC %s", step.config.ESIMAC)
 						}
-						err := bpClient.UpdateEvpnInterconnectGroup(ctx, id, &step.config)
+						err = bpClient.UpdateEVPNInterconnectGroup(ctx, step.config)
 						require.NoError(t, err)
 
-						get, err := bpClient.GetEvpnInterconnectGroup(ctx, id)
+						get, err = bpClient.GetEVPNInterconnectGroup(ctx, id)
 						require.NoError(t, err)
-						require.Equal(t, id, get.Id)
-						require.NotNil(t, get.Data)
-						compare(t, &step.config, get.Data)
+						require.NotNil(t, get.ID())
+						require.Equal(t, id, *get.ID())
+						comparedatacenter.EVPNInterconnectGroup(t, step.config, get)
 
-						get, err = bpClient.GetEvpnInterconnectGroupByName(ctx, step.config.Label)
+						require.NotNil(t, step.config.Label)
+						get, err = bpClient.GetEVPNInterconnectGroupByName(ctx, *step.config.Label)
 						require.NoError(t, err)
-						require.Equal(t, id, get.Id)
-						require.NotNil(t, get.Data)
-						compare(t, &step.config, get.Data)
+						require.NotNil(t, get.ID())
+						require.Equal(t, id, *get.ID())
+						comparedatacenter.EVPNInterconnectGroup(t, step.config, get)
 					}
 				})
 			}
@@ -297,40 +272,42 @@ func TestEvpnInterconnectGroup(t *testing.T) {
 
 				wg.Wait()
 
-				all, err := bpClient.GetAllEvpnInterconnectGroups(ctx)
+				all, err := bpClient.GetAllEVPNInterconnectGroups(ctx)
 				require.NoError(t, err)
 				require.Equal(t, len(testCases), len(all))
 
-				retrievedIds := make([]ObjectId, len(all))
+				retrievedIds := make([]string, len(all))
 				for i, o := range all {
-					retrievedIds[i] = o.Id
+					require.NotNil(t, o.ID())
+					retrievedIds[i] = *o.ID()
 				}
 
-				compareSlicesAsSets(t, createdIds, retrievedIds, "created and retrieved IDs do not match")
+				compare.SlicesAsSets(t, createdIds, retrievedIds, "created and retrieved IDs do not match")
 
 				for _, evpnInterconnectGroup := range all {
-					t.Run("delete_"+evpnInterconnectGroup.Id.String(), func(t *testing.T) {
+					t.Run("delete_"+*evpnInterconnectGroup.ID(), func(t *testing.T) {
 						t.Parallel()
 
-						err = bpClient.DeleteEvpnInterconnectGroup(ctx, evpnInterconnectGroup.Id)
+						err = bpClient.DeleteEVPNInterconnectGroup(ctx, *evpnInterconnectGroup.ID())
 						require.NoError(t, err)
 
-						var ace ClientErr
+						var ace apstra.ClientErr
 
-						err = bpClient.DeleteEvpnInterconnectGroup(ctx, evpnInterconnectGroup.Id)
+						err = bpClient.DeleteEVPNInterconnectGroup(ctx, *evpnInterconnectGroup.ID())
 						require.Error(t, err)
 						require.ErrorAs(t, err, &ace)
-						require.Equal(t, ErrNotfound, ace.errType)
+						require.Equal(t, apstra.ErrNotfound, ace.Type())
 
-						_, err = bpClient.GetEvpnInterconnectGroup(ctx, evpnInterconnectGroup.Id)
+						_, err = bpClient.GetEVPNInterconnectGroup(ctx, *evpnInterconnectGroup.ID())
 						require.Error(t, err)
 						require.ErrorAs(t, err, &ace)
-						require.Equal(t, ErrNotfound, ace.errType)
+						require.Equal(t, apstra.ErrNotfound, ace.Type())
 
-						_, err = bpClient.GetEvpnInterconnectGroupByName(ctx, evpnInterconnectGroup.Data.Label)
+						require.NotNil(t, evpnInterconnectGroup.Label)
+						_, err = bpClient.GetEVPNInterconnectGroupByName(ctx, *evpnInterconnectGroup.Label)
 						require.Error(t, err)
 						require.ErrorAs(t, err, &ace)
-						require.Equal(t, ErrNotfound, ace.errType)
+						require.Equal(t, apstra.ErrNotfound, ace.Type())
 					})
 				}
 			})

--- a/apstra/two_stage_l3_clos_evpn_interconnect_group_test.go
+++ b/apstra/two_stage_l3_clos_evpn_interconnect_group_test.go
@@ -178,5 +178,4 @@ func TestEVPNInterconnectGroup_UnmarshalJSON(t *testing.T) {
 			comparedatacenter.EVPNInterconnectGroup(t, tCase.exp, result)
 		})
 	}
-
 }

--- a/apstra/two_stage_l3_clos_evpn_interconnect_group_test.go
+++ b/apstra/two_stage_l3_clos_evpn_interconnect_group_test.go
@@ -2,6 +2,8 @@
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build requiretestutils
+
 package apstra_test
 
 import (

--- a/apstra/two_stage_l3_clos_evpn_interconnect_group_test.go
+++ b/apstra/two_stage_l3_clos_evpn_interconnect_group_test.go
@@ -1,0 +1,182 @@
+// Copyright (c) Juniper Networks, Inc., 2026-2026.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package apstra_test
+
+import (
+	"encoding/json"
+	"net"
+	"testing"
+
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/internal/pointer"
+	testutils "github.com/Juniper/apstra-go-sdk/internal/test_utils"
+	comparedatacenter "github.com/Juniper/apstra-go-sdk/internal/test_utils/compare/datacenter"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEVPNInterconnectGroup_MarshalJSON(t *testing.T) {
+	type testCase struct {
+		data apstra.EVPNInterconnectGroup
+		exp  string
+	}
+
+	testCases := map[string]testCase{
+		"empty": {
+			data: apstra.EVPNInterconnectGroup{},
+			exp:  "{}",
+		},
+		"full": {
+			data: apstra.EVPNInterconnectGroup{
+				Label:       pointer.To("label"),
+				RouteTarget: pointer.To("1:1"),
+				ESIMAC:      testutils.Must(net.ParseMAC("00:11:22:33:44:55")),
+				InterconnectSecurityZones: map[string]apstra.InterconnectSecurityZone{
+					"a": {
+						L3Enabled:       true,
+						RouteTarget:     pointer.To("11:11"),
+						RoutingPolicyId: pointer.To("aa"),
+					},
+					"b": {
+						L3Enabled:       false,
+						RouteTarget:     pointer.To("22:22"),
+						RoutingPolicyId: pointer.To("bb"),
+					},
+				},
+				InterconnectVirtualNetworks: map[string]apstra.InterconnectVirtualNetwork{
+					"c": {
+						L2Enabled:      true,
+						L3Enabled:      true,
+						TranslationVNI: pointer.To(uint32(333)),
+					},
+					"d": {
+						L2Enabled:      false,
+						L3Enabled:      false,
+						TranslationVNI: pointer.To(uint32(444)),
+					},
+				},
+			},
+			exp: `{
+  "label": "label",
+  "interconnect_route_target": "1:1",
+  "interconnect_esi_mac": "00:11:22:33:44:55",
+  "interconnect_security_zones": {
+    "a": {
+      "enabled_for_l3": true,
+      "interconnect_route_target": "11:11",
+      "routing_policy_id": "aa"
+    },
+    "b": {
+      "enabled_for_l3": false,
+      "interconnect_route_target": "22:22",
+      "routing_policy_id": "bb"
+    }
+  },
+  "interconnect_virtual_networks": {
+    "c": {
+      "l2": true,
+      "l3": true,
+      "translation_vni": 333
+    },
+    "d": {
+      "l2": false,
+      "l3": false,
+      "translation_vni": 444
+    }
+  }
+}`,
+		},
+	}
+
+	for tName, tCase := range testCases {
+		t.Run(tName, func(t *testing.T) {
+			result, err := json.Marshal(tCase.data)
+			require.NoError(t, err)
+			require.JSONEq(t, tCase.exp, string(result))
+		})
+	}
+}
+
+func TestEVPNInterconnectGroup_UnmarshalJSON(t *testing.T) {
+	type testCase struct {
+		data string
+		exp  apstra.EVPNInterconnectGroup
+	}
+
+	testCases := map[string]testCase{
+		"empty": {
+			exp:  apstra.EVPNInterconnectGroup{},
+			data: "{}",
+		},
+		"full": {
+			exp: apstra.EVPNInterconnectGroup{
+				Label:       pointer.To("label"),
+				RouteTarget: pointer.To("1:1"),
+				ESIMAC:      testutils.Must(net.ParseMAC("00:11:22:33:44:55")),
+				InterconnectSecurityZones: map[string]apstra.InterconnectSecurityZone{
+					"a": {
+						L3Enabled:       true,
+						RouteTarget:     pointer.To("11:11"),
+						RoutingPolicyId: pointer.To("aa"),
+					},
+					"b": {
+						L3Enabled:       false,
+						RouteTarget:     pointer.To("22:22"),
+						RoutingPolicyId: pointer.To("bb"),
+					},
+				},
+				InterconnectVirtualNetworks: map[string]apstra.InterconnectVirtualNetwork{
+					"c": {
+						L2Enabled:      true,
+						L3Enabled:      true,
+						TranslationVNI: pointer.To(uint32(333)),
+					},
+					"d": {
+						L2Enabled:      false,
+						L3Enabled:      false,
+						TranslationVNI: pointer.To(uint32(444)),
+					},
+				},
+			},
+			data: `{
+  "label": "label",
+  "interconnect_route_target": "1:1",
+  "interconnect_esi_mac": "00:11:22:33:44:55",
+  "interconnect_security_zones": {
+    "a": {
+      "enabled_for_l3": true,
+      "interconnect_route_target": "11:11",
+      "routing_policy_id": "aa"
+    },
+    "b": {
+      "enabled_for_l3": false,
+      "interconnect_route_target": "22:22",
+      "routing_policy_id": "bb"
+    }
+  },
+  "interconnect_virtual_networks": {
+    "c": {
+      "l2": true,
+      "l3": true,
+      "translation_vni": 333
+    },
+    "d": {
+      "l2": false,
+      "l3": false,
+      "translation_vni": 444
+    }
+  }
+}`,
+		},
+	}
+
+	for tName, tCase := range testCases {
+		t.Run(tName, func(t *testing.T) {
+			var result apstra.EVPNInterconnectGroup
+			require.NoError(t, json.Unmarshal([]byte(tCase.data), &result))
+			comparedatacenter.EVPNInterconnectGroup(t, tCase.exp, result)
+		})
+	}
+
+}

--- a/apstra/two_stage_l3_clos_remote_gateways_integration_test.go
+++ b/apstra/two_stage_l3_clos_remote_gateways_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2024-2025.
+// Copyright (c) Juniper Networks, Inc., 2024-2026.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/apstra/two_stage_l3_clos_remote_gateways_integration_test.go
+++ b/apstra/two_stage_l3_clos_remote_gateways_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/enum"
+	"github.com/Juniper/apstra-go-sdk/internal/pointer"
 	"github.com/stretchr/testify/require"
 )
 
@@ -82,12 +83,12 @@ func TestCRUDRemoteGateway(t *testing.T) {
 			leafIds, err := getSystemIdsByRole(ctx, bp, "leaf")
 			require.NoError(t, err)
 
-			evpnInterConnectGroupId, err := bp.CreateEvpnInterconnectGroup(ctx, &EvpnInterconnectGroupData{
-				Label:       "a" + randString(6, "hex"),
-				RouteTarget: fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1),
+			evpnInterConnectGroupID, err := bp.CreateEVPNInterconnectGroup(ctx, EVPNInterconnectGroup{
+				Label:       pointer.To("a" + randString(6, "hex")),
+				RouteTarget: pointer.To(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
 			})
 			require.NoError(t, err)
-			_ = evpnInterConnectGroupId
+			_ = evpnInterConnectGroupID
 
 			type testStep struct {
 				config TwoStageL3ClosRemoteGatewayData
@@ -138,7 +139,7 @@ func TestCRUDRemoteGateway(t *testing.T) {
 								KeepaliveTimer:          toPtr(uint16(rand.Intn(math.MaxUint16) + 1)),   // 1-65535
 								HoldtimeTimer:           toPtr(uint16(rand.Intn(math.MaxUint16-2) + 3)), // 3-65535
 								Password:                toPtr(randString(6, "hex")),
-								EvpnInterconnectGroupId: &evpnInterConnectGroupId,
+								EvpnInterconnectGroupId: (*ObjectId)(&evpnInterConnectGroupID),
 								LocalGwNodes:            leafIds,
 							},
 						},
@@ -166,7 +167,7 @@ func TestCRUDRemoteGateway(t *testing.T) {
 								KeepaliveTimer:          toPtr(uint16(rand.Intn(math.MaxUint16) + 1)),   // 1-65535
 								HoldtimeTimer:           toPtr(uint16(rand.Intn(math.MaxUint16-2) + 3)), // 3-65535
 								Password:                toPtr(randString(6, "hex")),
-								EvpnInterconnectGroupId: &evpnInterConnectGroupId,
+								EvpnInterconnectGroupId: (*ObjectId)(&evpnInterConnectGroupID),
 								LocalGwNodes:            leafIds,
 							},
 						},
@@ -192,7 +193,7 @@ func TestCRUDRemoteGateway(t *testing.T) {
 								KeepaliveTimer:          toPtr(uint16(rand.Intn(math.MaxUint16) + 1)),   // 1-65535
 								HoldtimeTimer:           toPtr(uint16(rand.Intn(math.MaxUint16-2) + 3)), // 3-65535
 								Password:                toPtr(randString(6, "hex")),
-								EvpnInterconnectGroupId: &evpnInterConnectGroupId,
+								EvpnInterconnectGroupId: (*ObjectId)(&evpnInterConnectGroupID),
 								LocalGwNodes:            leafIds,
 							},
 						},
@@ -209,7 +210,7 @@ func TestCRUDRemoteGateway(t *testing.T) {
 								Label:                   randString(6, "hex"),
 								GwIp:                    netIpToNetIpAddr(t, randomIpv4()),
 								GwAsn:                   rand.Uint32(),
-								EvpnInterconnectGroupId: &evpnInterConnectGroupId,
+								EvpnInterconnectGroupId: (*ObjectId)(&evpnInterConnectGroupID),
 								LocalGwNodes:            []ObjectId{leafIds[rand.Intn(len(leafIds))]},
 							},
 						},

--- a/errors.go
+++ b/errors.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// Copyright (c) Juniper Networks, Inc., 2025-2026.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/errors.go
+++ b/errors.go
@@ -10,6 +10,12 @@ func (e ErrAPIResponseInvalid) Error() string {
 	return string(e)
 }
 
+type ErrIDAlreadySet string
+
+func (e ErrIDAlreadySet) Error() string {
+	return string(e)
+}
+
 type ErrInternal string
 
 func (e ErrInternal) Error() string {

--- a/internal/test_utils/compare/datacenter/evpn_interconnect_group.go
+++ b/internal/test_utils/compare/datacenter/evpn_interconnect_group.go
@@ -1,0 +1,46 @@
+// Copyright (c) Juniper Networks, Inc., 2026-2026.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build requiretestutils
+
+package comparedatacenter
+
+import (
+	"testing"
+
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	testmessage "github.com/Juniper/apstra-go-sdk/internal/test_utils/test_message"
+	"github.com/stretchr/testify/require"
+)
+
+func EVPNInterconnectGroup(t testing.TB, req, resp apstra.EVPNInterconnectGroup, msg ...string) {
+	msg = testmessage.Add(msg, "Comparing EVPN Interconnect Group")
+
+	if req.Label != nil {
+		require.NotNil(t, resp.Label, msg)
+		require.Equal(t, *req.Label, *resp.Label, msg)
+	}
+
+	if req.RouteTarget != nil {
+		require.NotNil(t, resp.RouteTarget, msg)
+		require.Equal(t, *req.RouteTarget, *resp.RouteTarget, msg)
+	}
+
+	if req.ESIMAC != nil {
+		require.NotNil(t, resp.ESIMAC, msg)
+		require.Equal(t, req.ESIMAC.String(), resp.ESIMAC.String(), msg)
+	}
+
+	for k, reqv := range req.InterconnectSecurityZones {
+		require.Contains(t, resp.InterconnectSecurityZones, k, msg)
+		respv := resp.InterconnectSecurityZones[k]
+		InterconnectSecurityZone(t, reqv, respv, testmessage.Add(msg, "Comparing Interconnect Security Zone %s", k)...)
+	}
+
+	for k, reqv := range req.InterconnectVirtualNetworks {
+		require.Contains(t, resp.InterconnectVirtualNetworks, k, msg)
+		respv := resp.InterconnectVirtualNetworks[k]
+		InterconnectVirtualNetwork(t, reqv, respv, testmessage.Add(msg, "Comparing Interconnect Virtual Network %s", k)...)
+	}
+}

--- a/internal/test_utils/compare/datacenter/interconnect_security_zone.go
+++ b/internal/test_utils/compare/datacenter/interconnect_security_zone.go
@@ -1,0 +1,33 @@
+// Copyright (c) Juniper Networks, Inc., 2026-2026.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build requiretestutils
+
+package comparedatacenter
+
+import (
+	"testing"
+
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	testmessage "github.com/Juniper/apstra-go-sdk/internal/test_utils/test_message"
+	"github.com/stretchr/testify/require"
+)
+
+func InterconnectSecurityZone(t testing.TB, req, resp apstra.InterconnectSecurityZone, msg ...string) {
+	msg = testmessage.Add(msg, "Comparing Interconnect Security Zone")
+
+	require.Equal(t, req.L3Enabled, resp.L3Enabled, msg)
+	if req.RouteTarget == nil {
+		require.Nil(t, resp.RouteTarget, msg)
+	} else {
+		require.NotNil(t, resp.RouteTarget, msg)
+		require.Equal(t, *req.RouteTarget, *resp.RouteTarget, msg)
+	}
+	if req.RoutingPolicyId == nil {
+		require.Nil(t, resp.RoutingPolicyId, msg)
+	} else {
+		require.NotNil(t, resp.RoutingPolicyId, msg)
+		require.Equal(t, *req.RoutingPolicyId, *resp.RoutingPolicyId, msg)
+	}
+}

--- a/internal/test_utils/compare/datacenter/interconnect_virtual_network.go
+++ b/internal/test_utils/compare/datacenter/interconnect_virtual_network.go
@@ -1,0 +1,28 @@
+// Copyright (c) Juniper Networks, Inc., 2026-2026.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build requiretestutils
+
+package comparedatacenter
+
+import (
+	"testing"
+
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	testmessage "github.com/Juniper/apstra-go-sdk/internal/test_utils/test_message"
+	"github.com/stretchr/testify/require"
+)
+
+func InterconnectVirtualNetwork(t testing.TB, req, resp apstra.InterconnectVirtualNetwork, msg ...string) {
+	msg = testmessage.Add(msg, "Comparing Interconnect Virtual Network")
+
+	require.Equal(t, req.L2Enabled, resp.L2Enabled, msg)
+	require.Equal(t, req.L3Enabled, resp.L3Enabled, msg)
+	if req.TranslationVNI == nil {
+		require.Nil(t, resp.TranslationVNI, msg)
+	} else {
+		require.NotNil(t, resp.TranslationVNI, msg)
+		require.Equal(t, *req.TranslationVNI, *resp.TranslationVNI, msg)
+	}
+}

--- a/internal/test_utils/error.go
+++ b/internal/test_utils/error.go
@@ -1,0 +1,8 @@
+package testutils
+
+func Must[T any](t T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return t
+}

--- a/internal/test_utils/error.go
+++ b/internal/test_utils/error.go
@@ -2,6 +2,8 @@
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build requiretestutils
+
 package testutils
 
 func Must[T any](t T, err error) T {

--- a/internal/test_utils/error.go
+++ b/internal/test_utils/error.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2026-2026.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package testutils
 
 func Must[T any](t T, err error) T {

--- a/internal/test_utils/random.go
+++ b/internal/test_utils/random.go
@@ -302,3 +302,33 @@ func RandTime(bounds ...time.Time) time.Time {
 
 	return time.Unix(tStart.Unix()+randomSeconds, randomNanos).UTC()
 }
+
+// RandomHardwareAddr returns a net.HardwareAddr. The set and unset arguments
+// allow the caller to specify certain bits which must be set or must be unset
+// in the result.
+// For example, to get a random mac with only the LAA bit set, you'd invoke the
+// function with arguments indicating that LAA must be set and all other bits
+// in the first byte must be unset:
+//
+//	set:   []byte{2},
+//	unset: []byte{253},
+func RandomHardwareAddr(set []byte, unset []byte) net.HardwareAddr {
+	result := net.HardwareAddr{
+		byte(rand.Intn(math.MaxUint8 + 1)),
+		byte(rand.Intn(math.MaxUint8 + 1)),
+		byte(rand.Intn(math.MaxUint8 + 1)),
+		byte(rand.Intn(math.MaxUint8 + 1)),
+		byte(rand.Intn(math.MaxUint8 + 1)),
+		byte(rand.Intn(math.MaxUint8 + 1)),
+	}
+
+	for i := range min(len(set), len(result)) {
+		result[i] = result[i] | set[i]
+	}
+
+	for i := range min(len(unset), len(result)) {
+		result[i] = result[i] & ^unset[i]
+	}
+
+	return result
+}

--- a/internal/test_utils/random_test.go
+++ b/internal/test_utils/random_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// Copyright (c) Juniper Networks, Inc., 2025-2026.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/internal/test_utils/random_test.go
+++ b/internal/test_utils/random_test.go
@@ -80,3 +80,56 @@ func TestRandTime(t *testing.T) {
 		})
 	}
 }
+
+func TestRandomHardwareAddr(t *testing.T) {
+	type testCase struct {
+		set   []byte
+		unset []byte
+	}
+
+	testCases := map[string]testCase{
+		"laa": {
+			set: []byte{2},
+		},
+		"group": {
+			set: []byte{1},
+		},
+		"laa_and_not_group": {
+			set:   []byte{2},
+			unset: []byte{1},
+		},
+		"group_and_not_laa": {
+			set:   []byte{1},
+			unset: []byte{2},
+		},
+		"laa_and_group": {
+			set: []byte{3},
+		},
+		"last_byte_128": {
+			set:   []byte{0, 0, 0, 0, 0, 128},
+			unset: []byte{0, 0, 0, 0, 0, 127},
+		},
+		"last_byte_high": {
+			set: []byte{0, 0, 0, 0, 0, 128},
+		},
+		"last_byte_low": {
+			unset: []byte{0, 0, 0, 0, 0, 128},
+		},
+	}
+
+	for tName, tCase := range testCases {
+		t.Run(tName, func(t *testing.T) {
+			t.Parallel()
+
+			result := testutils.RandomHardwareAddr(tCase.set, tCase.unset)
+
+			for i, setByte := range tCase.set {
+				require.Equal(t, setByte, result[i]&setByte)
+			}
+
+			for i, unsetByte := range tCase.unset {
+				require.Equal(t, ^unsetByte, result[i]|^unsetByte)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR refactors the `EvpnInterconnectGroup` struct and related functions. The main objective is to support the `PATCH` method in which every detail is optional, so every struct element must be a pointer with JSON tag `omitempty`.

In here we have the common refactor pattern used for lots of recent work:
- No independent `EvpnInterconnectGroupData` struct
- Embedded private `id` element
- Standardized capitalization
- Elimination of `ObjectId` type
- Client methods deal in object values, rather than pointers
- Rewritten tests

Odds and ends:
- a `Must()` generic test function which panics on error
- The `RandomHardwareAddr()` function and its test has been moved into the `testutils` package.
- Introduction of `ErrIDAlreadySet` implementation of `error` - it occurs to me that `SetID()` function is going to be useful outside of tests. The current (test only) `SetID()` functions panic when setting an ID that already exists. That won't be good enough for user-facing code, so this new error can be used to handle that case.

Tested with:
 - 4.2.0-236
 - 4.2.1-207
 - 4.2.1.1-10
 - 4.2.2-2
 - 5.0.0-63
 - 5.0.1-1
 - 5.1.0-117
 - 6.0.0-189
 - 6.1.0-5
 - 6.1.1-70
 - 6.1.2-28