### PR TITLE
717 blueprint client should cache default routing zone

### DIFF
--- a/apstra/client_rendered_diff_integration_test.go
+++ b/apstra/client_rendered_diff_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/apstra-go-sdk/internal/query"
 	testutils "github.com/Juniper/apstra-go-sdk/internal/test_utils"
@@ -66,7 +67,7 @@ func TestGetNodeRenderedDiff(t *testing.T) {
 
 				// create a security zone
 				szLabel := testutils.RandString(6, "hex")
-				szId, err := bp.CreateSecurityZone(ctx, apstra.SecurityZone{
+				szId, err := bp.CreateSecurityZone(ctx, datacenter.SecurityZone{
 					Label:   szLabel,
 					Type:    enum.SecurityZoneTypeEVPN,
 					VRFName: szLabel,

--- a/apstra/helpers_test.go
+++ b/apstra/helpers_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/Juniper/apstra-go-sdk/compatibility"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -734,7 +735,7 @@ func testSecurityZone(t testing.TB, ctx context.Context, bp *TwoStageL3ClosClien
 
 	rs := randString(6, "hex")
 
-	id, err := bp.CreateSecurityZone(ctx, SecurityZone{
+	id, err := bp.CreateSecurityZone(ctx, datacenter.SecurityZone{
 		Label:            rs,
 		Type:             enum.SecurityZoneTypeEVPN,
 		VRFName:          rs,

--- a/apstra/two_stage_l3_clos_client.go
+++ b/apstra/two_stage_l3_clos_client.go
@@ -69,6 +69,7 @@ type TwoStageL3ClosClient struct {
 	Mutex                  Mutex
 	blueprintType          BlueprintType
 	nodeIdsByType          map[NodeType][]ObjectId
+	defaultSecurityZoneID  string
 	defaultSwitchingZoneID string
 }
 

--- a/apstra/two_stage_l3_clos_connectivity_template_assignment_integration_test.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_assignment_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/compatibility"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/apstra-go-sdk/internal/pointer"
 	"github.com/stretchr/testify/require"
@@ -90,7 +91,7 @@ func TestAssignClearCtToInterface(t *testing.T) {
 			}
 
 			vrf := randString(5, "hex")
-			szId, err := bpClient.CreateSecurityZone(ctx, SecurityZone{
+			szId, err := bpClient.CreateSecurityZone(ctx, datacenter.SecurityZone{
 				Label:   vrf,
 				Type:    enum.SecurityZoneTypeEVPN,
 				VRFName: vrf,
@@ -366,7 +367,7 @@ func TestSetDelApplicationPointConnectivityTemplates_Errors(t *testing.T) {
 				rzAddressing = &enum.AddressingSchemeIPv46
 			}
 
-			rzID, err := bpClient.CreateSecurityZone(ctx, SecurityZone{
+			rzID, err := bpClient.CreateSecurityZone(ctx, datacenter.SecurityZone{
 				Label:             randString(6, "hex"),
 				Type:              enum.SecurityZoneTypeEVPN,
 				VRFName:           randString(6, "hex"),

--- a/apstra/two_stage_l3_clos_endpoint_policies_status_integration_test.go
+++ b/apstra/two_stage_l3_clos_endpoint_policies_status_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/compatibility"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/stretchr/testify/require"
 )
@@ -88,7 +89,7 @@ func TestGetAllConnectivityTemplateStatus(t *testing.T) {
 		}
 
 		szLabel := randString(6, "hex")
-		szId, err := bp.CreateSecurityZone(ctx, SecurityZone{
+		szId, err := bp.CreateSecurityZone(ctx, datacenter.SecurityZone{
 			Label:             szLabel,
 			Type:              enum.SecurityZoneTypeEVPN,
 			VRFName:           szLabel,

--- a/apstra/two_stage_l3_clos_evpn_interconnect_group_integration_test.go
+++ b/apstra/two_stage_l3_clos_evpn_interconnect_group_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/apstra-go-sdk/internal/pointer"
 	testutils "github.com/Juniper/apstra-go-sdk/internal/test_utils"
@@ -65,7 +66,7 @@ func TestEvpnInterconnectGroup(t *testing.T) {
 			securityZoneIDs := make([]string, securityZoneCount)
 			for i := range securityZoneIDs {
 				vrfName := testutils.RandString(6, "hex")
-				id, err := bpClient.CreateSecurityZone(ctx, apstra.SecurityZone{
+				id, err := bpClient.CreateSecurityZone(ctx, datacenter.SecurityZone{
 					Label:   vrfName,
 					Type:    enum.SecurityZoneTypeEVPN,
 					VRFName: vrfName,

--- a/apstra/two_stage_l3_clos_policies_integration_test.go
+++ b/apstra/two_stage_l3_clos_policies_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/apstra-go-sdk/enum"
 )
 
@@ -263,7 +264,7 @@ func TestCreateDatacenterPolicy(t *testing.T) {
 
 			// create a security zone (VNs live here)
 			szName := randString(5, "hex")
-			szId, err := bp.CreateSecurityZone(ctx, SecurityZone{
+			szId, err := bp.CreateSecurityZone(ctx, datacenter.SecurityZone{
 				Type:    enum.SecurityZoneTypeEVPN,
 				Label:   szName,
 				VRFName: szName,
@@ -388,7 +389,7 @@ func TestAddDeletePolicyRule(t *testing.T) {
 
 			// create a security zone (VNs live here)
 			szName := randString(5, "hex")
-			szId, err := bp.CreateSecurityZone(ctx, SecurityZone{
+			szId, err := bp.CreateSecurityZone(ctx, datacenter.SecurityZone{
 				Type:    enum.SecurityZoneTypeEVPN,
 				Label:   szName,
 				VRFName: szName,

--- a/apstra/two_stage_l3_clos_security_zone.go
+++ b/apstra/two_stage_l3_clos_security_zone.go
@@ -6,88 +6,28 @@ package apstra
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 
 	"github.com/Juniper/apstra-go-sdk/compatibility"
 	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/apstra-go-sdk/enum"
-	"github.com/Juniper/apstra-go-sdk/internal"
+	"github.com/Juniper/apstra-go-sdk/errors"
 	"github.com/Juniper/apstra-go-sdk/internal/pointer"
 	"github.com/Juniper/apstra-go-sdk/internal/str"
+	"github.com/Juniper/apstra-go-sdk/internal/urls"
 )
 
 const (
-	apiUrlBlueprintSecurityZones               = apiUrlBlueprintById + apiUrlPathDelim + "security-zones"
-	apiUrlBlueprintSecurityZonesPrefix         = apiUrlBlueprintSecurityZones + apiUrlPathDelim
-	apiUrlBlueprintSecurityZoneById            = apiUrlBlueprintSecurityZonesPrefix + "%s"
-	apiUrlBlueprintSecurityZoneByIdDhcpServers = apiUrlBlueprintSecurityZoneById + apiUrlPathDelim + "dhcp-servers"
+	defaultSecurityZoneIDLock  = "default_security_zone"
+	defaultSecurityZoneVRFName = "default"
 )
-
-var (
-	_ internal.IDer    = (*SecurityZone)(nil)
-	_ json.Unmarshaler = (*SecurityZone)(nil)
-)
-
-type SecurityZone struct {
-	Label             string                 `json:"label"`
-	Description       *string                `json:"vrf_description,omitempty"`
-	Type              enum.SecurityZoneType  `json:"sz_type"`
-	VRFName           string                 `json:"vrf_name"`
-	RoutingPolicyID   string                 `json:"routing_policy_id,omitempty"`   // automatically assigned if not set
-	RouteTarget       *string                `json:"route_target,omitempty"`        // calculated only value
-	RTPolicy          *datacenter.RTPolicy   `json:"rt_policy,omitempty"`           // can be null
-	VLAN              *uint16                `json:"vlan_id,omitempty"`             // can be null
-	VNI               *int                   `json:"vni_id,omitempty"`              // can be null
-	JunosEVPNIRBMode  *enum.JunosEVPNIRBMode `json:"junos_evpn_irb_mode,omitempty"` // can be null in POST, required in PUT AOS-58916
-	AddressingSupport *enum.AddressingScheme `json:"addressing_support,omitempty"`  // Apstra 6.1+ only
-	DisableIPv4       *bool                  `json:"disable_ipv4,omitempty"`        // Apstra 6.1+ only
-	VTEPAddressing    *enum.AddressingScheme `json:"vtep_addressing,omitempty"`     // Apstra 6.1+ only
-	Tags              []string               // Apstra 5.0.0+ and read-only - JSON struct tag is omitted to prevent marshaling this attribute
-
-	id string
-}
-
-// ID returns a pointer to a copy of the object's ID, or nil when no ID is set.
-func (o SecurityZone) ID() *string {
-	if o.id == "" {
-		return nil
-	}
-	id := o.id
-	return &id
-}
-
-func (o *SecurityZone) SetID(id string) {
-	o.id = id
-}
-
-func (o *SecurityZone) UnmarshalJSON(bytes []byte) error {
-	type securityZoneAlias SecurityZone // type alias prevents recursion
-
-	var aux struct {
-		securityZoneAlias
-		ID   string   `json:"id"`   // the `id` struct element cannot be unmarshaled so we temporarily stash that value here
-		Tags []string `json:"tags"` // the `Tags` struct element cannot be unmarshaled so we temporarily stash that value here
-	}
-
-	// unmarshal everything which can be handled by the `json` package.
-	if err := json.Unmarshal(bytes, &aux); err != nil {
-		return err
-	}
-
-	*o = SecurityZone(aux.securityZoneAlias)
-	o.id = aux.ID
-	o.Tags = aux.Tags
-
-	return nil
-}
 
 // CreateSecurityZone creates an Apstra Routing Zone / Security Zone / VRF.
 // If cfg.JunosEVPNIRBMode is omitted, but the API's version-dependent behavior
 // requires that field, it will be set to JunosEVPNIRBModeAsymmetric in the
 // request sent to the API.
-func (o TwoStageL3ClosClient) CreateSecurityZone(ctx context.Context, cfg SecurityZone) (string, error) {
+func (o TwoStageL3ClosClient) CreateSecurityZone(ctx context.Context, cfg datacenter.SecurityZone) (string, error) {
 	szAddressingSupportOK := compatibility.SecurityZoneAddressingSupported.Check(o.client.apiVersion)
 
 	if (cfg.AddressingSupport != nil || cfg.DisableIPv4 != nil) && !szAddressingSupportOK {
@@ -104,7 +44,7 @@ func (o TwoStageL3ClosClient) CreateSecurityZone(ctx context.Context, cfg Securi
 	response := &objectIdResponse{}
 	err := o.client.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodPost,
-		urlStr:      fmt.Sprintf(apiUrlBlueprintSecurityZones, o.blueprintId),
+		urlStr:      fmt.Sprintf(urls.DatacenterSecurityZones, o.blueprintId),
 		apiInput:    cfg,
 		apiResponse: response,
 	})
@@ -116,69 +56,29 @@ func (o TwoStageL3ClosClient) CreateSecurityZone(ctx context.Context, cfg Securi
 }
 
 // GetSecurityZone fetches the Security Zone / Routing Zone / VRF with the given id
-func (o TwoStageL3ClosClient) GetSecurityZone(ctx context.Context, id string) (SecurityZone, error) {
-	var response SecurityZone
+func (o TwoStageL3ClosClient) GetSecurityZone(ctx context.Context, id string) (datacenter.SecurityZone, error) {
+	var response datacenter.SecurityZone
 	err := o.client.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodGet,
-		urlStr:      fmt.Sprintf(apiUrlBlueprintSecurityZoneById, o.blueprintId, id),
+		urlStr:      fmt.Sprintf(urls.DatacenterSecurityZoneById, o.blueprintId, id),
 		apiResponse: &response,
 	})
 	if err != nil {
-		return SecurityZone{}, convertTtaeToAceWherePossible(err)
+		return datacenter.SecurityZone{}, convertTtaeToAceWherePossible(err)
 	}
 
 	return response, nil
 }
 
-// GetSecurityZoneByLabel fetches the Security Zone / Routing Zone / VRF with
-// the given label.
-func (o TwoStageL3ClosClient) GetSecurityZoneByLabel(ctx context.Context, label string) (SecurityZone, error) {
-	zones, err := o.GetSecurityZones(ctx)
-	if err != nil {
-		return SecurityZone{}, err
-	}
-
-	for _, zone := range zones {
-		if zone.Label == label {
-			return zone, nil
-		}
-	}
-
-	return SecurityZone{}, ClientErr{
-		errType: ErrNotfound,
-		err:     fmt.Errorf("security zone with label %q not found in blueprint %q", label, o.blueprintId),
-	}
-}
-
-// GetSecurityZoneByVRFName fetches the Security Zone / Routing Zone / VRF with
-// the given label.
-func (o TwoStageL3ClosClient) GetSecurityZoneByVRFName(ctx context.Context, vrfName string) (SecurityZone, error) {
-	zones, err := o.GetSecurityZones(ctx)
-	if err != nil {
-		return SecurityZone{}, err
-	}
-
-	for _, zone := range zones {
-		if zone.VRFName == vrfName {
-			return zone, nil
-		}
-	}
-
-	return SecurityZone{}, ClientErr{
-		errType: ErrNotfound,
-		err:     fmt.Errorf("security zone with vrf name %q not found in blueprint %q", vrfName, o.blueprintId),
-	}
-}
-
 // GetSecurityZones returns []SecurityZone representing all Security Zones /
 // Routing Zones / VRFs on the system.
-func (o TwoStageL3ClosClient) GetSecurityZones(ctx context.Context) ([]SecurityZone, error) {
+func (o TwoStageL3ClosClient) GetSecurityZones(ctx context.Context) ([]datacenter.SecurityZone, error) {
 	response := &struct {
-		Items map[string]SecurityZone `json:"items"`
+		Items map[string]datacenter.SecurityZone `json:"items"`
 	}{}
 	err := o.client.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodGet,
-		urlStr:      fmt.Sprintf(apiUrlBlueprintSecurityZones, o.blueprintId),
+		urlStr:      fmt.Sprintf(urls.DatacenterSecurityZones, o.blueprintId),
 		apiResponse: response,
 	})
 	if err != nil {
@@ -186,7 +86,7 @@ func (o TwoStageL3ClosClient) GetSecurityZones(ctx context.Context) ([]SecurityZ
 	}
 
 	// This API endpoint returns a map. Convert to list for consistency with other 'GetAll' functions.
-	result := make([]SecurityZone, len(response.Items))
+	result := make([]datacenter.SecurityZone, len(response.Items))
 	var i int
 	for _, v := range response.Items {
 		result[i] = v
@@ -196,8 +96,119 @@ func (o TwoStageL3ClosClient) GetSecurityZones(ctx context.Context) ([]SecurityZ
 	return result, nil
 }
 
+// GetSecurityZoneByLabel fetches the Security Zone / Routing Zone / VRF with
+// the given label.
+func (o TwoStageL3ClosClient) GetSecurityZoneByLabel(ctx context.Context, label string) (datacenter.SecurityZone, error) {
+	zones, err := o.GetSecurityZones(ctx)
+	if err != nil {
+		return datacenter.SecurityZone{}, err
+	}
+
+	for _, zone := range zones {
+		if zone.Label == label {
+			return zone, nil
+		}
+	}
+
+	return datacenter.SecurityZone{}, ClientErr{
+		errType: ErrNotfound,
+		err:     fmt.Errorf("security zone with label %q not found in blueprint %q", label, o.blueprintId),
+	}
+}
+
+// GetSecurityZoneByVRFName fetches the Security Zone / Routing Zone / VRF with
+// the given label.
+func (o TwoStageL3ClosClient) GetSecurityZoneByVRFName(ctx context.Context, vrfName string) (datacenter.SecurityZone, error) {
+	zones, err := o.GetSecurityZones(ctx)
+	if err != nil {
+		return datacenter.SecurityZone{}, err
+	}
+
+	for _, zone := range zones {
+		if zone.VRFName == vrfName {
+			return zone, nil
+		}
+	}
+
+	return datacenter.SecurityZone{}, ClientErr{
+		errType: ErrNotfound,
+		err:     fmt.Errorf("security zone with vrf name %q not found in blueprint %q", vrfName, o.blueprintId),
+	}
+}
+
+func (c *TwoStageL3ClosClient) DefaultSecurityZoneID(ctx context.Context) (string, error) {
+	c.client.lock(defaultSecurityZoneIDLock)
+	defer c.client.unlock(defaultSecurityZoneIDLock)
+
+	// If we know the default Security Zone ID, return it.
+	if c.defaultSecurityZoneID != "" {
+		return c.defaultSecurityZoneID, nil
+	}
+
+	// Retrieve the default Security Zone.
+	sz, err := c.GetSecurityZoneByVRFName(ctx, defaultSecurityZoneVRFName)
+	if err != nil {
+		return "", fmt.Errorf("failed while fetching default Routing Zone ID: %w", err)
+	}
+
+	id := sz.ID()
+	if id == nil {
+		return "", errors.APIResponseInvalid("default Routing Zone ID returned nil ID")
+	}
+
+	c.defaultSecurityZoneID = *id // Cache the default Switching Zone ID.
+
+	return *id, nil
+}
+
+func (c *TwoStageL3ClosClient) GetDefaultSecurityZone(ctx context.Context) (datacenter.SecurityZone, error) {
+	c.client.lock(defaultSecurityZoneIDLock)
+	defer c.client.unlock(defaultSecurityZoneIDLock)
+
+	// If we know the default Security Zone ID, fetch it using the cached ID.
+	if c.defaultSecurityZoneID != "" {
+		return c.GetSecurityZone(ctx, c.defaultSecurityZoneID)
+	}
+
+	// Retrieve the default Security Zone the hard way.
+	sz, err := c.GetSecurityZoneByVRFName(ctx, defaultSecurityZoneVRFName)
+	if err != nil {
+		return datacenter.SecurityZone{}, fmt.Errorf("failed while fetching default Security Zone: %w", err)
+	}
+
+	id := sz.ID()
+	if id == nil {
+		return datacenter.SecurityZone{}, errors.APIResponseInvalid("default Security Zone ID returned nil ID")
+	}
+
+	c.defaultSwitchingZoneID = *id // Cache the default Switching Zone ID.
+
+	return sz, nil
+}
+
+func (c *TwoStageL3ClosClient) ListSecurityZones(ctx context.Context) ([]string, error) {
+	items, err := c.GetSecurityZones(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]string, len(items))
+	for i, item := range items {
+		idPtr := item.ID()
+		if idPtr == nil {
+			return nil, ClientErr{
+				errType: ErrInvalidId,
+				err:     fmt.Errorf("the Security Zone at index %d has nil ID", i),
+			}
+		}
+		result[i] = *idPtr
+	}
+
+	return result, nil
+}
+
 // UpdateSecurityZone replaces the configuration of zone zoneId with the supplied CreateSecurityZoneCfg
-func (o TwoStageL3ClosClient) UpdateSecurityZone(ctx context.Context, v SecurityZone) error {
+func (o TwoStageL3ClosClient) UpdateSecurityZone(ctx context.Context, v datacenter.SecurityZone) error {
 	if v.ID() == nil {
 		return fmt.Errorf("id is required in %s", str.FuncName())
 	}
@@ -238,7 +249,7 @@ func (o TwoStageL3ClosClient) UpdateSecurityZone(ctx context.Context, v Security
 
 	err := o.client.talkToApstra(ctx, &talkToApstraIn{
 		method:   http.MethodPut,
-		urlStr:   fmt.Sprintf(apiUrlBlueprintSecurityZoneById, o.blueprintId, v.id),
+		urlStr:   fmt.Sprintf(urls.DatacenterSecurityZoneById, o.blueprintId, *v.ID()),
 		apiInput: v,
 	})
 	if err != nil {
@@ -251,7 +262,7 @@ func (o TwoStageL3ClosClient) UpdateSecurityZone(ctx context.Context, v Security
 func (o TwoStageL3ClosClient) DeleteSecurityZone(ctx context.Context, id string) error {
 	err := o.client.talkToApstra(ctx, &talkToApstraIn{
 		method: http.MethodDelete,
-		urlStr: fmt.Sprintf(apiUrlBlueprintSecurityZoneById, o.blueprintId, id),
+		urlStr: fmt.Sprintf(urls.DatacenterSecurityZoneById, o.blueprintId, id),
 	})
 	return convertTtaeToAceWherePossible(err)
 }

--- a/apstra/two_stage_l3_clos_security_zone.go
+++ b/apstra/two_stage_l3_clos_security_zone.go
@@ -136,29 +136,31 @@ func (o TwoStageL3ClosClient) GetSecurityZoneByVRFName(ctx context.Context, vrfN
 	}
 }
 
-func (c *TwoStageL3ClosClient) DefaultSecurityZoneID(ctx context.Context) (string, error) {
+func (c *TwoStageL3ClosClient) DefaultSecurityZoneID(ctx context.Context) (*string, error) {
 	c.client.lock(defaultSecurityZoneIDLock)
 	defer c.client.unlock(defaultSecurityZoneIDLock)
 
 	// If we know the default Security Zone ID, return it.
 	if c.defaultSecurityZoneID != "" {
-		return c.defaultSecurityZoneID, nil
+		// make a copy rather than returning a pointer to our cached value to defend against modification by the caller
+		result := c.defaultSecurityZoneID
+		return &result, nil
 	}
 
 	// Retrieve the default Security Zone.
 	sz, err := c.GetSecurityZoneByVRFName(ctx, defaultSecurityZoneVRFName)
 	if err != nil {
-		return "", fmt.Errorf("failed while fetching default Routing Zone ID: %w", err)
+		return nil, fmt.Errorf("failed while fetching default Routing Zone ID: %w", err)
 	}
 
 	id := sz.ID()
 	if id == nil {
-		return "", errors.APIResponseInvalid("default Routing Zone ID returned nil ID")
+		return nil, errors.APIResponseInvalid("default Routing Zone ID returned nil ID")
 	}
 
-	c.defaultSecurityZoneID = *id // Cache the default Switching Zone ID.
+	c.defaultSecurityZoneID = *id // Cache the default Security Zone ID.
 
-	return *id, nil
+	return id, nil
 }
 
 func (c *TwoStageL3ClosClient) GetDefaultSecurityZone(ctx context.Context) (datacenter.SecurityZone, error) {
@@ -181,7 +183,7 @@ func (c *TwoStageL3ClosClient) GetDefaultSecurityZone(ctx context.Context) (data
 		return datacenter.SecurityZone{}, errors.APIResponseInvalid("default Security Zone ID returned nil ID")
 	}
 
-	c.defaultSwitchingZoneID = *id // Cache the default Switching Zone ID.
+	c.defaultSecurityZoneID = *id // Cache the default Security Zone ID.
 
 	return sz, nil
 }

--- a/apstra/two_stage_l3_clos_security_zone.go
+++ b/apstra/two_stage_l3_clos_security_zone.go
@@ -142,9 +142,7 @@ func (c *TwoStageL3ClosClient) DefaultSecurityZoneID(ctx context.Context) (*stri
 
 	// If we know the default Security Zone ID, return it.
 	if c.defaultSecurityZoneID != "" {
-		// make a copy rather than returning a pointer to our cached value to defend against modification by the caller
-		result := c.defaultSecurityZoneID
-		return &result, nil
+		return pointer.ToCopy(c.defaultSecurityZoneID), nil
 	}
 
 	// Retrieve the default Security Zone.

--- a/apstra/two_stage_l3_clos_security_zone.go
+++ b/apstra/two_stage_l3_clos_security_zone.go
@@ -142,7 +142,7 @@ func (c *TwoStageL3ClosClient) DefaultSecurityZoneID(ctx context.Context) (*stri
 
 	// If we know the default Security Zone ID, return it.
 	if c.defaultSecurityZoneID != "" {
-		return pointer.ToCopy(c.defaultSecurityZoneID), nil
+		return pointer.ToCopyOf(c.defaultSecurityZoneID), nil
 	}
 
 	// Retrieve the default Security Zone.

--- a/apstra/two_stage_l3_clos_security_zone_dhcp_servers.go
+++ b/apstra/two_stage_l3_clos_security_zone_dhcp_servers.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+
+	"github.com/Juniper/apstra-go-sdk/internal/urls"
 )
 
 // GetSecurityZoneDhcpServers returns []net.IP representing the DHCP relay
@@ -20,7 +22,7 @@ func (o TwoStageL3ClosClient) GetSecurityZoneDhcpServers(ctx context.Context, id
 	}{}
 	err := o.client.talkToApstra(ctx, &talkToApstraIn{
 		method:      http.MethodGet,
-		urlStr:      fmt.Sprintf(apiUrlBlueprintSecurityZoneByIdDhcpServers, o.blueprintId, id),
+		urlStr:      fmt.Sprintf(urls.DatacenterSecurityZoneDHCPServers, o.blueprintId, id),
 		apiResponse: response,
 	})
 	if err != nil {
@@ -51,7 +53,7 @@ func (o TwoStageL3ClosClient) SetSecurityZoneDhcpServers(ctx context.Context, id
 
 	return convertTtaeToAceWherePossible(o.client.talkToApstra(ctx, &talkToApstraIn{
 		method: http.MethodPut,
-		urlStr: fmt.Sprintf(apiUrlBlueprintSecurityZoneByIdDhcpServers, o.blueprintId, id),
+		urlStr: fmt.Sprintf(urls.DatacenterSecurityZoneDHCPServers, o.blueprintId, id),
 		apiInput: &struct {
 			Items []string `json:"items"`
 		}{

--- a/apstra/two_stage_l3_clos_security_zone_info_integration_test.go
+++ b/apstra/two_stage_l3_clos_security_zone_info_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/compatibility"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/apstra-go-sdk/internal/pointer"
 	"github.com/stretchr/testify/require"
@@ -25,7 +26,7 @@ func TestTwoStageL3ClosClient_GetSecurityZoneInfo(t *testing.T) {
 
 	securityZoneCount := rand.Intn(3) + 3
 
-	compareSzToSzInfo := func(t *testing.T, a *SecurityZone, b *TwoStageL3ClosSecurityZoneInfo) {
+	compareSzToSzInfo := func(t *testing.T, a *datacenter.SecurityZone, b *TwoStageL3ClosSecurityZoneInfo) {
 		t.Helper()
 
 		require.NotNil(t, a)
@@ -102,7 +103,7 @@ func TestTwoStageL3ClosClient_GetSecurityZoneInfo(t *testing.T) {
 			}
 
 			szIds := make([]string, securityZoneCount)
-			securityZones := make([]SecurityZone, securityZoneCount)
+			securityZones := make([]datacenter.SecurityZone, securityZoneCount)
 			VlanIds := make([]int, securityZoneCount) // dedicated vlan slice ensures no collisions
 			randomIntsN(VlanIds, 4092)
 
@@ -113,7 +114,7 @@ func TestTwoStageL3ClosClient_GetSecurityZoneInfo(t *testing.T) {
 
 			// create security zones
 			for i := range securityZoneCount {
-				securityZones[i] = SecurityZone{
+				securityZones[i] = datacenter.SecurityZone{
 					Label:             randString(6, "hex"),
 					Type:              enum.SecurityZoneTypeEVPN,
 					VRFName:           randString(6, "hex"),

--- a/apstra/two_stage_l3_clos_security_zone_loopbacks.go
+++ b/apstra/two_stage_l3_clos_security_zone_loopbacks.go
@@ -12,9 +12,8 @@ import (
 	"net/netip"
 
 	"github.com/Juniper/apstra-go-sdk/compatibility"
+	"github.com/Juniper/apstra-go-sdk/internal/urls"
 )
-
-const apiUrlBlueprintSecurityZoneLoopbacksById = apiUrlBlueprintSecurityZoneById + apiUrlPathDelim + "loopbacks"
 
 var _ json.Marshaler = (*SecurityZoneLoopback)(nil)
 
@@ -129,7 +128,7 @@ func (o *TwoStageL3ClosClient) SetSecurityZoneLoopbacks(ctx context.Context, szI
 
 	err := o.client.talkToApstra(ctx, &talkToApstraIn{
 		method:   http.MethodPatch,
-		urlStr:   fmt.Sprintf(apiUrlBlueprintSecurityZoneLoopbacksById, o.blueprintId, szId),
+		urlStr:   fmt.Sprintf(urls.DatacenterSecurityZoneLoopbacks, o.blueprintId, szId),
 		apiInput: apiInput,
 	})
 	if err != nil {

--- a/apstra/two_stage_l3_clos_security_zone_loopbacks_integration_test.go
+++ b/apstra/two_stage_l3_clos_security_zone_loopbacks_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/compatibility"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/apstra-go-sdk/internal/pointer"
 	"github.com/stretchr/testify/require"
@@ -116,7 +117,7 @@ func TestTwoStageL3ClosClient_SetSecurityZoneLoopbacks(t *testing.T) {
 			if compatibility.SecurityZoneAddressingSupported.Check(client.client.apiVersion) {
 				as = pointer.To(enum.AddressingSchemeIPv46)
 			}
-			rzID, err := bpClient.CreateSecurityZone(ctx, SecurityZone{
+			rzID, err := bpClient.CreateSecurityZone(ctx, datacenter.SecurityZone{
 				Label:             randString(6, "hex"),
 				Type:              enum.SecurityZoneTypeEVPN,
 				VRFName:           randString(6, "hex"),

--- a/apstra/two_stage_l3_clos_subinterface_integration_test.go
+++ b/apstra/two_stage_l3_clos_subinterface_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/Juniper/apstra-go-sdk/compatibility"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/stretchr/testify/require"
 )
@@ -92,7 +93,7 @@ func TestUpdateTwoStageL3ClosSubinterface(t *testing.T) {
 			if compatibility.SecurityZoneAddressingSupported.Check(client.client.apiVersion) {
 				as = &enum.AddressingSchemeIPv46
 			}
-			szId, err := bp.CreateSecurityZone(ctx, SecurityZone{
+			szId, err := bp.CreateSecurityZone(ctx, datacenter.SecurityZone{
 				Label:             szName,
 				Type:              enum.SecurityZoneTypeEVPN,
 				VRFName:           szName,

--- a/apstra/two_stage_l3_clos_virtual_network_bindings_integration_test.go
+++ b/apstra/two_stage_l3_clos_virtual_network_bindings_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/compatibility"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/apstra-go-sdk/internal/pointer"
 	"github.com/stretchr/testify/require"
@@ -107,7 +108,7 @@ func TestSetVirtualNetworkLeafBindings(t *testing.T) {
 			require.LessOrEqual(t, len(leafIds), 40, "test requires no more than 40 leaf switches")
 
 			rzLabel := randString(6, "hex")
-			rzId, err := bp.CreateSecurityZone(ctx, SecurityZone{
+			rzId, err := bp.CreateSecurityZone(ctx, datacenter.SecurityZone{
 				Label:   rzLabel,
 				Type:    enum.SecurityZoneTypeEVPN,
 				VRFName: rzLabel,
@@ -267,7 +268,7 @@ func TestUpdateVirtualNetworkLeafBindings(t *testing.T) {
 			leafIds = leafIds[1:]
 
 			rzLabel := randString(6, "hex")
-			rzId, err := bp.CreateSecurityZone(ctx, SecurityZone{
+			rzId, err := bp.CreateSecurityZone(ctx, datacenter.SecurityZone{
 				Label:   rzLabel,
 				Type:    enum.SecurityZoneTypeEVPN,
 				VRFName: rzLabel,

--- a/apstra/two_stage_l3_clos_virtual_networks_integration_test.go
+++ b/apstra/two_stage_l3_clos_virtual_networks_integration_test.go
@@ -152,7 +152,7 @@ func TestCreateUpdateDeleteVirtualNetwork(t *testing.T) {
 			bpClient.SetType(BlueprintTypeStaging)
 
 			log.Printf("testing CreateSecurityZone() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-			zoneId, err := bpClient.CreateSecurityZone(ctx, SecurityZone{
+			zoneId, err := bpClient.CreateSecurityZone(ctx, datacenter.SecurityZone{
 				Type:    enum.SecurityZoneTypeEVPN,
 				VRFName: vrfName,
 				Label:   label,
@@ -338,7 +338,7 @@ func TestVirtualNetworkTags(t *testing.T) {
 			bpClient := testBlueprintC(ctx, t, client.client)
 
 			log.Printf("testing CreateSecurityZone() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-			zoneId, err := bpClient.CreateSecurityZone(ctx, SecurityZone{
+			zoneId, err := bpClient.CreateSecurityZone(ctx, datacenter.SecurityZone{
 				Type:    enum.SecurityZoneTypeEVPN,
 				VRFName: vrfName,
 				Label:   label,

--- a/datacenter/security_zone.go
+++ b/datacenter/security_zone.go
@@ -1,0 +1,78 @@
+// Copyright (c) Juniper Networks, Inc., 2026-2026.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package datacenter
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/Juniper/apstra-go-sdk/enum"
+	"github.com/Juniper/apstra-go-sdk/errors"
+	"github.com/Juniper/apstra-go-sdk/internal"
+)
+
+var (
+	_ internal.IDer     = (*SecurityZone)(nil)
+	_ internal.IDSetter = (*SecurityZone)(nil)
+	_ json.Unmarshaler  = (*SecurityZone)(nil)
+)
+
+type SecurityZone struct {
+	Label             string                 `json:"label"`
+	Description       *string                `json:"vrf_description,omitempty"`
+	Type              enum.SecurityZoneType  `json:"sz_type"`
+	VRFName           string                 `json:"vrf_name"`
+	RoutingPolicyID   string                 `json:"routing_policy_id,omitempty"`   // automatically assigned if not set
+	RouteTarget       *string                `json:"route_target,omitempty"`        // calculated only value
+	RTPolicy          *RTPolicy              `json:"rt_policy,omitempty"`           // can be null
+	VLAN              *uint16                `json:"vlan_id,omitempty"`             // can be null
+	VNI               *int                   `json:"vni_id,omitempty"`              // can be null
+	JunosEVPNIRBMode  *enum.JunosEVPNIRBMode `json:"junos_evpn_irb_mode,omitempty"` // can be null in POST, required in PUT AOS-58916
+	AddressingSupport *enum.AddressingScheme `json:"addressing_support,omitempty"`  // Apstra 6.1+ only
+	DisableIPv4       *bool                  `json:"disable_ipv4,omitempty"`        // Apstra 6.1+ only
+	VTEPAddressing    *enum.AddressingScheme `json:"vtep_addressing,omitempty"`     // Apstra 6.1+ only
+	Tags              []string               // Apstra 5.0.0+ and read-only - JSON struct tag is omitted to prevent marshaling this attribute
+
+	id string
+}
+
+// ID returns a pointer to a copy of the object's ID, or nil when no ID is set.
+func (o SecurityZone) ID() *string {
+	if o.id == "" {
+		return nil
+	}
+	id := o.id
+	return &id
+}
+
+func (o *SecurityZone) SetID(id string) error {
+	if o.id != "" {
+		return errors.IDAlreadySet(fmt.Sprintf("id already has value %q", o.id))
+	}
+
+	o.id = id
+	return nil
+}
+
+func (o *SecurityZone) UnmarshalJSON(bytes []byte) error {
+	type securityZoneAlias SecurityZone // type alias prevents recursion
+
+	var aux struct {
+		securityZoneAlias
+		ID   string   `json:"id"`   // the `id` struct element cannot be unmarshaled so we temporarily stash that value here
+		Tags []string `json:"tags"` // the `Tags` struct element cannot be unmarshaled so we temporarily stash that value here
+	}
+
+	// unmarshal everything which can be handled by the `json` package.
+	if err := json.Unmarshal(bytes, &aux); err != nil {
+		return err
+	}
+
+	*o = SecurityZone(aux.securityZoneAlias)
+	o.id = aux.ID
+	o.Tags = aux.Tags
+
+	return nil
+}

--- a/datacenter/security_zone_integration_test.go
+++ b/datacenter/security_zone_integration_test.go
@@ -369,9 +369,10 @@ func TestSecurityZone_GetDefaultSecurityZone(t *testing.T) {
 			// The default Security Zone ID should be cached here
 			id, err := bp.DefaultSecurityZoneID(ctx)
 			require.NoError(t, err)
+			require.NotNil(t, id)
 			require.NotEmpty(t, id)
 
-			require.Equal(t, id, *sz.ID())
+			require.Equal(t, *id, *sz.ID())
 
 			// The default Security Zone ID should be cached here
 			sz, err = bp.GetDefaultSecurityZone(ctx)
@@ -380,7 +381,7 @@ func TestSecurityZone_GetDefaultSecurityZone(t *testing.T) {
 			require.NotEmpty(t, *sz.ID())
 			require.Equal(t, "default", sz.VRFName)
 
-			require.Equal(t, id, *sz.ID())
+			require.Equal(t, *id, *sz.ID())
 		})
 	}
 }
@@ -390,11 +391,15 @@ func TestSecurityZone_DefaultSecurityZoneID(t *testing.T) {
 	clients := testclient.GetTestClients(t, ctx)
 	for _, client := range clients {
 		t.Run(client.Name(), func(t *testing.T) {
+			t.Parallel()
+			ctx := testutils.ContextWithTestID(ctx, t)
+
 			bp := dctestobj.TestBlueprintA(t, ctx, client.Client)
 
 			// The default Security Zone ID will not be cached at this point
 			id, err := bp.DefaultSecurityZoneID(ctx)
 			require.NoError(t, err)
+			require.NotNil(t, id)
 			require.NotEmpty(t, id)
 
 			// The default Security Zone ID should be cached here
@@ -404,14 +409,15 @@ func TestSecurityZone_DefaultSecurityZoneID(t *testing.T) {
 			require.NotEmpty(t, *sz.ID())
 			require.Equal(t, "default", sz.VRFName)
 
-			require.Equal(t, id, *sz.ID())
+			require.Equal(t, *id, *sz.ID())
 
 			// The default Security Zone ID should be cached here
 			id, err = bp.DefaultSecurityZoneID(ctx)
 			require.NoError(t, err)
+			require.NotNil(t, id)
 			require.NotEmpty(t, id)
 
-			require.Equal(t, id, *sz.ID())
+			require.Equal(t, *id, *sz.ID())
 		})
 	}
 }

--- a/datacenter/security_zone_integration_test.go
+++ b/datacenter/security_zone_integration_test.go
@@ -4,13 +4,15 @@
 
 //go:build integration && requiretestutils
 
-package apstra_test
+package datacenter_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
 	"github.com/Juniper/apstra-go-sdk/compatibility"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/apstra-go-sdk/internal/pointer"
 	"github.com/Juniper/apstra-go-sdk/internal/slice"
@@ -27,18 +29,18 @@ func TestCRUDSecurityZone(t *testing.T) {
 
 	type testCase struct {
 		versionConstraint *compatibility.Constraint
-		create            apstra.SecurityZone
-		update            *apstra.SecurityZone
+		create            datacenter.SecurityZone
+		update            *datacenter.SecurityZone
 	}
 
 	testCases := map[string]testCase{
 		"start_minimal_4.x+": {
-			create: apstra.SecurityZone{
+			create: datacenter.SecurityZone{
 				Label:   testutils.RandString(6, "hex"),
 				VRFName: testutils.RandString(6, "hex"),
 				Type:    enum.SecurityZoneTypeEVPN,
 			},
-			update: &apstra.SecurityZone{
+			update: &datacenter.SecurityZone{
 				Label:            testutils.RandString(8, "hex"),
 				Type:             enum.SecurityZoneTypeEVPN,
 				RoutingPolicyID:  "",
@@ -49,7 +51,7 @@ func TestCRUDSecurityZone(t *testing.T) {
 			},
 		},
 		"start_maximal_4.x+": {
-			create: apstra.SecurityZone{
+			create: datacenter.SecurityZone{
 				Label:            testutils.RandString(8, "hex"),
 				Type:             enum.SecurityZoneTypeEVPN,
 				RoutingPolicyID:  "",
@@ -59,19 +61,19 @@ func TestCRUDSecurityZone(t *testing.T) {
 				JunosEVPNIRBMode: pointer.To(enum.JunosEVPNIRBModeSymmetric),
 				VRFName:          testutils.RandString(6, "hex"),
 			},
-			update: &apstra.SecurityZone{
+			update: &datacenter.SecurityZone{
 				Label: testutils.RandString(6, "hex"),
 				Type:  enum.SecurityZoneTypeEVPN,
 			},
 		},
 		"start_minimal_5.x+": {
 			versionConstraint: &compatibility.SecurityZoneDescriptionSupported,
-			create: apstra.SecurityZone{
+			create: datacenter.SecurityZone{
 				Label:   testutils.RandString(6, "hex"),
 				VRFName: testutils.RandString(6, "hex"),
 				Type:    enum.SecurityZoneTypeEVPN,
 			},
-			update: &apstra.SecurityZone{
+			update: &datacenter.SecurityZone{
 				Description:      pointer.To(testutils.RandString(8, "hex")),
 				Label:            testutils.RandString(8, "hex"),
 				Type:             enum.SecurityZoneTypeEVPN,
@@ -84,7 +86,7 @@ func TestCRUDSecurityZone(t *testing.T) {
 		},
 		"start_maximal_5.x+": {
 			versionConstraint: &compatibility.SecurityZoneDescriptionSupported,
-			create: apstra.SecurityZone{
+			create: datacenter.SecurityZone{
 				Description:      pointer.To(testutils.RandString(8, "hex")),
 				Label:            testutils.RandString(8, "hex"),
 				Type:             enum.SecurityZoneTypeEVPN,
@@ -95,19 +97,19 @@ func TestCRUDSecurityZone(t *testing.T) {
 				JunosEVPNIRBMode: pointer.To(enum.JunosEVPNIRBModeSymmetric),
 				VRFName:          testutils.RandString(6, "hex"),
 			},
-			update: &apstra.SecurityZone{
+			update: &datacenter.SecurityZone{
 				Label: testutils.RandString(6, "hex"),
 				Type:  enum.SecurityZoneTypeEVPN,
 			},
 		},
 		"start_minimal_6.1+": {
 			versionConstraint: &compatibility.SecurityZoneAddressingSupported,
-			create: apstra.SecurityZone{
+			create: datacenter.SecurityZone{
 				Label:   testutils.RandString(6, "hex"),
 				VRFName: testutils.RandString(6, "hex"),
 				Type:    enum.SecurityZoneTypeEVPN,
 			},
-			update: &apstra.SecurityZone{
+			update: &datacenter.SecurityZone{
 				Description:       pointer.To(testutils.RandString(8, "hex")),
 				Label:             testutils.RandString(8, "hex"),
 				Type:              enum.SecurityZoneTypeEVPN,
@@ -122,7 +124,7 @@ func TestCRUDSecurityZone(t *testing.T) {
 		},
 		"start_maximmal_6.1+": {
 			versionConstraint: &compatibility.SecurityZoneAddressingSupported,
-			create: apstra.SecurityZone{
+			create: datacenter.SecurityZone{
 				Description:       pointer.To(testutils.RandString(8, "hex")),
 				Label:             testutils.RandString(8, "hex"),
 				VRFName:           testutils.RandString(6, "hex"),
@@ -135,21 +137,21 @@ func TestCRUDSecurityZone(t *testing.T) {
 				AddressingSupport: &enum.AddressingSchemeIPv46,
 				DisableIPv4:       pointer.To(false),
 			},
-			update: &apstra.SecurityZone{
+			update: &datacenter.SecurityZone{
 				Label: testutils.RandString(6, "hex"),
 				Type:  enum.SecurityZoneTypeEVPN,
 			},
 		},
 		"auto_reset_of_disable_ipv4_attribute_6.1+": {
 			versionConstraint: &compatibility.SecurityZoneAddressingSupported,
-			create: apstra.SecurityZone{
+			create: datacenter.SecurityZone{
 				Label:             testutils.RandString(6, "hex"),
 				VRFName:           testutils.RandString(6, "hex"),
 				Type:              enum.SecurityZoneTypeEVPN,
 				AddressingSupport: &enum.AddressingSchemeIPv6,
 				DisableIPv4:       pointer.To(true),
 			},
-			update: &apstra.SecurityZone{
+			update: &datacenter.SecurityZone{
 				Label:             testutils.RandString(6, "hex"),
 				Type:              enum.SecurityZoneTypeEVPN,
 				AddressingSupport: &enum.AddressingSchemeIPv4,
@@ -177,7 +179,7 @@ func TestCRUDSecurityZone(t *testing.T) {
 					// because we modify these values below
 					create := tCase.create
 					create.VRFName = create.Label
-					var update *apstra.SecurityZone
+					var update *datacenter.SecurityZone
 					if tCase.update != nil {
 						update = pointer.To(*tCase.update)
 						require.Empty(t, update.VRFName, "vrf name must not be set in test case 'update'")
@@ -186,7 +188,7 @@ func TestCRUDSecurityZone(t *testing.T) {
 
 					var id string
 					var err error
-					var obj apstra.SecurityZone
+					var obj datacenter.SecurityZone
 
 					// create the object
 					id, err = bpClient.CreateSecurityZone(ctx, create)
@@ -221,6 +223,12 @@ func TestCRUDSecurityZone(t *testing.T) {
 					require.NotNil(t, obj.ID())
 					require.Equal(t, id, *obj.ID())
 					comparedatacenter.SecurityZone(t, create, obj)
+
+					// retrieve the list of IDs (ours must be in there) and validate
+					ids, err := bpClient.ListSecurityZones(ctx)
+					require.NoError(t, err)
+					require.NotNil(t, ids)
+					require.Contains(t, ids, id)
 
 					if update != nil {
 						// update the object
@@ -289,6 +297,12 @@ func TestCRUDSecurityZone(t *testing.T) {
 					objPtr = slice.MustFindByID(objs, id)
 					require.Nil(t, objPtr)
 
+					// retrieve the list of IDs (ours must *not* be in there)
+					ids, err = bpClient.ListSecurityZones(ctx)
+					require.NoError(t, err)
+					require.NotNil(t, ids)
+					require.NotContains(t, ids, id)
+
 					// update the object
 					create.SetID(id)
 					require.NotNil(t, create.ID())
@@ -305,24 +319,6 @@ func TestCRUDSecurityZone(t *testing.T) {
 					require.Equal(t, apstra.ErrNotfound, ace.Type())
 				})
 			}
-		})
-	}
-}
-
-func TestGetDefaultRoutingZone(t *testing.T) {
-	ctx := testutils.ContextWithTestID(t.Context(), t)
-
-	clients := testclient.GetTestClients(t, ctx)
-
-	for _, client := range clients {
-		t.Run(client.Name(), func(t *testing.T) {
-			t.Parallel()
-			ctx := testutils.ContextWithTestID(ctx, t)
-
-			bpClient := dctestobj.TestBlueprintA(t, ctx, client.Client)
-			sz, err := bpClient.GetSecurityZoneByVRFName(ctx, "default")
-			require.NoError(t, err)
-			require.Equal(t, "default", sz.VRFName)
 		})
 	}
 }
@@ -352,6 +348,70 @@ func TestSecurityZone_Tagging(t *testing.T) {
 			sz, err = bpClient.GetSecurityZone(ctx, *sz.ID())
 
 			require.ElementsMatch(t, desiredTags, sz.Tags)
+		})
+	}
+}
+
+func TestSecurityZone_GetDefaultSecurityZone(t *testing.T) {
+	ctx := testutils.ContextWithTestID(context.Background(), t)
+	clients := testclient.GetTestClients(t, ctx)
+	for _, client := range clients {
+		t.Run(client.Name(), func(t *testing.T) {
+			bp := dctestobj.TestBlueprintA(t, ctx, client.Client)
+
+			// The default Security Zone ID will not be cached at this point
+			sz, err := bp.GetDefaultSecurityZone(ctx)
+			require.NoError(t, err)
+			require.NotNil(t, sz.ID())
+			require.NotEmpty(t, *sz.ID())
+			require.Equal(t, "default", sz.VRFName)
+
+			// The default Security Zone ID should be cached here
+			id, err := bp.DefaultSecurityZoneID(ctx)
+			require.NoError(t, err)
+			require.NotEmpty(t, id)
+
+			require.Equal(t, id, *sz.ID())
+
+			// The default Security Zone ID should be cached here
+			sz, err = bp.GetDefaultSecurityZone(ctx)
+			require.NoError(t, err)
+			require.NotNil(t, sz.ID())
+			require.NotEmpty(t, *sz.ID())
+			require.Equal(t, "default", sz.VRFName)
+
+			require.Equal(t, id, *sz.ID())
+		})
+	}
+}
+
+func TestSecurityZone_DefaultSecurityZoneID(t *testing.T) {
+	ctx := testutils.ContextWithTestID(context.Background(), t)
+	clients := testclient.GetTestClients(t, ctx)
+	for _, client := range clients {
+		t.Run(client.Name(), func(t *testing.T) {
+			bp := dctestobj.TestBlueprintA(t, ctx, client.Client)
+
+			// The default Security Zone ID will not be cached at this point
+			id, err := bp.DefaultSecurityZoneID(ctx)
+			require.NoError(t, err)
+			require.NotEmpty(t, id)
+
+			// The default Security Zone ID should be cached here
+			sz, err := bp.GetDefaultSecurityZone(ctx)
+			require.NoError(t, err)
+			require.NotNil(t, sz.ID())
+			require.NotEmpty(t, *sz.ID())
+			require.Equal(t, "default", sz.VRFName)
+
+			require.Equal(t, id, *sz.ID())
+
+			// The default Security Zone ID should be cached here
+			id, err = bp.DefaultSecurityZoneID(ctx)
+			require.NoError(t, err)
+			require.NotEmpty(t, id)
+
+			require.Equal(t, id, *sz.ID())
 		})
 	}
 }

--- a/internal/test_utils/compare/two_stage_l3_clos/security_zone.go
+++ b/internal/test_utils/compare/two_stage_l3_clos/security_zone.go
@@ -9,12 +9,12 @@ package comparedatacenter
 import (
 	"testing"
 
-	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/apstra-go-sdk/internal/test_utils/test_message"
 	"github.com/stretchr/testify/require"
 )
 
-func SecurityZone(t testing.TB, req, resp apstra.SecurityZone, msg ...string) {
+func SecurityZone(t testing.TB, req, resp datacenter.SecurityZone, msg ...string) {
 	msg = testmessage.Add(msg, "Comparing Security Zone")
 
 	if req.ID() != nil {

--- a/internal/test_utils/datacenter_test_objects/security_zones.go
+++ b/internal/test_utils/datacenter_test_objects/security_zones.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/Juniper/apstra-go-sdk/apstra"
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 	"github.com/Juniper/apstra-go-sdk/enum"
 	testutils "github.com/Juniper/apstra-go-sdk/internal/test_utils"
 	"github.com/stretchr/testify/require"
@@ -21,7 +22,7 @@ func TestSecurityZoneA(t testing.TB, ctx context.Context, bp *apstra.TwoStageL3C
 
 	rs := testutils.RandString(6, "hex")
 
-	id, err := bp.CreateSecurityZone(ctx, apstra.SecurityZone{
+	id, err := bp.CreateSecurityZone(ctx, datacenter.SecurityZone{
 		Label:            rs,
 		Type:             enum.SecurityZoneTypeEVPN,
 		VRFName:          rs,

--- a/internal/urls/datacenter.go
+++ b/internal/urls/datacenter.go
@@ -5,6 +5,11 @@
 package urls
 
 const (
+	DatacenterSecurityZones           = blueprintByID + pathDelim + "security-zones"
+	DatacenterSecurityZoneById        = DatacenterSecurityZones + pathDelim + "%s"
+	DatacenterSecurityZoneDHCPServers = DatacenterSecurityZoneById + pathDelim + "dhcp-servers"
+	DatacenterSecurityZoneLoopbacks   = DatacenterSecurityZoneById + pathDelim + "loopbacks"
+
 	DatacenterSwitchingZones    = blueprintByID + pathDelim + "switching-zones"
 	DatacenterSwitchingZoneByID = DatacenterSwitchingZones + pathDelim + "%s"
 )


### PR DESCRIPTION
This PR adds the same a "cache the default Routing Zone ID" client feature similar to what was added for Switching Zones in #723.

In addition to that, we:

- Move the `SecurityZone` type from `apstra` into the `datacenter` package (many changed files contain only the new package location of this type.
- Move Security Zone URL constants into the `internal/urls` package.
- Introduce the `ListSecurityZones()` client method with tests.