### PR TITLE
Introduce support for switching zone

### DIFF
--- a/apstra/two_stage_l3_clos_switching_zone.go
+++ b/apstra/two_stage_l3_clos_switching_zone.go
@@ -1,0 +1,123 @@
+// Copyright (c) Juniper Networks, Inc., 2026-2026.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package apstra
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"net/http"
+	"slices"
+
+	"github.com/Juniper/apstra-go-sdk/datacenter"
+	"github.com/Juniper/apstra-go-sdk/internal/str"
+	"github.com/Juniper/apstra-go-sdk/internal/urls"
+)
+
+func (c *TwoStageL3ClosClient) CreateSwitchingZone(ctx context.Context, v datacenter.SwitchingZone) (string, error) {
+	var response struct {
+		ID string `json:"id"`
+	}
+	err := c.client.talkToApstra(ctx, &talkToApstraIn{
+		method:      http.MethodPost,
+		urlStr:      fmt.Sprintf(urls.DatacenterSwitchingZones, c.blueprintId),
+		apiInput:    v,
+		apiResponse: &response,
+	})
+	if err != nil {
+		return "", convertTtaeToAceWherePossible(err)
+	}
+
+	return response.ID, nil
+}
+
+func (c *TwoStageL3ClosClient) GetSwitchingZone(ctx context.Context, id string) (datacenter.SwitchingZone, error) {
+	var result datacenter.SwitchingZone
+	err := c.client.talkToApstra(ctx, &talkToApstraIn{
+		method:      http.MethodGet,
+		urlStr:      fmt.Sprintf(urls.DatacenterSwitchingZoneByID, c.blueprintId, id),
+		apiResponse: &result,
+	})
+	if err != nil {
+		return result, convertTtaeToAceWherePossible(err)
+	}
+
+	return result, nil
+}
+
+func (c *TwoStageL3ClosClient) GetSwitchingZones(ctx context.Context) ([]datacenter.SwitchingZone, error) {
+	var result struct {
+		Items map[string]datacenter.SwitchingZone `json:"items"`
+	}
+	err := c.client.talkToApstra(ctx, &talkToApstraIn{
+		method:      http.MethodGet,
+		urlStr:      fmt.Sprintf(urls.DatacenterSwitchingZones, c.blueprintId),
+		apiResponse: &result,
+	})
+	if err != nil {
+		return nil, convertTtaeToAceWherePossible(err)
+	}
+
+	return slices.Collect(maps.Values(result.Items)), nil
+}
+
+func (c *TwoStageL3ClosClient) GetSwitchingZoneByLabel(ctx context.Context, label string) (datacenter.SwitchingZone, error) {
+	items, err := c.GetSwitchingZones(ctx)
+	if err != nil {
+		return datacenter.SwitchingZone{}, err
+	}
+
+	var result *datacenter.SwitchingZone
+	for _, item := range items {
+		if item.Label != nil && *item.Label == label {
+			if result == nil {
+				result = &item
+			} else {
+				return datacenter.SwitchingZone{}, ClientErr{
+					errType: ErrMultipleMatch,
+					err:     fmt.Errorf("found multiple Switching Zones with label %q", label),
+				}
+			}
+		}
+	}
+
+	if result == nil {
+		return datacenter.SwitchingZone{}, ClientErr{
+			errType: ErrNotfound,
+			err:     fmt.Errorf("no Switching Zone with label %q", label),
+		}
+	}
+
+	return *result, nil
+}
+
+func (c *TwoStageL3ClosClient) UpdateSwitchingZone(ctx context.Context, v datacenter.SwitchingZone) error {
+	if v.ID() == nil {
+		return fmt.Errorf("id is required in %s", str.FuncName())
+	}
+
+	err := c.client.talkToApstra(ctx, &talkToApstraIn{
+		method:   http.MethodPatch,
+		urlStr:   fmt.Sprintf(urls.DatacenterSwitchingZoneByID, c.blueprintId, *v.ID()),
+		apiInput: v,
+	})
+	if err != nil {
+		return convertTtaeToAceWherePossible(err)
+	}
+
+	return nil
+}
+
+func (c *TwoStageL3ClosClient) DeleteSwitchingZone(ctx context.Context, id string) error {
+	err := c.client.talkToApstra(ctx, &talkToApstraIn{
+		method: http.MethodDelete,
+		urlStr: fmt.Sprintf(urls.DatacenterSwitchingZoneByID, c.blueprintId, id),
+	})
+	if err != nil {
+		return convertTtaeToAceWherePossible(err)
+	}
+
+	return nil
+}

--- a/apstra/two_stage_l3_clos_switching_zone.go
+++ b/apstra/two_stage_l3_clos_switching_zone.go
@@ -6,6 +6,7 @@ package apstra
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"maps"
 	"net/http"
@@ -91,6 +92,76 @@ func (c *TwoStageL3ClosClient) GetSwitchingZoneByLabel(ctx context.Context, labe
 	}
 
 	return *result, nil
+}
+
+func (c *TwoStageL3ClosClient) GetDefaultSwitchingZone(ctx context.Context) (datacenter.SwitchingZone, error) {
+	// collect all Switching Zones here without unpacking them
+	var response struct {
+		Items map[string]json.RawMessage `json:"items"`
+	}
+
+	err := c.client.talkToApstra(ctx, &talkToApstraIn{
+		method:      http.MethodGet,
+		urlStr:      fmt.Sprintf(urls.DatacenterSwitchingZones, c.blueprintId),
+		apiResponse: &response,
+	})
+	if err != nil {
+		return datacenter.SwitchingZone{}, convertTtaeToAceWherePossible(err)
+	}
+
+	// impl_type is omitted from the SwitchingZone type. This struct exists as a filter used here only.
+	var target struct {
+		ImplType string `json:"impl_type"`
+	}
+
+	// loop over switching zones looking for the one (we expect) with impl_type == default
+	var result *datacenter.SwitchingZone
+	for i, item := range response.Items {
+		if err = json.Unmarshal(item, &target); err != nil {
+			return datacenter.SwitchingZone{}, fmt.Errorf("error unmarshalling Switching Zone %q: %w", i, err)
+		}
+		if target.ImplType == "default" {
+			if result != nil {
+				return datacenter.SwitchingZone{}, ClientErr{
+					errType: ErrMultipleMatch,
+					err:     fmt.Errorf("found multiple Switching Zones with impl_type == default"),
+				}
+			}
+			if err = json.Unmarshal(item, &result); err != nil {
+				return datacenter.SwitchingZone{}, fmt.Errorf("error unmarshalling default Switching Zone: %w", err)
+			}
+		}
+	}
+
+	if result == nil {
+		return datacenter.SwitchingZone{}, ClientErr{
+			errType: ErrNotfound,
+			err:     fmt.Errorf("no Switching Zone with impl_type == default"),
+		}
+	}
+
+	return *result, nil
+}
+
+func (c *TwoStageL3ClosClient) ListSwitchingZones(ctx context.Context) ([]string, error) {
+	items, err := c.GetSwitchingZones(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]string, len(items))
+	for i, item := range items {
+		idPtr := item.ID()
+		if idPtr == nil {
+			return nil, ClientErr{
+				errType: ErrInvalidId,
+				err:     fmt.Errorf("the Switching Zone at index %d has nil ID", i),
+			}
+		}
+		result[i] = *idPtr
+	}
+
+	return result, nil
 }
 
 func (c *TwoStageL3ClosClient) UpdateSwitchingZone(ctx context.Context, v datacenter.SwitchingZone) error {

--- a/compatibility/compatibility.go
+++ b/compatibility/compatibility.go
@@ -20,6 +20,7 @@ const (
 	apstra610  = "6.1.0"
 	apstra611  = "6.1.1"
 	apstra612  = "6.1.2"
+	apstra620  = "6.2.0"
 )
 
 var (

--- a/compatibility/constraints.go
+++ b/compatibility/constraints.go
@@ -17,6 +17,9 @@ var (
 	BpHasVirtualNetworkPolicyNode = Constraint{
 		constraints: version.MustConstraints(version.NewConstraint("<=" + apstra420)),
 	}
+	DatacenterSwitchingZoneOK = Constraint{
+		constraints: version.MustConstraints(version.NewConstraint(">=" + apstra620)),
+	}
 	DeviceProfileHasRefdesignCapabilities = Constraint{
 		constraints: version.MustConstraints(version.NewConstraint(">=" + apstra500)),
 	}

--- a/datacenter/base_url.go
+++ b/datacenter/base_url.go
@@ -1,7 +1,0 @@
-package datacenter
-
-const (
-	apiUrlPathDelim     = "/"
-	apiUrlBlueprints    = "/api/blueprints"
-	apiUrlBlueprintByID = apiUrlBlueprints + apiUrlPathDelim + "%s"
-)

--- a/datacenter/base_url.go
+++ b/datacenter/base_url.go
@@ -1,0 +1,7 @@
+package datacenter
+
+const (
+	apiUrlPathDelim     = "/"
+	apiUrlBlueprints    = "/api/blueprints"
+	apiUrlBlueprintByID = apiUrlBlueprints + apiUrlPathDelim + "%s"
+)

--- a/datacenter/switching_zone.go
+++ b/datacenter/switching_zone.go
@@ -34,7 +34,7 @@ func (z SwitchingZone) ID() *string {
 
 func (z *SwitchingZone) SetID(id string) error {
 	if z.id != "" {
-		return errors.ErrIDAlreadySet(fmt.Sprintf("id already has value %q", z.id))
+		return errors.IDAlreadySet(fmt.Sprintf("id already has value %q", z.id))
 	}
 
 	z.id = id

--- a/datacenter/switching_zone.go
+++ b/datacenter/switching_zone.go
@@ -1,0 +1,42 @@
+package datacenter
+
+import (
+	"fmt"
+
+	"github.com/Juniper/apstra-go-sdk/enum"
+	"github.com/Juniper/apstra-go-sdk/errors"
+)
+
+const (
+	apiUrlBlueprintSwitchingZones    = apiUrlBlueprintByID + apiUrlPathDelim + "switching-zones"
+	apiUrlBlueprintSwitchingZoneByID = apiUrlBlueprintSwitchingZones + apiUrlPathDelim + "%s"
+)
+
+type SwitchingZone struct {
+	ImplementationType *enum.SwitchingZoneImplementationType `json:"impl_type,omitempty"`
+	Label              *string                               `json:"label,omitempty"`
+	MACVRFDescription  *string                               `json:"mac_vrf_description,omitempty"`
+	MACVRFName         *string                               `json:"mac_vrf_name,omitempty"`
+	MACVRFServiceType  *enum.SwitchingZoneMACVRFServiceType  `json:"mac_vrf_service_type,omitempty"`
+	RouteTarget        *string                               `json:"route_target,omitempty"`
+	Tags               []string                              `json:"tags,omitempty"`
+	id                 string
+}
+
+// ID returns a pointer to a copy of the object's ID, or nil when no ID is set.
+func (z SwitchingZone) ID() *string {
+	if z.id == "" {
+		return nil
+	}
+	id := z.id
+	return &id
+}
+
+func (z *SwitchingZone) SetID(id string) error {
+	if z.id != "" {
+		return errors.ErrIDAlreadySet(fmt.Sprintf("id already has value %q", z.id))
+	}
+
+	z.id = id
+	return nil
+}

--- a/datacenter/switching_zone.go
+++ b/datacenter/switching_zone.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2026-2026.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package datacenter
 
 import (
@@ -5,11 +9,6 @@ import (
 
 	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/apstra-go-sdk/errors"
-)
-
-const (
-	apiUrlBlueprintSwitchingZones    = apiUrlBlueprintByID + apiUrlPathDelim + "switching-zones"
-	apiUrlBlueprintSwitchingZoneByID = apiUrlBlueprintSwitchingZones + apiUrlPathDelim + "%s"
 )
 
 type SwitchingZone struct {

--- a/datacenter/switching_zone.go
+++ b/datacenter/switching_zone.go
@@ -5,21 +5,29 @@
 package datacenter
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/apstra-go-sdk/errors"
+	"github.com/Juniper/apstra-go-sdk/internal"
+)
+
+var (
+	_ internal.IDer     = (*SwitchingZone)(nil)
+	_ internal.IDSetter = (*SwitchingZone)(nil)
+	_ json.Marshaler    = (*SwitchingZone)(nil)
+	_ json.Unmarshaler  = (*SwitchingZone)(nil)
 )
 
 type SwitchingZone struct {
-	ImplementationType *enum.SwitchingZoneImplementationType `json:"impl_type,omitempty"`
-	Label              *string                               `json:"label,omitempty"`
-	MACVRFDescription  *string                               `json:"mac_vrf_description,omitempty"`
-	MACVRFName         *string                               `json:"mac_vrf_name,omitempty"`
-	MACVRFServiceType  *enum.SwitchingZoneMACVRFServiceType  `json:"mac_vrf_service_type,omitempty"`
-	RouteTarget        *string                               `json:"route_target,omitempty"`
-	Tags               []string                              `json:"tags,omitempty"`
-	id                 string
+	Label             *string                              `json:"label,omitempty"`
+	MACVRFDescription *string                              `json:"mac_vrf_description,omitempty"`
+	MACVRFName        *string                              `json:"mac_vrf_name,omitempty"`
+	MACVRFServiceType *enum.SwitchingZoneMACVRFServiceType `json:"mac_vrf_service_type,omitempty"`
+	RouteTarget       *string                              `json:"route_target,omitempty"`
+	Tags              []string                             `json:"tags,omitempty"`
+	id                string
 }
 
 // ID returns a pointer to a copy of the object's ID, or nil when no ID is set.
@@ -37,5 +45,40 @@ func (z *SwitchingZone) SetID(id string) error {
 	}
 
 	z.id = id
+	return nil
+}
+
+// MarshalJSON is implemented because the API is expecting an extra (mandatory) field
+// `impl_type` which must always be "mac_vrf". Rather than exposing this nonsense to
+// the caller, we just sneak it in here at the last minute.
+func (z SwitchingZone) MarshalJSON() ([]byte, error) {
+	type switchingZoneAlias SwitchingZone
+	return json.Marshal(struct {
+		switchingZoneAlias
+		ImplementationType string `json:"impl_type"`
+	}{
+		switchingZoneAlias: switchingZoneAlias(z),
+		ImplementationType: "mac_vrf",
+	})
+}
+
+// UnmarshalJSON is implemented because we want to unmarshal the private
+// struct element `id`.
+func (z *SwitchingZone) UnmarshalJSON(bytes []byte) error {
+	type alias SwitchingZone
+
+	aux := struct {
+		ID string `json:"id"`
+		*alias
+	}{
+		alias: (*alias)(z),
+	}
+
+	if err := json.Unmarshal(bytes, &aux); err != nil {
+		return err
+	}
+
+	z.id = aux.ID
+
 	return nil
 }

--- a/datacenter/switching_zone_integration_test.go
+++ b/datacenter/switching_zone_integration_test.go
@@ -1,0 +1,207 @@
+// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package datacenter_test
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/compatibility"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
+	"github.com/Juniper/apstra-go-sdk/enum"
+	"github.com/Juniper/apstra-go-sdk/internal/pointer"
+	"github.com/Juniper/apstra-go-sdk/internal/slice"
+	testutils "github.com/Juniper/apstra-go-sdk/internal/test_utils"
+	comparedatacenter "github.com/Juniper/apstra-go-sdk/internal/test_utils/compare/datacenter"
+	dctestobj "github.com/Juniper/apstra-go-sdk/internal/test_utils/datacenter_test_objects"
+	testclient "github.com/Juniper/apstra-go-sdk/internal/test_utils/test_client"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSwitchingZone_CRUD(t *testing.T) {
+	ctx := testutils.ContextWithTestID(context.Background(), t)
+	clients := testclient.GetTestClients(t, ctx)
+
+	type testCase struct {
+		constraints []compatibility.Constraint
+		create      datacenter.SwitchingZone
+		update      datacenter.SwitchingZone
+	}
+
+	testCases := map[string]testCase{
+		"vlan_aware": {
+			constraints: []compatibility.Constraint{compatibility.DatacenterSwitchingZoneOK},
+			create: datacenter.SwitchingZone{
+				Label:             pointer.To(testutils.RandString(6, "hex")),
+				MACVRFDescription: pointer.To(testutils.RandString(6, "hex")),
+				MACVRFName:        pointer.To(testutils.RandString(6, "hex")),
+				MACVRFServiceType: pointer.To(enum.SwitchingZoneMACVRFServiceTypeVLANAware),
+				RouteTarget:       pointer.To(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)), Tags: nil,
+			},
+			update: datacenter.SwitchingZone{
+				Label:             pointer.To(testutils.RandString(6, "hex")),
+				MACVRFDescription: pointer.To(testutils.RandString(6, "hex")),
+				RouteTarget:       pointer.To(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)), Tags: nil,
+			},
+		},
+		"vlan_bundle": {
+			constraints: []compatibility.Constraint{compatibility.DatacenterSwitchingZoneOK},
+			create: datacenter.SwitchingZone{
+				Label:             pointer.To(testutils.RandString(6, "hex")),
+				MACVRFDescription: pointer.To(testutils.RandString(6, "hex")),
+				MACVRFName:        pointer.To(testutils.RandString(6, "hex")),
+				MACVRFServiceType: pointer.To(enum.SwitchingZoneMACVRFServiceTypeVLANBundle),
+				RouteTarget:       pointer.To(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)), Tags: nil,
+			},
+			update: datacenter.SwitchingZone{
+				Label:             pointer.To(testutils.RandString(6, "hex")),
+				MACVRFDescription: pointer.To(testutils.RandString(6, "hex")),
+				RouteTarget:       pointer.To(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)), Tags: nil,
+			},
+		},
+	}
+
+	for tName, tCase := range testCases {
+		ctx := testutils.ContextWithTestID(ctx, t)
+		t.Run(tName, func(t *testing.T) {
+			for _, client := range clients {
+				t.Run(client.Name(), func(t *testing.T) {
+					t.Parallel()
+					ctx := testutils.ContextWithTestID(ctx, t)
+
+					for i, constraint := range tCase.constraints {
+						if !constraint.Check(client.APIVersion()) {
+							t.Skipf("skipping %s test due to constraint %d: %q", tName, i, constraint.String())
+						}
+					}
+
+					create, update := tCase.create, tCase.update // because we modify these values below
+
+					bp := dctestobj.TestBlueprintA(t, ctx, client.Client)
+
+					// create the object
+					id, err := bp.CreateSwitchingZone(ctx, create)
+					require.NoError(t, err)
+					require.NotEmpty(t, id)
+
+					// retrieve the object by ID and validate
+					obj, err := bp.GetSwitchingZone(ctx, id)
+					require.NoError(t, err)
+					idPtr := obj.ID()
+					require.NotNil(t, idPtr)
+					require.Equal(t, id, *idPtr)
+					comparedatacenter.SwitchingZone(t, create, obj)
+
+					// retrieve the object by label and validate
+					if create.Label != nil {
+						obj, err = bp.GetSwitchingZoneByLabel(ctx, *create.Label)
+						require.NoError(t, err)
+						idPtr = obj.ID()
+						require.NotNil(t, idPtr)
+						require.Equal(t, id, *idPtr)
+						comparedatacenter.SwitchingZone(t, create, obj)
+					}
+					// retrieve the list of IDs - ours must be in there
+					ids, err := bp.ListSwitchingZones(ctx)
+					require.NoError(t, err)
+					require.Contains(t, ids, id)
+
+					// retrieve the list of objects (ours must be in there) and validate
+					objs, err := bp.GetSwitchingZones(ctx)
+					require.NoError(t, err)
+					objPtr := slice.MustFindByID(objs, id)
+					require.NotNil(t, objPtr)
+					obj = *objPtr
+					idPtr = obj.ID()
+					require.NotNil(t, idPtr)
+					require.Equal(t, id, *idPtr)
+					comparedatacenter.SwitchingZone(t, create, obj)
+
+					// update the object and validate
+					require.NoError(t, update.SetID(id))
+					require.NotNil(t, update.ID())
+					require.Equal(t, id, *update.ID())
+					err = bp.UpdateSwitchingZone(ctx, update)
+					require.NoError(t, err)
+
+					// retrieve the updated object by ID and validate
+					obj, err = bp.GetSwitchingZone(ctx, id)
+					require.NoError(t, err)
+					idPtr = obj.ID()
+					require.NotNil(t, idPtr)
+					require.Equal(t, id, *idPtr)
+					comparedatacenter.SwitchingZone(t, update, obj)
+
+					// delete the object
+					err = bp.DeleteSwitchingZone(ctx, id)
+					require.NoError(t, err)
+
+					// below this point we're expecting to *not* find the object
+					var ace apstra.ClientErr
+
+					// get the object by ID
+					_, err = bp.GetSwitchingZone(ctx, id)
+					require.Error(t, err)
+					require.ErrorAs(t, err, &ace)
+					require.Equal(t, apstra.ErrNotfound, ace.Type())
+
+					// get the object by label
+					if create.Label != nil {
+						_, err = bp.GetSwitchingZoneByLabel(ctx, *create.Label)
+						require.Error(t, err)
+						require.ErrorAs(t, err, &ace)
+						require.Equal(t, apstra.ErrNotfound, ace.Type())
+					}
+
+					// retrieve the list of IDs (ours must *not* be in there)
+					ids, err = bp.ListSwitchingZones(ctx)
+					require.NoError(t, err)
+					require.NotContains(t, ids, id)
+
+					// retrieve the list of objects (ours must *not* be in there)
+					objs, err = bp.GetSwitchingZones(ctx)
+					require.NoError(t, err)
+					objPtr = slice.MustFindByID(objs, id)
+					require.Nil(t, objPtr)
+
+					// update the object
+					err = bp.UpdateSwitchingZone(ctx, update)
+					require.Error(t, err)
+					require.ErrorAs(t, err, &ace)
+					require.Equal(t, apstra.ErrNotfound, ace.Type())
+
+					// delete the object
+					err = bp.DeleteSwitchingZone(ctx, id)
+					require.Error(t, err)
+					require.ErrorAs(t, err, &ace)
+					require.Equal(t, apstra.ErrNotfound, ace.Type())
+				})
+			}
+		})
+	}
+}
+
+func TestSwitchingZone_GetDefaultSwitchingZone(t *testing.T) {
+	ctx := testutils.ContextWithTestID(context.Background(), t)
+	clients := testclient.GetTestClients(t, ctx)
+	for _, client := range clients {
+		t.Run(client.Name(), func(t *testing.T) {
+			if !compatibility.DatacenterSwitchingZoneOK.Check(client.APIVersion()) {
+				t.Skipf("skipping test due to compatibility constraint: %q", compatibility.DatacenterSwitchingZoneOK.String())
+			}
+
+			bp := dctestobj.TestBlueprintA(t, ctx, client.Client)
+
+			sz, err := bp.GetDefaultSwitchingZone(ctx)
+			require.NoError(t, err)
+			require.NotNil(t, sz.ID())
+			require.NotEmpty(t, *sz.ID())
+		})
+	}
+}

--- a/datacenter/switching_zone_integration_test.go
+++ b/datacenter/switching_zone_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// Copyright (c) Juniper Networks, Inc., 2026-2026.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/datacenter/switching_zone_test.go
+++ b/datacenter/switching_zone_test.go
@@ -1,0 +1,151 @@
+// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package datacenter_test
+
+import (
+	"encoding/json"
+	"log"
+	"testing"
+
+	"github.com/Juniper/apstra-go-sdk/datacenter"
+	"github.com/Juniper/apstra-go-sdk/enum"
+	"github.com/Juniper/apstra-go-sdk/errors"
+	"github.com/Juniper/apstra-go-sdk/internal/pointer"
+	testutils "github.com/Juniper/apstra-go-sdk/internal/test_utils"
+	comparedatacenter "github.com/Juniper/apstra-go-sdk/internal/test_utils/compare/datacenter"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSwitchingZone_ID_SetID(t *testing.T) {
+	var o datacenter.SwitchingZone
+	require.Nil(t, o.ID())
+	id := testutils.RandString(6, "hex")
+	require.NoError(t, o.SetID(id))
+	err := o.SetID(id)
+	require.Error(t, err)
+	var eErr errors.IDAlreadySet
+	require.ErrorAs(t, err, &eErr)
+	require.Equal(t, id, *o.ID())
+}
+
+func TestSwitchingZone_MarshalJSON(t *testing.T) {
+	type testCase struct {
+		d datacenter.SwitchingZone
+		e string
+	}
+
+	testCases := map[string]testCase{
+		"vlan_aware": {
+			d: datacenter.SwitchingZone{
+				Label:             pointer.To("label1"),
+				MACVRFDescription: pointer.To("description1"),
+				MACVRFName:        pointer.To("name1"),
+				MACVRFServiceType: pointer.To(enum.SwitchingZoneMACVRFServiceTypeVLANAware),
+				RouteTarget:       pointer.To("1:1"),
+				Tags:              []string{"tag1", "tag2"},
+			},
+			e: `{
+                  "label": "label1",
+                  "mac_vrf_description": "description1",
+                  "mac_vrf_name": "name1",
+                  "mac_vrf_service_type": "vlan_aware",
+                  "route_target": "1:1",
+                  "tags": ["tag1", "tag2"],
+                  "impl_type": "mac_vrf"
+                }`,
+		},
+		"vlan_bundle": {
+			d: datacenter.SwitchingZone{
+				Label:             pointer.To("label2"),
+				MACVRFDescription: pointer.To("description2"),
+				MACVRFName:        pointer.To("name2"),
+				MACVRFServiceType: pointer.To(enum.SwitchingZoneMACVRFServiceTypeVLANBundle),
+				RouteTarget:       pointer.To("2:2"),
+				Tags:              []string{"tag3", "tag4"},
+			},
+			e: `{
+                  "label": "label2",
+                  "mac_vrf_description": "description2",
+                  "mac_vrf_name": "name2",
+                  "mac_vrf_service_type": "vlan_bundle",
+                  "route_target": "2:2",
+                  "tags": ["tag3", "tag4"],
+                  "impl_type": "mac_vrf"
+                }`,
+		},
+	}
+
+	for tName, tCase := range testCases {
+		t.Run(tName, func(t *testing.T) {
+			r, err := json.Marshal(tCase.d)
+			require.NoError(t, err)
+			log.Println(string(r))
+			require.JSONEq(t, tCase.e, string(r))
+		})
+	}
+}
+
+func TestSwitchingZone_UnmarshalJSON(t *testing.T) {
+	type testCase struct {
+		d   string
+		e   datacenter.SwitchingZone
+		eid string
+	}
+
+	testCases := map[string]testCase{
+		"vlan_aware": {
+			d: `{
+                  "label": "label1",
+                  "mac_vrf_description": "description1",
+                  "mac_vrf_name": "name1",
+                  "mac_vrf_service_type": "vlan_aware",
+                  "route_target": "1:1",
+                  "tags": ["tag1", "tag2"],
+                  "impl_type": "mac_vrf",
+                  "id": "abc"
+                 }`,
+			e: datacenter.SwitchingZone{
+				Label:             pointer.To("label1"),
+				MACVRFDescription: pointer.To("description1"),
+				MACVRFName:        pointer.To("name1"),
+				MACVRFServiceType: pointer.To(enum.SwitchingZoneMACVRFServiceTypeVLANAware),
+				RouteTarget:       pointer.To("1:1"),
+				Tags:              []string{"tag1", "tag2"},
+			},
+			eid: "abc",
+		},
+		"vlan_bundle": {
+			d: `{
+                  "label": "label2",
+                  "mac_vrf_description": "description2",
+                  "mac_vrf_name": "name2",
+                  "mac_vrf_service_type": "vlan_bundle",
+                  "route_target": "2:2",
+                  "tags": ["tag3", "tag4"],
+                  "impl_type": "mac_vrf",
+                  "id": "def"
+                }`,
+			e: datacenter.SwitchingZone{
+				Label:             pointer.To("label2"),
+				MACVRFDescription: pointer.To("description2"),
+				MACVRFName:        pointer.To("name2"),
+				MACVRFServiceType: pointer.To(enum.SwitchingZoneMACVRFServiceTypeVLANBundle),
+				RouteTarget:       pointer.To("2:2"),
+				Tags:              []string{"tag3", "tag4"},
+			},
+			eid: "def",
+		},
+	}
+
+	for tName, tCase := range testCases {
+		t.Run(tName, func(t *testing.T) {
+			var r datacenter.SwitchingZone
+			require.NoError(t, json.Unmarshal([]byte(tCase.d), &r))
+			comparedatacenter.SwitchingZone(t, tCase.e, r)
+			require.NotNil(t, r.ID())
+			require.Equal(t, tCase.eid, *r.ID())
+		})
+	}
+}

--- a/datacenter/switching_zone_test.go
+++ b/datacenter/switching_zone_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// Copyright (c) Juniper Networks, Inc., 2026-2026.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/enum/enums.go
+++ b/enum/enums.go
@@ -518,6 +518,20 @@ var (
 	SviIpv6ModeLinkLocal = SviIpv6Mode{Value: "link_local"}
 )
 
+type SwitchingZoneImplementationType oenum.Member[string]
+
+var (
+	SwitchingZoneImplementationTypeDefault = SwitchingZoneImplementationType{Value: "default"}
+	SwitchingZoneImplementationTypeMACVRF  = SwitchingZoneImplementationType{Value: "mac_vrf"}
+)
+
+type SwitchingZoneMACVRFServiceType oenum.Member[string]
+
+var (
+	SwitchingZoneMACVRFServiceTypeVLANAware  = SwitchingZoneMACVRFServiceType{Value: "vlan_aware"}
+	SwitchingZoneMACVRFServiceTypeVLANBundle = SwitchingZoneMACVRFServiceType{Value: "vlan_bundle"}
+)
+
 type SystemManagementLevel oenum.Member[string]
 
 var ( // do not introduce "not_installed" - that's an agent parameter with similar enum values

--- a/enum/enums.go
+++ b/enum/enums.go
@@ -518,13 +518,6 @@ var (
 	SviIpv6ModeLinkLocal = SviIpv6Mode{Value: "link_local"}
 )
 
-type SwitchingZoneImplementationType oenum.Member[string]
-
-var (
-	SwitchingZoneImplementationTypeDefault = SwitchingZoneImplementationType{Value: "default"}
-	SwitchingZoneImplementationTypeMACVRF  = SwitchingZoneImplementationType{Value: "mac_vrf"}
-)
-
 type SwitchingZoneMACVRFServiceType oenum.Member[string]
 
 var (

--- a/enum/generated_enums.go
+++ b/enum/generated_enums.go
@@ -1625,37 +1625,6 @@ func (o *SviIpv6Mode) UnmarshalJSON(bytes []byte) error {
 }
 
 var (
-	_ enum             = (*SwitchingZoneImplementationType)(nil)
-	_ json.Marshaler   = (*SwitchingZoneImplementationType)(nil)
-	_ json.Unmarshaler = (*SwitchingZoneImplementationType)(nil)
-)
-
-func (o SwitchingZoneImplementationType) String() string {
-	return o.Value
-}
-
-func (o *SwitchingZoneImplementationType) FromString(s string) error {
-	if SwitchingZoneImplementationTypes.Parse(s) == nil {
-		return newEnumParseError(o, s)
-	}
-	o.Value = s
-	return nil
-}
-
-func (o SwitchingZoneImplementationType) MarshalJSON() ([]byte, error) {
-	return json.Marshal(o.String())
-}
-
-func (o *SwitchingZoneImplementationType) UnmarshalJSON(bytes []byte) error {
-	var s string
-	err := json.Unmarshal(bytes, &s)
-	if err != nil {
-		return err
-	}
-	return o.FromString(s)
-}
-
-var (
 	_ enum             = (*SwitchingZoneMACVRFServiceType)(nil)
 	_ json.Marshaler   = (*SwitchingZoneMACVRFServiceType)(nil)
 	_ json.Unmarshaler = (*SwitchingZoneMACVRFServiceType)(nil)
@@ -2352,12 +2321,6 @@ var (
 		SviIpv6ModeEnabled,
 		SviIpv6ModeForced,
 		SviIpv6ModeLinkLocal,
-	)
-
-	_                                enum = new(SwitchingZoneImplementationType)
-	SwitchingZoneImplementationTypes      = oenum.New(
-		SwitchingZoneImplementationTypeDefault,
-		SwitchingZoneImplementationTypeMACVRF,
 	)
 
 	_                               enum = new(SwitchingZoneMACVRFServiceType)

--- a/enum/generated_enums.go
+++ b/enum/generated_enums.go
@@ -1625,6 +1625,68 @@ func (o *SviIpv6Mode) UnmarshalJSON(bytes []byte) error {
 }
 
 var (
+	_ enum             = (*SwitchingZoneImplementationType)(nil)
+	_ json.Marshaler   = (*SwitchingZoneImplementationType)(nil)
+	_ json.Unmarshaler = (*SwitchingZoneImplementationType)(nil)
+)
+
+func (o SwitchingZoneImplementationType) String() string {
+	return o.Value
+}
+
+func (o *SwitchingZoneImplementationType) FromString(s string) error {
+	if SwitchingZoneImplementationTypes.Parse(s) == nil {
+		return newEnumParseError(o, s)
+	}
+	o.Value = s
+	return nil
+}
+
+func (o SwitchingZoneImplementationType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(o.String())
+}
+
+func (o *SwitchingZoneImplementationType) UnmarshalJSON(bytes []byte) error {
+	var s string
+	err := json.Unmarshal(bytes, &s)
+	if err != nil {
+		return err
+	}
+	return o.FromString(s)
+}
+
+var (
+	_ enum             = (*SwitchingZoneMACVRFServiceType)(nil)
+	_ json.Marshaler   = (*SwitchingZoneMACVRFServiceType)(nil)
+	_ json.Unmarshaler = (*SwitchingZoneMACVRFServiceType)(nil)
+)
+
+func (o SwitchingZoneMACVRFServiceType) String() string {
+	return o.Value
+}
+
+func (o *SwitchingZoneMACVRFServiceType) FromString(s string) error {
+	if SwitchingZoneMACVRFServiceTypes.Parse(s) == nil {
+		return newEnumParseError(o, s)
+	}
+	o.Value = s
+	return nil
+}
+
+func (o SwitchingZoneMACVRFServiceType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(o.String())
+}
+
+func (o *SwitchingZoneMACVRFServiceType) UnmarshalJSON(bytes []byte) error {
+	var s string
+	err := json.Unmarshal(bytes, &s)
+	if err != nil {
+		return err
+	}
+	return o.FromString(s)
+}
+
+var (
 	_ enum             = (*SystemManagementLevel)(nil)
 	_ json.Marshaler   = (*SystemManagementLevel)(nil)
 	_ json.Unmarshaler = (*SystemManagementLevel)(nil)
@@ -2290,6 +2352,18 @@ var (
 		SviIpv6ModeEnabled,
 		SviIpv6ModeForced,
 		SviIpv6ModeLinkLocal,
+	)
+
+	_                                enum = new(SwitchingZoneImplementationType)
+	SwitchingZoneImplementationTypes      = oenum.New(
+		SwitchingZoneImplementationTypeDefault,
+		SwitchingZoneImplementationTypeMACVRF,
+	)
+
+	_                               enum = new(SwitchingZoneMACVRFServiceType)
+	SwitchingZoneMACVRFServiceTypes      = oenum.New(
+		SwitchingZoneMACVRFServiceTypeVLANAware,
+		SwitchingZoneMACVRFServiceTypeVLANBundle,
 	)
 
 	_                      enum = new(SystemManagementLevel)

--- a/internal/interfaces.go
+++ b/internal/interfaces.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// Copyright (c) Juniper Networks, Inc., 2025-2026.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/internal/interfaces.go
+++ b/internal/interfaces.go
@@ -7,3 +7,7 @@ package internal
 type IDer interface {
 	ID() *string
 }
+
+type IDSetter interface {
+	SetID(string) error
+}

--- a/internal/test_utils/compare/datacenter/switching_zone.go
+++ b/internal/test_utils/compare/datacenter/switching_zone.go
@@ -1,0 +1,54 @@
+// Copyright (c) Juniper Networks, Inc., 2026-2026.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build requiretestutils
+
+package comparedatacenter
+
+import (
+	"testing"
+
+	"github.com/Juniper/apstra-go-sdk/datacenter"
+	testmessage "github.com/Juniper/apstra-go-sdk/internal/test_utils/test_message"
+	"github.com/stretchr/testify/require"
+)
+
+func SwitchingZone(t testing.TB, req, resp datacenter.SwitchingZone, msg ...string) {
+	msg = testmessage.Add(msg, "Comparing Switching Zone")
+
+	if req.Label != nil {
+		require.NotNil(t, resp.Label, msg)
+		require.Equal(t, *req.Label, *resp.Label, msg)
+	}
+
+	if req.MACVRFDescription != nil {
+		require.NotNil(t, resp.MACVRFDescription, msg)
+		require.Equal(t, *req.MACVRFDescription, *resp.MACVRFDescription, msg)
+	}
+
+	if req.MACVRFName != nil {
+		require.NotNil(t, resp.MACVRFName, msg)
+		require.Equal(t, *req.MACVRFName, *resp.MACVRFName, msg)
+	}
+
+	if req.MACVRFServiceType != nil {
+		require.NotNil(t, resp.MACVRFServiceType, msg)
+		require.Equal(t, *req.MACVRFServiceType, *resp.MACVRFServiceType, msg)
+	}
+
+	if req.RouteTarget != nil {
+		require.NotNil(t, resp.RouteTarget, msg)
+		require.Equal(t, *req.RouteTarget, *resp.RouteTarget, msg)
+	}
+
+	if req.Tags != nil {
+		require.Equal(t, len(req.Tags), len(resp.Tags), msg)
+		require.ElementsMatch(t, req.Tags, resp.Tags, msg)
+	}
+
+	if req.ID() != nil {
+		require.NotNil(t, resp.ID(), msg)
+		require.Equal(t, *req.ID(), *resp.ID(), msg)
+	}
+}

--- a/internal/urls/base.go
+++ b/internal/urls/base.go
@@ -1,3 +1,7 @@
+// Copyright (c) Juniper Networks, Inc., 2026-2026.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package urls
 
 const (

--- a/internal/urls/base.go
+++ b/internal/urls/base.go
@@ -1,0 +1,7 @@
+package urls
+
+const (
+	PathDelim     = "/"
+	Blueprints    = "/api/blueprints"
+	BlueprintByID = Blueprints + PathDelim + "%s"
+)

--- a/internal/urls/base.go
+++ b/internal/urls/base.go
@@ -5,7 +5,7 @@
 package urls
 
 const (
-	PathDelim     = "/"
-	Blueprints    = "/api/blueprints"
-	BlueprintByID = Blueprints + PathDelim + "%s"
+	pathDelim     = "/"
+	blueprints    = "/api/blueprints"
+	blueprintByID = blueprints + pathDelim + "%s"
 )

--- a/internal/urls/datacenter.go
+++ b/internal/urls/datacenter.go
@@ -5,6 +5,6 @@
 package urls
 
 const (
-	DatacenterSwitchingZones    = BlueprintByID + PathDelim + "switching-zones"
-	DatacenterSwitchingZoneByID = DatacenterSwitchingZones + PathDelim + "%s"
+	DatacenterSwitchingZones    = blueprintByID + pathDelim + "switching-zones"
+	DatacenterSwitchingZoneByID = DatacenterSwitchingZones + pathDelim + "%s"
 )

--- a/internal/urls/datacenter.go
+++ b/internal/urls/datacenter.go
@@ -1,0 +1,10 @@
+// Copyright (c) Juniper Networks, Inc., 2026-2026.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package urls
+
+const (
+	DatacenterSwitchingZones    = BlueprintByID + PathDelim + "switching-zones"
+	DatacenterSwitchingZoneByID = DatacenterSwitchingZones + PathDelim + "%s"
+)


### PR DESCRIPTION
This PR introduces support for Switching Zones, introduced with Apstra 6.2.0.

This is just the initial work: The object with the usual CRUD methods. Switching Zone ID has been added as a required attribute to various other APIs, so those will need to be extended to match.

In this PR we have:

- The usual get/update/delete methods
- Some new constants, version constraints and enums
- The new `SwitchingZone{}` type with unit tests and integration tests
- A test helper function for comparing switching zones
- A new `internal/urls` package where I intend to migrate URL constants
- A new `IDSetter` interface definition used as a compile-time check for types with private `id` field.

Closes #707