### PR TITLE
`ID()` should return a pointer to a copy of the ID

### DIFF
--- a/apstra/freeform_aggregate_link.go
+++ b/apstra/freeform_aggregate_link.go
@@ -35,11 +35,13 @@ type FreeformAggregateLink struct {
 	id string
 }
 
+// ID returns a pointer to a copy of the object's ID, or nil when no ID is set.
 func (o FreeformAggregateLink) ID() *string {
 	if o.id == "" {
 		return nil
 	}
-	return &o.id
+	id := o.id
+	return &id
 }
 
 func (o *FreeformAggregateLink) SetID(id string) {

--- a/apstra/freeform_aggregate_link_endpoint.go
+++ b/apstra/freeform_aggregate_link_endpoint.go
@@ -36,11 +36,13 @@ type FreeformAggregateLinkEndpoint struct {
 	id            string
 }
 
+// ID returns a pointer to a copy of the object's ID, or nil when no ID is set.
 func (o FreeformAggregateLinkEndpoint) ID() *string {
 	if o.id == "" {
 		return nil
 	}
-	return &o.id
+	id := o.id
+	return &id
 }
 
 func (o FreeformAggregateLinkEndpoint) MarshalJSON() ([]byte, error) {

--- a/apstra/freeform_aggregate_link_endpoint_group.go
+++ b/apstra/freeform_aggregate_link_endpoint_group.go
@@ -46,11 +46,13 @@ func (o FreeformAggregateLinkEndpointGroup) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&raw)
 }
 
+// ID returns a pointer to a copy of the object's ID, or nil when no ID is set.
 func (o FreeformAggregateLinkEndpointGroup) ID() *string {
 	if o.id == "" {
 		return nil
 	}
-	return &o.id
+	id := o.id
+	return &id
 }
 
 func (o *FreeformAggregateLinkEndpointGroup) UnmarshalJSON(bytes []byte) error {

--- a/apstra/two_stage_l3_clos_evpn_interconnect_group.go
+++ b/apstra/two_stage_l3_clos_evpn_interconnect_group.go
@@ -50,11 +50,13 @@ type EVPNInterconnectGroup struct {
 	id string
 }
 
+// ID returns a pointer to a copy of the object's ID, or nil when no ID is set.
 func (e EVPNInterconnectGroup) ID() *string {
 	if e.id == "" {
 		return nil
 	}
-	return &e.id
+	id := e.id
+	return &id
 }
 
 func (e *EVPNInterconnectGroup) SetID(id string) error {

--- a/apstra/two_stage_l3_clos_security_zone.go
+++ b/apstra/two_stage_l3_clos_security_zone.go
@@ -47,11 +47,13 @@ type SecurityZone struct {
 	id string
 }
 
+// ID returns a pointer to a copy of the object's ID, or nil when no ID is set.
 func (o SecurityZone) ID() *string {
 	if o.id == "" {
 		return nil
 	}
-	return &o.id
+	id := o.id
+	return &id
 }
 
 func (o *SecurityZone) SetID(id string) {

--- a/design/config_template.go
+++ b/design/config_template.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// Copyright (c) Juniper Networks, Inc., 2025-2026.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -29,11 +29,13 @@ type ConfigTemplate struct {
 	lastModifiedAt *time.Time
 }
 
+// ID returns a pointer to a copy of the object's ID, or nil when no ID is set.
 func (c ConfigTemplate) ID() *string {
 	if c.id == "" {
 		return nil
 	}
-	return &c.id
+	id := c.id
+	return &id
 }
 
 func (c ConfigTemplate) CreatedAt() *time.Time {

--- a/design/configlet.go
+++ b/design/configlet.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// Copyright (c) Juniper Networks, Inc., 2025-2026.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -29,11 +29,13 @@ type Configlet struct {
 	lastModifiedAt *time.Time
 }
 
+// ID returns a pointer to a copy of the object's ID, or nil when no ID is set.
 func (c Configlet) ID() *string {
 	if c.id == "" {
 		return nil
 	}
-	return &c.id
+	id := c.id
+	return &id
 }
 
 func (c Configlet) CreatedAt() *time.Time {

--- a/design/interface_map.go
+++ b/design/interface_map.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// Copyright (c) Juniper Networks, Inc., 2025-2026.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -31,11 +31,13 @@ type InterfaceMap struct {
 	lastModifiedAt *time.Time
 }
 
+// ID returns a pointer to a copy of the object's ID, or nil when no ID is set.
 func (i InterfaceMap) ID() *string {
 	if i.id == "" {
 		return nil
 	}
-	return &i.id
+	id := i.id
+	return &id
 }
 
 func (i InterfaceMap) CreatedAt() *time.Time {

--- a/design/interface_map_digest.go
+++ b/design/interface_map_digest.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// Copyright (c) Juniper Networks, Inc., 2025-2026.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -31,11 +31,13 @@ type InterfaceMapDigest struct {
 	lastModifiedAt *time.Time
 }
 
+// ID returns a pointer to a copy of the object's ID, or nil when no ID is set.
 func (i InterfaceMapDigest) ID() *string {
 	if i.id == "" {
 		return nil
 	}
-	return &i.id
+	id := i.id
+	return &id
 }
 
 func (i InterfaceMapDigest) CreatedAt() *time.Time {

--- a/design/logical_device.go
+++ b/design/logical_device.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// Copyright (c) Juniper Networks, Inc., 2025-2026.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -30,11 +30,13 @@ type LogicalDevice struct {
 	lastModifiedAt *time.Time
 }
 
+// ID returns a pointer to a copy of the object's ID, or nil when no ID is set.
 func (l LogicalDevice) ID() *string {
 	if l.id == "" {
 		return nil
 	}
-	return &l.id
+	id := l.id
+	return &id
 }
 
 // Replicate returns a copy of itself with zero values for metadata fields

--- a/design/rack_type.go
+++ b/design/rack_type.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// Copyright (c) Juniper Networks, Inc., 2025-2026.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -37,11 +37,13 @@ type RackType struct {
 	lastModifiedAt *time.Time
 }
 
+// ID returns a pointer to a copy of the object's ID, or nil when no ID is set.
 func (r RackType) ID() *string {
 	if r.id == "" {
 		return nil
 	}
-	return &r.id
+	id := r.id
+	return &id
 }
 
 // Replicate returns a copy of itself with zero values for metadata fields

--- a/design/tag.go
+++ b/design/tag.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// Copyright (c) Juniper Networks, Inc., 2025-2026.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -30,11 +30,13 @@ type Tag struct {
 	lastModifiedAt *time.Time
 }
 
+// ID returns a pointer to a copy of the object's ID, or nil when no ID is set.
 func (t Tag) ID() *string {
 	if t.id == "" {
 		return nil
 	}
-	return &t.id
+	id := t.id
+	return &id
 }
 
 // Replicate returns a copy of itself with zero values for metadata fields

--- a/design/template_l3_collapsed.go
+++ b/design/template_l3_collapsed.go
@@ -42,11 +42,13 @@ func (t TemplateL3Collapsed) TemplateType() enum.TemplateType {
 	return enum.TemplateTypeL3Collapsed
 }
 
+// ID returns a pointer to a copy of the object's ID, or nil when no ID is set.
 func (t TemplateL3Collapsed) ID() *string {
 	if t.id == "" {
 		return nil
 	}
-	return &t.id
+	id := t.id
+	return &id
 }
 
 func (t TemplateL3Collapsed) MarshalJSON() ([]byte, error) {

--- a/design/template_pod_based.go
+++ b/design/template_pod_based.go
@@ -38,11 +38,13 @@ func (t TemplatePodBased) TemplateType() enum.TemplateType {
 	return enum.TemplateTypePodBased
 }
 
+// ID returns a pointer to a copy of the object's ID, or nil when no ID is set.
 func (t TemplatePodBased) ID() *string {
 	if t.id == "" {
 		return nil
 	}
-	return &t.id
+	id := t.id
+	return &id
 }
 
 func (t TemplatePodBased) MarshalJSON() ([]byte, error) {

--- a/design/template_rack_based.go
+++ b/design/template_rack_based.go
@@ -46,11 +46,13 @@ func (t TemplateRackBased) TemplateType() enum.TemplateType {
 	return enum.TemplateTypeRackBased
 }
 
+// ID returns a pointer to a copy of the object's ID, or nil when no ID is set.
 func (t TemplateRackBased) ID() *string {
 	if t.id == "" {
 		return nil
 	}
-	return &t.id
+	id := t.id
+	return &id
 }
 
 // Replicate returns a copy of itself with zero values for metadata fields

--- a/design/template_rail_collapsed.go
+++ b/design/template_rail_collapsed.go
@@ -38,11 +38,13 @@ func (t TemplateRailCollapsed) TemplateType() enum.TemplateType {
 	return enum.TemplateTypeRailCollapsed
 }
 
+// ID returns a pointer to a copy of the object's ID, or nil when no ID is set.
 func (t TemplateRailCollapsed) ID() *string {
 	if t.id == "" {
 		return nil
 	}
-	return &t.id
+	id := t.id
+	return &id
 }
 
 func (t TemplateRailCollapsed) MarshalJSON() ([]byte, error) {

--- a/device/profile.go
+++ b/device/profile.go
@@ -44,11 +44,13 @@ type Profile struct {
 	lastModifiedAt *time.Time
 }
 
+// ID returns a pointer to a copy of the object's ID, or nil when no ID is set.
 func (p Profile) ID() *string {
 	if p.id == "" {
 		return nil
 	}
-	return &p.id
+	id := p.id
+	return &id
 }
 
 func (p Profile) MarshalJSON() ([]byte, error) {

--- a/internal/template/common.go
+++ b/internal/template/common.go
@@ -43,11 +43,13 @@ func (t Common) TemplateType() enum.TemplateType {
 	return t.templateType
 }
 
+// ID returns a pointer to a copy of the object's ID, or nil when no ID is set.
 func (t Common) ID() *string {
 	if t.id == "" {
 		return nil
 	}
-	return &t.id
+	id := t.id
+	return &id
 }
 
 func (t *Common) UnmarshalJSON(bytes []byte) error {


### PR DESCRIPTION
This PR ensures that various `ID()` methods return a pointer to a _copy_ of the ID string to enforce immutability of the `id` struct element.

Closes #708