### PR TITLE
Update VN support for 6.2.0: Tags and Security Zone

### DIFF
--- a/apstra/two_stage_l3_clos_virtual_networks.go
+++ b/apstra/two_stage_l3_clos_virtual_networks.go
@@ -209,7 +209,7 @@ func (o *TwoStageL3ClosClient) GetVirtualNetworks(ctx context.Context) ([]datace
 }
 
 func (o *TwoStageL3ClosClient) CreateVirtualNetwork(ctx context.Context, vn datacenter.VirtualNetwork) (string, error) {
-	if vn.Tags != nil {
+	if vn.Tags != nil && !compatibility.VirtualNetworkAPITags.Check(o.client.apiVersion) {
 		return "", ClientErr{
 			errType: ErrNotSupported,
 			err:     fmt.Errorf("tags must be nil when creating virtual network with Apstra %s", o.client.ApiVersion()),
@@ -244,11 +244,33 @@ func (o *TwoStageL3ClosClient) UpdateVirtualNetwork(ctx context.Context, vn data
 		return fmt.Errorf("id is required in %s", str.FuncName())
 	}
 
-	if vn.Tags != nil {
+	if vn.Tags != nil && !compatibility.VirtualNetworkAPITags.Check(o.client.apiVersion) {
 		return ClientErr{
 			errType: ErrNotSupported,
 			err:     fmt.Errorf("tags must be nil when updating virtual network with Apstra %s", o.client.ApiVersion()),
 		}
+	}
+
+	if vn.SecurityZoneID == "" && compatibility.VirtualNetworkZoneIDsRequired.Check(o.client.apiVersion) {
+		id, err := o.DefaultSecurityZoneID(ctx)
+		if err != nil {
+			return fmt.Errorf("determining default security zone ID: %w", err)
+		}
+		if id == nil {
+			return fmt.Errorf("got nil ID for default security zone")
+		}
+		vn.SecurityZoneID = *id
+	}
+
+	if vn.SwitchingZoneID == "" && compatibility.VirtualNetworkZoneIDsRequired.Check(o.client.apiVersion) {
+		id, err := o.DefaultSwitchingZoneID(ctx)
+		if err != nil {
+			return fmt.Errorf("determining default switching zone ID: %w", err)
+		}
+		if id == nil {
+			return fmt.Errorf("got nil ID for default switching zone")
+		}
+		vn.SwitchingZoneID = *id
 	}
 
 	if vn.Bindings == nil {

--- a/apstra/two_stage_l3_clos_virtual_networks_integration_test.go
+++ b/apstra/two_stage_l3_clos_virtual_networks_integration_test.go
@@ -122,19 +122,30 @@ func TestVirtualNetworkTags(t *testing.T) {
 			create.Tags = tags
 			create.Label = randString(6, "hex")
 
-			log.Printf("ensuring that CreateVirtualNetwork() with tags fails against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-			var ace ClientErr
-			_, err = bpClient.CreateVirtualNetwork(ctx, create)
-			require.Error(t, err)
-			require.ErrorAs(t, err, &ace)
-			require.Equal(t, ErrNotSupported, ace.Type())
+			if compatibility.VirtualNetworkAPITags.Check(client.client.apiVersion) {
+				log.Printf("ensuring that CreateVirtualNetwork() with tags succeeds against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+				id, err := bpClient.CreateVirtualNetwork(ctx, create)
+				require.NoError(t, err)
 
-			log.Printf("ensuring that UpdateVirtualNetwork() with tags fails against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-			require.NoError(t, create.SetID(vnId))
-			err = bpClient.UpdateVirtualNetwork(ctx, create)
-			require.Error(t, err)
-			require.ErrorAs(t, err, &ace)
-			require.Equal(t, ErrNotSupported, ace.Type())
+				require.NoError(t, create.SetID(id))
+				log.Printf("ensuring that UpdateVirtualNetwork() with tags succeeds against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+				err = bpClient.UpdateVirtualNetwork(ctx, create)
+				require.NoError(t, err)
+			} else {
+				log.Printf("ensuring that CreateVirtualNetwork() with tags fails against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+				var ace ClientErr
+				_, err := bpClient.CreateVirtualNetwork(ctx, create)
+				require.Error(t, err)
+				require.ErrorAs(t, err, &ace)
+				require.Equal(t, ErrNotSupported, ace.Type())
+
+				log.Printf("ensuring that UpdateVirtualNetwork() with tags fails against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
+				require.NoError(t, create.SetID(vnId))
+				err = bpClient.UpdateVirtualNetwork(ctx, create)
+				require.Error(t, err)
+				require.ErrorAs(t, err, &ace)
+				require.Equal(t, ErrNotSupported, ace.Type())
+			}
 		})
 	}
 }

--- a/compatibility/constraints.go
+++ b/compatibility/constraints.go
@@ -70,6 +70,9 @@ var (
 	SwitchSystemLinksSystemIDNotSupported = Constraint{
 		constraints: version.MustConstraints(version.NewConstraint("<" + apstra610)),
 	}
+	SwitchingZoneSupported = Constraint{
+		constraints: version.MustConstraints(version.NewConstraint(">=" + apstra620)),
+	}
 	SystemManagerHasSkipInterfaceShutdownOnUpgrade = Constraint{
 		constraints: version.MustConstraints(version.NewConstraint(">=" + apstra500)),
 	}
@@ -79,7 +82,13 @@ var (
 	VirtualNetworkAddressesInActiveGraphOnly = Constraint{
 		constraints: version.MustConstraints(version.NewConstraint(">=" + apstra420)),
 	}
+	VirtualNetworkAPITags = Constraint{
+		constraints: version.MustConstraints(version.NewConstraint(">=" + apstra620)),
+	}
 	VirtualNetworkTags = Constraint{
 		constraints: version.MustConstraints(version.NewConstraint(">=" + apstra500)),
+	}
+	VirtualNetworkZoneIDsRequired = Constraint{
+		constraints: version.MustConstraints(version.NewConstraint(">=" + apstra620)),
 	}
 )

--- a/datacenter/virtual_network.go
+++ b/datacenter/virtual_network.go
@@ -36,8 +36,9 @@ type VirtualNetwork struct {
 	Label                     string             `json:"label"`
 	ReservedVLAN              *uint16            `json:"reserved_vlan_id,omitempty"`
 	RTPolicy                  *RTPolicy          `json:"rt_policy"`
-	SecurityZoneID            string             `json:"security_zone_id,omitempty"`
 	SVIIPs                    []SVIAddressing    `json:"svi_ips"`
+	SecurityZoneID            string             `json:"security_zone_id,omitempty"`
+	SwitchingZoneID           string             `json:"switching_zone_id,omitempty"`
 	Tags                      []string           `json:"tags"`
 	Type                      enum.VnType        `json:"vn_type"`
 	VirtualGatewayIPv4        net.IP             `json:"-"`
@@ -114,8 +115,9 @@ func (vn *VirtualNetwork) UnmarshalJSON(bytes []byte) error {
 		Label                     string             `json:"label"`
 		ReservedVLAN              *uint16            `json:"reserved_vlan_id"`
 		RTPolicy                  *RTPolicy          `json:"rt_policy"`
-		SecurityZoneID            string             `json:"security_zone_id"`
 		SVIIPs                    []SVIAddressing    `json:"svi_ips"`
+		SecurityZoneID            string             `json:"security_zone_id"`
+		SwitchingZoneID           string             `json:"switching_zone_id"`
 		Tags                      []string           `json:"tags"`
 		VirtualGatewayIPv4        string             `json:"virtual_gateway_ipv4"`
 		VirtualGatewayIPv6        string             `json:"virtual_gateway_ipv6"`
@@ -152,8 +154,9 @@ func (vn *VirtualNetwork) UnmarshalJSON(bytes []byte) error {
 	vn.Label = raw.Label
 	vn.ReservedVLAN = raw.ReservedVLAN
 	vn.RTPolicy = raw.RTPolicy
-	vn.SecurityZoneID = raw.SecurityZoneID
 	vn.SVIIPs = raw.SVIIPs
+	vn.SecurityZoneID = raw.SecurityZoneID
+	vn.SwitchingZoneID = raw.SwitchingZoneID
 	vn.Tags = raw.Tags
 
 	vn.VirtualGatewayIPv4, err = parse.IPFromString(raw.VirtualGatewayIPv4)

--- a/datacenter/virtual_network_integration_test.go
+++ b/datacenter/virtual_network_integration_test.go
@@ -681,20 +681,20 @@ func TestVirtualNetwork_CRUD(t *testing.T) {
 					case "nondefault":
 						create.SecurityZoneID = rzMap[clientName]
 					case "default":
-						szID, err := bpMap[clientName].DefaultSecurityZoneID(ctx)
+						zoneID, err := bpMap[clientName].DefaultSecurityZoneID(ctx)
 						require.NoError(t, err)
-						require.NotNil(t, szID)
-						create.SecurityZoneID = *szID
+						require.NotNil(t, zoneID)
+						create.SecurityZoneID = *zoneID
 					}
 					// set switching zone ID if necessary
 					switch create.SwitchingZoneID {
 					case "nondefault":
 						create.SwitchingZoneID = szMap[clientName]
 					case "default":
-						szID, err := bpMap[clientName].DefaultSwitchingZoneID(ctx)
+						zoneID, err := bpMap[clientName].DefaultSwitchingZoneID(ctx)
 						require.NoError(t, err)
-						require.NotNil(t, szID)
-						create.SwitchingZoneID = *szID
+						require.NotNil(t, zoneID)
+						create.SwitchingZoneID = *zoneID
 					}
 
 					if update != nil {
@@ -774,25 +774,15 @@ func TestVirtualNetwork_CRUD(t *testing.T) {
 								update.Bindings[i].VLAN = pointer.ToCopyOf(*update.ReservedVLAN)
 							}
 						}
-						// set the security zone ID if necessary
+						// set the routing zone ID if necessary
 						switch update.SecurityZoneID {
 						case "nondefault":
 							update.SecurityZoneID = rzMap[clientName]
 						case "default":
-							szID, err := bpMap[clientName].DefaultSecurityZoneID(ctx)
+							zoneID, err := bpMap[clientName].DefaultSecurityZoneID(ctx)
 							require.NoError(t, err)
-							require.NotNil(t, szID)
-							update.SecurityZoneID = *szID
-						}
-						// set the routing zone ID if necessary
-						switch create.SecurityZoneID {
-						case "nondefault":
-							create.SecurityZoneID = rzMap[clientName]
-						case "default":
-							szID, err := bpMap[clientName].DefaultSecurityZoneID(ctx)
-							require.NoError(t, err)
-							require.NotNil(t, szID)
-							create.SecurityZoneID = *szID
+							require.NotNil(t, zoneID)
+							update.SecurityZoneID = *zoneID
 						}
 						// set switching zone ID if necessary
 						switch update.SwitchingZoneID {

--- a/datacenter/virtual_network_integration_test.go
+++ b/datacenter/virtual_network_integration_test.go
@@ -39,10 +39,11 @@ func TestVirtualNetwork_CRUD(t *testing.T) {
 		update      *datacenter.VirtualNetwork
 	}
 
-	// Create maps keyed by clent name: blueprints, slices of leaf id, and non-default RZ
+	// Create maps keyed by clent name: blueprints, slices of leaf id, non-default RZ and SZ
 	bpMap := make(map[string]*apstra.TwoStageL3ClosClient, len(clients))
 	leafsMap := make(map[string][]string, len(clients))
 	rzMap := make(map[string]string, len(clients))
+	szMap := make(map[string]string, len(clients))
 	wg := new(sync.WaitGroup)
 	wg.Add(len(clients))
 	mu := new(sync.Mutex)
@@ -68,6 +69,14 @@ func TestVirtualNetwork_CRUD(t *testing.T) {
 			})
 			require.NoError(t, err)
 			rzMap[client.Name()] = rzID
+
+			if compatibility.SwitchingZoneSupported.Check(version.Must(version.NewVersion(bpMap[client.Name()].Client().ApiVersion()))) {
+				szMap[client.Name()], err = bpMap[client.Name()].CreateSwitchingZone(ctx, datacenter.SwitchingZone{
+					MACVRFName:        pointer.To(testutils.RandString(6, "hex")),
+					MACVRFServiceType: pointer.To(enum.SwitchingZoneMACVRFServiceTypeVLANBundle),
+				})
+				require.NoError(t, err)
+			}
 
 			wg.Done()
 		}()
@@ -528,6 +537,58 @@ func TestVirtualNetwork_CRUD(t *testing.T) {
 				},
 			},
 		},
+		"add_tags": {
+			constraints: []compatibility.Constraint{compatibility.VirtualNetworkAPITags},
+			create: datacenter.VirtualNetwork{
+				Label: testutils.RandString(6, "hex"),
+				Type:  enum.VnTypeVlan,
+			},
+			update: &datacenter.VirtualNetwork{
+				Label: testutils.RandString(6, "hex"),
+				Type:  enum.VnTypeVlan,
+				Tags:  testutils.RandomStrings(3, 5, 6, "hex"),
+			},
+		},
+		"clear_tags": {
+			constraints: []compatibility.Constraint{compatibility.VirtualNetworkAPITags},
+			create: datacenter.VirtualNetwork{
+				Label: testutils.RandString(6, "hex"),
+				Type:  enum.VnTypeVlan,
+				Tags:  testutils.RandomStrings(3, 5, 6, "hex"),
+			},
+			update: &datacenter.VirtualNetwork{
+				Label: testutils.RandString(6, "hex"),
+				Type:  enum.VnTypeVlan,
+			},
+		},
+		"change_from_default_switching_zone": {
+			constraints: []compatibility.Constraint{compatibility.SwitchingZoneSupported},
+			create: datacenter.VirtualNetwork{
+				Label:           testutils.RandString(6, "hex"),
+				SecurityZoneID:  "nondefault",
+				SwitchingZoneID: "",
+				Type:            enum.VnTypeVxlan,
+			},
+			update: &datacenter.VirtualNetwork{
+				Label:           testutils.RandString(6, "hex"),
+				SecurityZoneID:  "nondefault",
+				SwitchingZoneID: "nondefault",
+				Type:            enum.VnTypeVxlan,
+			},
+		},
+		"change_to_default_switching_zone": {
+			constraints: []compatibility.Constraint{compatibility.SwitchingZoneSupported},
+			create: datacenter.VirtualNetwork{
+				Label:           testutils.RandString(6, "hex"),
+				SwitchingZoneID: "nondefault",
+				Type:            enum.VnTypeVlan,
+			},
+			update: &datacenter.VirtualNetwork{
+				Label:           testutils.RandString(6, "hex"),
+				SwitchingZoneID: "",
+				Type:            enum.VnTypeVlan,
+			},
+		},
 	}
 
 	for tName, tCase := range testCases {
@@ -615,7 +676,7 @@ func TestVirtualNetwork_CRUD(t *testing.T) {
 							create.Bindings[i].VLAN = pointer.ToCopyOf(*create.ReservedVLAN)
 						}
 					}
-					// set the security zone ID if necessary
+					// set the routing zone ID if necessary
 					switch create.SecurityZoneID {
 					case "nondefault":
 						create.SecurityZoneID = rzMap[clientName]
@@ -624,6 +685,16 @@ func TestVirtualNetwork_CRUD(t *testing.T) {
 						require.NoError(t, err)
 						require.NotNil(t, szID)
 						create.SecurityZoneID = *szID
+					}
+					// set switching zone ID if necessary
+					switch create.SwitchingZoneID {
+					case "nondefault":
+						create.SwitchingZoneID = szMap[clientName]
+					case "default":
+						szID, err := bpMap[clientName].DefaultSwitchingZoneID(ctx)
+						require.NoError(t, err)
+						require.NotNil(t, szID)
+						create.SwitchingZoneID = *szID
 					}
 
 					if update != nil {
@@ -712,6 +783,26 @@ func TestVirtualNetwork_CRUD(t *testing.T) {
 							require.NoError(t, err)
 							require.NotNil(t, szID)
 							update.SecurityZoneID = *szID
+						}
+						// set the routing zone ID if necessary
+						switch create.SecurityZoneID {
+						case "nondefault":
+							create.SecurityZoneID = rzMap[clientName]
+						case "default":
+							szID, err := bpMap[clientName].DefaultSecurityZoneID(ctx)
+							require.NoError(t, err)
+							require.NotNil(t, szID)
+							create.SecurityZoneID = *szID
+						}
+						// set switching zone ID if necessary
+						switch update.SwitchingZoneID {
+						case "nondefault":
+							update.SwitchingZoneID = szMap[clientName]
+						case "default":
+							szID, err := bpMap[clientName].DefaultSwitchingZoneID(ctx)
+							require.NoError(t, err)
+							require.NotNil(t, szID)
+							update.SwitchingZoneID = *szID
 						}
 					}
 

--- a/internal/test_utils/compare/datacenter/virtual_network.go
+++ b/internal/test_utils/compare/datacenter/virtual_network.go
@@ -49,6 +49,9 @@ func VirtualNetwork(t testing.TB, req, resp datacenter.VirtualNetwork, msg ...st
 	if req.SecurityZoneID != "" {
 		require.Equal(t, req.SecurityZoneID, resp.SecurityZoneID)
 	}
+	if req.SwitchingZoneID != "" {
+		require.Equal(t, req.SwitchingZoneID, resp.SwitchingZoneID)
+	}
 	require.Equal(t, req.Type, resp.Type)
 	require.Equal(t, req.VirtualGatewayIPv4.String(), resp.VirtualGatewayIPv4.String())
 	require.Equal(t, req.VirtualGatewayIPv6.String(), resp.VirtualGatewayIPv6.String())


### PR DESCRIPTION
This PR introduces support for two new things in the Virtual Network API:
- `security_zone_id` - A brand-new attribute, optional with `POST`, but required with `PUT`
- `tags` - now writable via `POST` and `PUT`, previously read-only via `GET`

Like `routing_zone_id`, if the `switching_zone_id` is empty in `UpdateVirtualNetwork()` we populate it with the default zone ID (cached in the client).

Closes #706