### PR TITLE
Rename function `GetEVPNInterconnectGroupByName()` -> `GetEVPNInterconnectGroupByLabel()`

### DIFF
--- a/apstra/two_stage_l3_clos_evpn_interconnect_group.go
+++ b/apstra/two_stage_l3_clos_evpn_interconnect_group.go
@@ -165,7 +165,7 @@ func (o *TwoStageL3ClosClient) GetAllEVPNInterconnectGroups(ctx context.Context)
 	return response.Items, nil
 }
 
-func (o *TwoStageL3ClosClient) GetEVPNInterconnectGroupByName(ctx context.Context, name string) (EVPNInterconnectGroup, error) {
+func (o *TwoStageL3ClosClient) GetEVPNInterconnectGroupByLabel(ctx context.Context, name string) (EVPNInterconnectGroup, error) {
 	items, err := o.GetAllEVPNInterconnectGroups(ctx)
 	if err != nil {
 		return EVPNInterconnectGroup{}, fmt.Errorf("GetAllEVPNInterconnectGroups: %w", err)

--- a/apstra/two_stage_l3_clos_evpn_interconnect_group_integration_test.go
+++ b/apstra/two_stage_l3_clos_evpn_interconnect_group_integration_test.go
@@ -259,7 +259,7 @@ func TestEvpnInterconnectGroup(t *testing.T) {
 						comparedatacenter.EVPNInterconnectGroup(t, step.config, get)
 
 						require.NotNil(t, step.config.Label)
-						get, err = bpClient.GetEVPNInterconnectGroupByName(ctx, *step.config.Label)
+						get, err = bpClient.GetEVPNInterconnectGroupByLabel(ctx, *step.config.Label)
 						require.NoError(t, err)
 						require.NotNil(t, get.ID())
 						require.Equal(t, id, *get.ID())
@@ -305,7 +305,7 @@ func TestEvpnInterconnectGroup(t *testing.T) {
 						require.Equal(t, apstra.ErrNotfound, ace.Type())
 
 						require.NotNil(t, evpnInterconnectGroup.Label)
-						_, err = bpClient.GetEVPNInterconnectGroupByName(ctx, *evpnInterconnectGroup.Label)
+						_, err = bpClient.GetEVPNInterconnectGroupByLabel(ctx, *evpnInterconnectGroup.Label)
 						require.Error(t, err)
 						require.ErrorAs(t, err, &ace)
 						require.Equal(t, apstra.ErrNotfound, ace.Type())


### PR DESCRIPTION
Closes #712