### PR TITLE
Fix expected count of resource group names (32 -> 33) in test

### DIFF
--- a/apstra/two_stage_l3_clos_resources_test.go
+++ b/apstra/two_stage_l3_clos_resources_test.go
@@ -83,7 +83,7 @@ func TestSetGetResourceAllocation(t *testing.T) {
 
 func TestAllResourceGroupNames(t *testing.T) {
 	all := AllResourceGroupNames()
-	expected := 32
+	expected := 33
 	if len(all) != expected {
 		t.Fatalf("expected %d resource group names, got %d", expected, len(all))
 	}


### PR DESCRIPTION
#711 added a new resource group name.

An existing test counts the number of resource group names and expects to find 32. The correct number is now 33.