### PR TITLE
`TwoStageL3ClosClient`: Add methods to retrieve and cache default Switching Zone ID

### DIFF
--- a/apstra/two_stage_l3_clos_client.go
+++ b/apstra/two_stage_l3_clos_client.go
@@ -64,11 +64,12 @@ func (o BlueprintType) string() string {
 }
 
 type TwoStageL3ClosClient struct {
-	client        *Client
-	blueprintId   ObjectId
-	Mutex         Mutex
-	blueprintType BlueprintType
-	nodeIdsByType map[NodeType][]ObjectId
+	client                 *Client
+	blueprintId            ObjectId
+	Mutex                  Mutex
+	blueprintType          BlueprintType
+	nodeIdsByType          map[NodeType][]ObjectId
+	defaultSwitchingZoneID string
 }
 
 // Id returns the client's Blueprint ID

--- a/apstra/two_stage_l3_clos_switching_zone.go
+++ b/apstra/two_stage_l3_clos_switching_zone.go
@@ -12,10 +12,14 @@ import (
 	"net/http"
 	"slices"
 
+	"github.com/Juniper/apstra-go-sdk/compatibility"
 	"github.com/Juniper/apstra-go-sdk/datacenter"
+	"github.com/Juniper/apstra-go-sdk/errors"
 	"github.com/Juniper/apstra-go-sdk/internal/str"
 	"github.com/Juniper/apstra-go-sdk/internal/urls"
 )
+
+const defaultSwitchingZoneIDLock = "default_switching_zone"
 
 func (c *TwoStageL3ClosClient) CreateSwitchingZone(ctx context.Context, v datacenter.SwitchingZone) (string, error) {
 	var response struct {
@@ -94,8 +98,68 @@ func (c *TwoStageL3ClosClient) GetSwitchingZoneByLabel(ctx context.Context, labe
 	return *result, nil
 }
 
+func (c *TwoStageL3ClosClient) DefaultSwitchingZoneID(ctx context.Context) (string, error) {
+	if !compatibility.DatacenterSwitchingZoneOK.Check(c.client.apiVersion) {
+		return "", errors.IncompatibleVersion(fmt.Sprintf(
+			"Switching Zones supported only with API versions %q, this is version %q",
+			compatibility.DatacenterSwitchingZoneOK, c.client.apiVersion,
+		))
+	}
+
+	c.client.lock(defaultSwitchingZoneIDLock)
+	defer c.client.unlock(defaultSwitchingZoneIDLock)
+
+	// If we know the default switching zone ID, return it.
+	if c.defaultSwitchingZoneID != "" {
+		return c.defaultSwitchingZoneID, nil
+	}
+
+	// Retrieve the default Switching Zone the hard way.
+	sz, err := c.getDefaultSwitchingZone(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed while fetching default Switching Zone ID: %w", err)
+	}
+
+	id := sz.ID()
+	if id == nil {
+		return "", errors.APIResponseInvalid("default Switching Zone ID returned nil ID")
+	}
+
+	c.defaultSwitchingZoneID = *id // Cache the default Switching Zone ID.
+
+	return *id, nil
+}
+
 func (c *TwoStageL3ClosClient) GetDefaultSwitchingZone(ctx context.Context) (datacenter.SwitchingZone, error) {
-	// collect all Switching Zones here without unpacking them
+	c.client.lock(defaultSwitchingZoneIDLock)
+	defer c.client.unlock(defaultSwitchingZoneIDLock)
+
+	// If we know the default Switching Zone ID, fetch it using the cached ID.
+	if c.defaultSwitchingZoneID != "" {
+		return c.GetSwitchingZone(ctx, c.defaultSwitchingZoneID)
+	}
+
+	// Retrieve the default Switching Zone the hard way.
+	sz, err := c.getDefaultSwitchingZone(ctx)
+	if err != nil {
+		return datacenter.SwitchingZone{}, fmt.Errorf("failed while fetching default Switching Zone: %w", err)
+	}
+
+	id := sz.ID()
+	if id == nil {
+		return datacenter.SwitchingZone{}, errors.APIResponseInvalid("default Switching Zone ID returned nil ID")
+	}
+
+	c.defaultSwitchingZoneID = *id // Cache the default Switching Zone ID.
+
+	return sz, nil
+}
+
+// getDefaultSwitchingZone fetches every Switching Zone looking for the one with
+//
+//	{ "impl_type": "default" }
+func (c *TwoStageL3ClosClient) getDefaultSwitchingZone(ctx context.Context) (datacenter.SwitchingZone, error) {
+	// Collect all Switching Zones here without unpacking them.
 	var response struct {
 		Items map[string]json.RawMessage `json:"items"`
 	}
@@ -114,7 +178,7 @@ func (c *TwoStageL3ClosClient) GetDefaultSwitchingZone(ctx context.Context) (dat
 		ImplType string `json:"impl_type"`
 	}
 
-	// loop over switching zones looking for the one (we expect) with impl_type == default
+	// Loop over switching zones looking for the one (we expect) with impl_type == default
 	var result *datacenter.SwitchingZone
 	for i, item := range response.Items {
 		if err = json.Unmarshal(item, &target); err != nil {

--- a/apstra/two_stage_l3_clos_switching_zone.go
+++ b/apstra/two_stage_l3_clos_switching_zone.go
@@ -109,7 +109,7 @@ func (c *TwoStageL3ClosClient) DefaultSwitchingZoneID(ctx context.Context) (stri
 	c.client.lock(defaultSwitchingZoneIDLock)
 	defer c.client.unlock(defaultSwitchingZoneIDLock)
 
-	// If we know the default switching zone ID, return it.
+	// If we know the default Switching Zone ID, return it.
 	if c.defaultSwitchingZoneID != "" {
 		return c.defaultSwitchingZoneID, nil
 	}
@@ -178,7 +178,7 @@ func (c *TwoStageL3ClosClient) getDefaultSwitchingZone(ctx context.Context) (dat
 		ImplType string `json:"impl_type"`
 	}
 
-	// Loop over switching zones looking for the one (we expect) with impl_type == default
+	// Loop over Switching Zones looking for the one (we expect) with impl_type == default
 	var result *datacenter.SwitchingZone
 	for i, item := range response.Items {
 		if err = json.Unmarshal(item, &target); err != nil {

--- a/apstra/two_stage_l3_clos_switching_zone.go
+++ b/apstra/two_stage_l3_clos_switching_zone.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Juniper/apstra-go-sdk/compatibility"
 	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/apstra-go-sdk/errors"
+	"github.com/Juniper/apstra-go-sdk/internal/pointer"
 	"github.com/Juniper/apstra-go-sdk/internal/str"
 	"github.com/Juniper/apstra-go-sdk/internal/urls"
 )
@@ -108,9 +109,7 @@ func (c *TwoStageL3ClosClient) DefaultSwitchingZoneID(ctx context.Context) (*str
 
 	// If we know the default Switching Zone ID, return it.
 	if c.defaultSwitchingZoneID != "" {
-		// make a copy rather than returning a pointer to our cached value to defend against modification by the caller
-		result := c.defaultSwitchingZoneID
-		return &result, nil
+		return pointer.ToCopy(c.defaultSwitchingZoneID), nil
 	}
 
 	// Retrieve the default Switching Zone the hard way.

--- a/apstra/two_stage_l3_clos_switching_zone.go
+++ b/apstra/two_stage_l3_clos_switching_zone.go
@@ -98,12 +98,9 @@ func (c *TwoStageL3ClosClient) GetSwitchingZoneByLabel(ctx context.Context, labe
 	return *result, nil
 }
 
-func (c *TwoStageL3ClosClient) DefaultSwitchingZoneID(ctx context.Context) (string, error) {
+func (c *TwoStageL3ClosClient) DefaultSwitchingZoneID(ctx context.Context) (*string, error) {
 	if !compatibility.DatacenterSwitchingZoneOK.Check(c.client.apiVersion) {
-		return "", errors.IncompatibleVersion(fmt.Sprintf(
-			"Switching Zones supported only with API versions %q, this is version %q",
-			compatibility.DatacenterSwitchingZoneOK, c.client.apiVersion,
-		))
+		return nil, nil
 	}
 
 	c.client.lock(defaultSwitchingZoneIDLock)
@@ -111,23 +108,25 @@ func (c *TwoStageL3ClosClient) DefaultSwitchingZoneID(ctx context.Context) (stri
 
 	// If we know the default Switching Zone ID, return it.
 	if c.defaultSwitchingZoneID != "" {
-		return c.defaultSwitchingZoneID, nil
+		// make a copy rather than returning a pointer to our cached value to defend against modification by the caller
+		result := c.defaultSwitchingZoneID
+		return &result, nil
 	}
 
 	// Retrieve the default Switching Zone the hard way.
 	sz, err := c.getDefaultSwitchingZone(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed while fetching default Switching Zone ID: %w", err)
+		return nil, fmt.Errorf("failed while fetching default Switching Zone ID: %w", err)
 	}
 
 	id := sz.ID()
 	if id == nil {
-		return "", errors.APIResponseInvalid("default Switching Zone ID returned nil ID")
+		return nil, errors.APIResponseInvalid("default Switching Zone ID returned nil ID")
 	}
 
 	c.defaultSwitchingZoneID = *id // Cache the default Switching Zone ID.
 
-	return *id, nil
+	return id, nil
 }
 
 func (c *TwoStageL3ClosClient) GetDefaultSwitchingZone(ctx context.Context) (datacenter.SwitchingZone, error) {

--- a/apstra/two_stage_l3_clos_switching_zone.go
+++ b/apstra/two_stage_l3_clos_switching_zone.go
@@ -109,7 +109,7 @@ func (c *TwoStageL3ClosClient) DefaultSwitchingZoneID(ctx context.Context) (*str
 
 	// If we know the default Switching Zone ID, return it.
 	if c.defaultSwitchingZoneID != "" {
-		return pointer.ToCopy(c.defaultSwitchingZoneID), nil
+		return pointer.ToCopyOf(c.defaultSwitchingZoneID), nil
 	}
 
 	// Retrieve the default Switching Zone the hard way.

--- a/datacenter/switching_zone_integration_test.go
+++ b/datacenter/switching_zone_integration_test.go
@@ -192,6 +192,9 @@ func TestSwitchingZone_GetDefaultSwitchingZone(t *testing.T) {
 	clients := testclient.GetTestClients(t, ctx)
 	for _, client := range clients {
 		t.Run(client.Name(), func(t *testing.T) {
+			t.Parallel()
+			ctx := testutils.ContextWithTestID(ctx, t)
+
 			if !compatibility.DatacenterSwitchingZoneOK.Check(client.APIVersion()) {
 				t.Skipf("skipping test due to compatibility constraint: %q", compatibility.DatacenterSwitchingZoneOK.String())
 			}
@@ -228,6 +231,9 @@ func TestSwitchingZone_DefaultSwitchingZoneID(t *testing.T) {
 	clients := testclient.GetTestClients(t, ctx)
 	for _, client := range clients {
 		t.Run(client.Name(), func(t *testing.T) {
+			t.Parallel()
+			ctx := testutils.ContextWithTestID(ctx, t)
+
 			if !compatibility.DatacenterSwitchingZoneOK.Check(client.APIVersion()) {
 				t.Skipf("skipping test due to compatibility constraint: %q", compatibility.DatacenterSwitchingZoneOK.String())
 			}

--- a/datacenter/switching_zone_integration_test.go
+++ b/datacenter/switching_zone_integration_test.go
@@ -198,10 +198,60 @@ func TestSwitchingZone_GetDefaultSwitchingZone(t *testing.T) {
 
 			bp := dctestobj.TestBlueprintA(t, ctx, client.Client)
 
+			// The default Switching Zone ID will not be cached at this point
 			sz, err := bp.GetDefaultSwitchingZone(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, sz.ID())
 			require.NotEmpty(t, *sz.ID())
+
+			// The default Switching Zone ID should be cached here
+			id, err := bp.DefaultSwitchingZoneID(ctx)
+			require.NoError(t, err)
+			require.NotEmpty(t, id)
+
+			require.Equal(t, id, *sz.ID())
+
+			// The default Switching Zone ID should be cached here
+			sz, err = bp.GetDefaultSwitchingZone(ctx)
+			require.NoError(t, err)
+			require.NotNil(t, sz.ID())
+			require.NotEmpty(t, *sz.ID())
+
+			require.Equal(t, id, *sz.ID())
+		})
+	}
+}
+
+func TestSwitchingZone_DefaultSwitchingZoneID(t *testing.T) {
+	ctx := testutils.ContextWithTestID(context.Background(), t)
+	clients := testclient.GetTestClients(t, ctx)
+	for _, client := range clients {
+		t.Run(client.Name(), func(t *testing.T) {
+			if !compatibility.DatacenterSwitchingZoneOK.Check(client.APIVersion()) {
+				t.Skipf("skipping test due to compatibility constraint: %q", compatibility.DatacenterSwitchingZoneOK.String())
+			}
+
+			bp := dctestobj.TestBlueprintA(t, ctx, client.Client)
+
+			// The default Switching Zone ID will not be cached at this point
+			id, err := bp.DefaultSwitchingZoneID(ctx)
+			require.NoError(t, err)
+			require.NotEmpty(t, id)
+
+			// The default Switching Zone ID should be cached here
+			sz, err := bp.GetDefaultSwitchingZone(ctx)
+			require.NoError(t, err)
+			require.NotNil(t, sz.ID())
+			require.NotEmpty(t, *sz.ID())
+
+			require.Equal(t, id, *sz.ID())
+
+			// The default Switching Zone ID should be cached here
+			id, err = bp.DefaultSwitchingZoneID(ctx)
+			require.NoError(t, err)
+			require.NotEmpty(t, id)
+
+			require.Equal(t, id, *sz.ID())
 		})
 	}
 }

--- a/datacenter/switching_zone_integration_test.go
+++ b/datacenter/switching_zone_integration_test.go
@@ -207,9 +207,10 @@ func TestSwitchingZone_GetDefaultSwitchingZone(t *testing.T) {
 			// The default Switching Zone ID should be cached here
 			id, err := bp.DefaultSwitchingZoneID(ctx)
 			require.NoError(t, err)
+			require.NotNil(t, id)
 			require.NotEmpty(t, id)
 
-			require.Equal(t, id, *sz.ID())
+			require.Equal(t, *id, *sz.ID())
 
 			// The default Switching Zone ID should be cached here
 			sz, err = bp.GetDefaultSwitchingZone(ctx)
@@ -217,7 +218,7 @@ func TestSwitchingZone_GetDefaultSwitchingZone(t *testing.T) {
 			require.NotNil(t, sz.ID())
 			require.NotEmpty(t, *sz.ID())
 
-			require.Equal(t, id, *sz.ID())
+			require.Equal(t, *id, *sz.ID())
 		})
 	}
 }
@@ -236,6 +237,7 @@ func TestSwitchingZone_DefaultSwitchingZoneID(t *testing.T) {
 			// The default Switching Zone ID will not be cached at this point
 			id, err := bp.DefaultSwitchingZoneID(ctx)
 			require.NoError(t, err)
+			require.NotNil(t, id)
 			require.NotEmpty(t, id)
 
 			// The default Switching Zone ID should be cached here
@@ -244,14 +246,15 @@ func TestSwitchingZone_DefaultSwitchingZoneID(t *testing.T) {
 			require.NotNil(t, sz.ID())
 			require.NotEmpty(t, *sz.ID())
 
-			require.Equal(t, id, *sz.ID())
+			require.Equal(t, *id, *sz.ID())
 
 			// The default Switching Zone ID should be cached here
 			id, err = bp.DefaultSwitchingZoneID(ctx)
 			require.NoError(t, err)
+			require.NotNil(t, id)
 			require.NotEmpty(t, id)
 
-			require.Equal(t, id, *sz.ID())
+			require.Equal(t, *id, *sz.ID())
 		})
 	}
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -16,6 +16,12 @@ func (e IDAlreadySet) Error() string {
 	return string(e)
 }
 
+type IncompatibleVersion string
+
+func (e IncompatibleVersion) Error() string {
+	return string(e)
+}
+
 type Internal string
 
 func (e Internal) Error() string {

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -16,12 +16,6 @@ func (e IDAlreadySet) Error() string {
 	return string(e)
 }
 
-type IncompatibleVersion string
-
-func (e IncompatibleVersion) Error() string {
-	return string(e)
-}
-
 type Internal string
 
 func (e Internal) Error() string {

--- a/internal/pointer/to.go
+++ b/internal/pointer/to.go
@@ -7,3 +7,8 @@ package pointer
 func To[A any](a A) *A {
 	return &a
 }
+
+func ToCopy[A any](a A) *A {
+	_copy := a
+	return &_copy
+}

--- a/internal/pointer/to.go
+++ b/internal/pointer/to.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// Copyright (c) Juniper Networks, Inc., 2025-2026.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -8,7 +8,7 @@ func To[A any](a A) *A {
 	return &a
 }
 
-func ToCopy[A any](a A) *A {
+func ToCopyOf[A any](a A) *A {
 	_copy := a
 	return &_copy
 }


### PR DESCRIPTION
This PR introduces a string pointer to the `TwoStageL3ClosClient` struct.

The Default switching zone has an unpredictable (but immutable!) ID which must be sent with VN creation.

By caching the ID we'll be able to streamline SDK consumer experience by allowing them to omit the Switching Zone ID from their transactions: If they omit it, we'll slap the default ID in there for them.

Caching the ID ensures we don't waste lots of time discovering it over and over.