### PR TITLE
Add support for read-only `tags` JSON attribute to `SecurityZone` struct

### DIFF
--- a/apstra/two_stage_l3_clos_security_zone.go
+++ b/apstra/two_stage_l3_clos_security_zone.go
@@ -62,7 +62,7 @@ func (o *SecurityZone) SetID(id string) {
 }
 
 func (o *SecurityZone) UnmarshalJSON(bytes []byte) error {
-	type securityZoneAlias SecurityZone // type alias defeats recursion
+	type securityZoneAlias SecurityZone // type alias prevents recursion
 
 	var aux struct {
 		securityZoneAlias

--- a/apstra/two_stage_l3_clos_security_zone.go
+++ b/apstra/two_stage_l3_clos_security_zone.go
@@ -43,7 +43,7 @@ type SecurityZone struct {
 	AddressingSupport *enum.AddressingScheme `json:"addressing_support,omitempty"`  // Apstra 6.1+ only
 	DisableIPv4       *bool                  `json:"disable_ipv4,omitempty"`        // Apstra 6.1+ only
 	VTEPAddressing    *enum.AddressingScheme `json:"vtep_addressing,omitempty"`     // Apstra 6.1+ only
-	Tags              []string               // Apstra 5.0.0+ only and read-only
+	Tags              []string               // Apstra 5.0.0+ and read-only - JSON struct tag is omitted to prevent marshaling this attribute
 
 	id string
 }

--- a/apstra/two_stage_l3_clos_security_zone.go
+++ b/apstra/two_stage_l3_clos_security_zone.go
@@ -43,6 +43,7 @@ type SecurityZone struct {
 	AddressingSupport *enum.AddressingScheme `json:"addressing_support,omitempty"`  // Apstra 6.1+ only
 	DisableIPv4       *bool                  `json:"disable_ipv4,omitempty"`        // Apstra 6.1+ only
 	VTEPAddressing    *enum.AddressingScheme `json:"vtep_addressing,omitempty"`     // Apstra 6.1+ only
+	Tags              []string               // Apstra 5.0.0+ only and read-only
 
 	id string
 }
@@ -61,41 +62,22 @@ func (o *SecurityZone) SetID(id string) {
 }
 
 func (o *SecurityZone) UnmarshalJSON(bytes []byte) error {
-	var raw struct {
-		ID                string                 `json:"id"`
-		Label             string                 `json:"label"`
-		Description       *string                `json:"vrf_description"`
-		Type              enum.SecurityZoneType  `json:"sz_type"`
-		VRFName           string                 `json:"vrf_name"`
-		RoutingPolicyID   string                 `json:"routing_policy_id"`
-		RouteTarget       *string                `json:"route_target"`
-		RTPolicy          *RTPolicy              `json:"rt_policy"`
-		VLAN              *VLAN                  `json:"vlan_id"`
-		VNI               *int                   `json:"vni_id"`
-		JunosEVPNIRBMode  *enum.JunosEVPNIRBMode `json:"junos_evpn_irb_mode"`
-		AddressingSupport *enum.AddressingScheme `json:"addressing_support"`
-		DisableIPv4       *bool                  `json:"disable_ipv4"`
-		VTEPAddressing    *enum.AddressingScheme `json:"vtep_addressing"`
+	type securityZoneAlias SecurityZone // type alias defeats recursion
+
+	var aux struct {
+		securityZoneAlias
+		ID   string   `json:"id"`   // the `id` struct element cannot be unmarshaled so we temporarily stash that value here
+		Tags []string `json:"tags"` // the `Tags` struct element cannot be unmarshaled so we temporarily stash that value here
 	}
-	err := json.Unmarshal(bytes, &raw)
-	if err != nil {
+
+	// unmarshal everything which can be handled by the `json` package.
+	if err := json.Unmarshal(bytes, &aux); err != nil {
 		return err
 	}
 
-	o.id = raw.ID
-	o.Label = raw.Label
-	o.Description = raw.Description
-	o.Type = raw.Type
-	o.VRFName = raw.VRFName
-	o.RoutingPolicyID = raw.RoutingPolicyID
-	o.RouteTarget = raw.RouteTarget
-	o.RTPolicy = raw.RTPolicy
-	o.VLAN = raw.VLAN
-	o.VNI = raw.VNI
-	o.JunosEVPNIRBMode = raw.JunosEVPNIRBMode
-	o.AddressingSupport = raw.AddressingSupport
-	o.DisableIPv4 = raw.DisableIPv4
-	o.VTEPAddressing = raw.VTEPAddressing
+	*o = SecurityZone(aux.securityZoneAlias)
+	o.id = aux.ID
+	o.Tags = aux.Tags
 
 	return nil
 }

--- a/apstra/two_stage_l3_clos_security_zone_integration_test.go
+++ b/apstra/two_stage_l3_clos_security_zone_integration_test.go
@@ -326,3 +326,32 @@ func TestGetDefaultRoutingZone(t *testing.T) {
 		})
 	}
 }
+
+func TestSecurityZone_Tagging(t *testing.T) {
+	ctx := testutils.ContextWithTestID(t.Context(), t)
+
+	clients := testclient.GetTestClients(t, ctx)
+
+	for _, client := range clients {
+		t.Run(client.Name(), func(t *testing.T) {
+			if compatibility.SecurityZoneTaggingForbidden.Check(client.APIVersion()) {
+				t.Skipf("skipping test due to API version constraints: tagging of security zones is forbidden in Apstra %s", client.APIVersion())
+			}
+
+			t.Parallel()
+			ctx := testutils.ContextWithTestID(ctx, t)
+
+			bpClient := dctestobj.TestBlueprintA(t, ctx, client.Client)
+			sz, err := bpClient.GetSecurityZoneByVRFName(ctx, "default")
+			require.NoError(t, err)
+			require.NotNil(t, sz.ID())
+
+			desiredTags := []string{testutils.RandString(6, "hex"), testutils.RandString(6, "hex")}
+
+			require.NoError(t, bpClient.SetNodeTags(ctx, apstra.ObjectId(*sz.ID()), desiredTags))
+			sz, err = bpClient.GetSecurityZone(ctx, *sz.ID())
+
+			require.ElementsMatch(t, desiredTags, sz.Tags)
+		})
+	}
+}

--- a/compatibility/constraints.go
+++ b/compatibility/constraints.go
@@ -56,6 +56,9 @@ var (
 	SecurityZoneLoopbackApiSupported = Constraint{
 		constraints: version.MustConstraints(version.NewConstraint(">=" + apstra500)),
 	}
+	SecurityZoneTaggingForbidden = Constraint{
+		constraints: version.MustConstraints(version.NewConstraint("<" + apstra500)),
+	}
 	ServerVersionSupported = Constraint{
 		constraints:             version.MustConstraints(version.NewConstraint(strings.Join(SupportedApiVersions(), ","))),
 		considerPreReleaseLabel: true,


### PR DESCRIPTION
This PR adds the `Tags` element to the `SecurityZone` struct.

There's no JSON struct tag for this element, because it's not writable via the `POST`/`PUT`/`PATCH` methods.

It's only readable via `GET`, so we have special handling for it in the `UnmarshalJSON()` function.

## Odds and Ends
- re-wrote the `UnmarshalJSON()` function using the aux/alias pattern to make it more concise.
- introduced test for tag retrieval