### PR TITLE
Move `PolicyApplicationPointData` to `datacenter` package

### DIFF
--- a/apstra/two_stage_l3_clos_policies.go
+++ b/apstra/two_stage_l3_clos_policies.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2022-2024.
+// Copyright (c) Juniper Networks, Inc., 2022-2026.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -8,6 +8,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+
+	"github.com/Juniper/apstra-go-sdk/datacenter"
 )
 
 const (
@@ -21,22 +23,22 @@ type Policy struct {
 }
 
 type PolicyData struct {
-	Enabled             bool                        `json:"enabled"`
-	Label               string                      `json:"label"`
-	Description         string                      `json:"description"`
-	SrcApplicationPoint *PolicyApplicationPointData `json:"src_application_point"`
-	DstApplicationPoint *PolicyApplicationPointData `json:"dst_application_point"`
-	Rules               []PolicyRule                `json:"rules"`
-	Tags                []string                    `json:"tags"`
+	Enabled             bool                                   `json:"enabled"`
+	Label               string                                 `json:"label"`
+	Description         string                                 `json:"description"`
+	SrcApplicationPoint *datacenter.PolicyApplicationPointData `json:"src_application_point"`
+	DstApplicationPoint *datacenter.PolicyApplicationPointData `json:"dst_application_point"`
+	Rules               []PolicyRule                           `json:"rules"`
+	Tags                []string                               `json:"tags"`
 }
 
 func (o PolicyData) request() *policyRequest {
 	var srcApplicationPoint, dstApplicationPoint ObjectId
 	if o.SrcApplicationPoint != nil {
-		srcApplicationPoint = o.SrcApplicationPoint.Id
+		srcApplicationPoint = ObjectId(o.SrcApplicationPoint.Id)
 	}
 	if o.DstApplicationPoint != nil {
-		dstApplicationPoint = o.DstApplicationPoint.Id
+		dstApplicationPoint = ObjectId(o.DstApplicationPoint.Id)
 	}
 
 	rules := make([]rawPolicyRule, len(o.Rules))
@@ -65,14 +67,14 @@ type policyRequest struct {
 }
 
 type rawPolicy struct {
-	Enabled             bool                        `json:"enabled"`
-	Label               string                      `json:"label"`
-	Description         string                      `json:"description"`
-	SrcApplicationPoint *PolicyApplicationPointData `json:"src_application_point,omitempty"`
-	DstApplicationPoint *PolicyApplicationPointData `json:"dst_application_point,omitempty"`
-	Rules               []rawPolicyRule             `json:"rules"`
-	Tags                []string                    `json:"tags"`
-	Id                  ObjectId                    `json:"id"`
+	Enabled             bool                                   `json:"enabled"`
+	Label               string                                 `json:"label"`
+	Description         string                                 `json:"description"`
+	SrcApplicationPoint *datacenter.PolicyApplicationPointData `json:"src_application_point,omitempty"`
+	DstApplicationPoint *datacenter.PolicyApplicationPointData `json:"dst_application_point,omitempty"`
+	Rules               []rawPolicyRule                        `json:"rules"`
+	Tags                []string                               `json:"tags"`
+	Id                  ObjectId                               `json:"id"`
 }
 
 func (o rawPolicy) polish() (*Policy, error) {
@@ -103,17 +105,11 @@ func (o rawPolicy) request() *policyRequest {
 		Enabled:             o.Enabled,
 		Label:               o.Label,
 		Description:         o.Description,
-		SrcApplicationPoint: o.SrcApplicationPoint.Id,
-		DstApplicationPoint: o.DstApplicationPoint.Id,
+		SrcApplicationPoint: ObjectId(o.SrcApplicationPoint.Id),
+		DstApplicationPoint: ObjectId(o.DstApplicationPoint.Id),
 		Rules:               o.Rules,
 		Tags:                o.Tags,
 	}
-}
-
-type PolicyApplicationPointData struct {
-	Id    ObjectId `json:"id"`
-	Label string   `json:"label"`
-	Type  string   `json:"type"` // group, internal, external, security_zone, virtual_network
 }
 
 func (o *TwoStageL3ClosClient) getAllPolicies(ctx context.Context) ([]rawPolicy, error) {

--- a/apstra/two_stage_l3_clos_policies.go
+++ b/apstra/two_stage_l3_clos_policies.go
@@ -35,10 +35,10 @@ type PolicyData struct {
 func (o PolicyData) request() *policyRequest {
 	var srcApplicationPoint, dstApplicationPoint ObjectId
 	if o.SrcApplicationPoint != nil {
-		srcApplicationPoint = ObjectId(o.SrcApplicationPoint.Id)
+		srcApplicationPoint = ObjectId(o.SrcApplicationPoint.ID)
 	}
 	if o.DstApplicationPoint != nil {
-		dstApplicationPoint = ObjectId(o.DstApplicationPoint.Id)
+		dstApplicationPoint = ObjectId(o.DstApplicationPoint.ID)
 	}
 
 	rules := make([]rawPolicyRule, len(o.Rules))
@@ -105,8 +105,8 @@ func (o rawPolicy) request() *policyRequest {
 		Enabled:             o.Enabled,
 		Label:               o.Label,
 		Description:         o.Description,
-		SrcApplicationPoint: ObjectId(o.SrcApplicationPoint.Id),
-		DstApplicationPoint: ObjectId(o.DstApplicationPoint.Id),
+		SrcApplicationPoint: ObjectId(o.SrcApplicationPoint.ID),
+		DstApplicationPoint: ObjectId(o.DstApplicationPoint.ID),
 		Rules:               o.Rules,
 		Tags:                o.Tags,
 	}

--- a/apstra/two_stage_l3_clos_policies_integration_test.go
+++ b/apstra/two_stage_l3_clos_policies_integration_test.go
@@ -299,8 +299,8 @@ func TestCreateDatacenterPolicy(t *testing.T) {
 					Enabled:             randBool(),
 					Label:               randString(5, "hex"),
 					Description:         randString(5, "hex"),
-					SrcApplicationPoint: &PolicyApplicationPointData{Id: ObjectId(vnIds[0])},
-					DstApplicationPoint: &PolicyApplicationPointData{Id: ObjectId(vnIds[1])},
+					SrcApplicationPoint: &datacenter.PolicyApplicationPointData{Id: vnIds[0]},
+					DstApplicationPoint: &datacenter.PolicyApplicationPointData{Id: vnIds[1]},
 					Rules:               nil,
 					Tags:                tags,
 				},
@@ -308,8 +308,8 @@ func TestCreateDatacenterPolicy(t *testing.T) {
 					Enabled:             randBool(),
 					Label:               randString(5, "hex"),
 					Description:         randString(5, "hex"),
-					SrcApplicationPoint: &PolicyApplicationPointData{Id: ObjectId(vnIds[1])},
-					DstApplicationPoint: &PolicyApplicationPointData{Id: ObjectId(vnIds[0])},
+					SrcApplicationPoint: &datacenter.PolicyApplicationPointData{Id: vnIds[1]},
+					DstApplicationPoint: &datacenter.PolicyApplicationPointData{Id: vnIds[0]},
 					Rules:               nil,
 					Tags:                tags,
 				},
@@ -418,8 +418,8 @@ func TestAddDeletePolicyRule(t *testing.T) {
 			policyId, err := bp.CreatePolicy(ctx, &PolicyData{
 				Enabled:             false,
 				Label:               randString(5, "hex"),
-				SrcApplicationPoint: &PolicyApplicationPointData{Id: ObjectId(vnIds[0])},
-				DstApplicationPoint: &PolicyApplicationPointData{Id: ObjectId(vnIds[1])},
+				SrcApplicationPoint: &datacenter.PolicyApplicationPointData{Id: vnIds[0]},
+				DstApplicationPoint: &datacenter.PolicyApplicationPointData{Id: vnIds[1]},
 			})
 			if err != nil {
 				t.Fatal(err)

--- a/apstra/two_stage_l3_clos_policies_integration_test.go
+++ b/apstra/two_stage_l3_clos_policies_integration_test.go
@@ -217,12 +217,12 @@ func comparePolicyData(a *PolicyData, aName string, b *PolicyData, bName string,
 		t.Fatalf("Policy Descriptions don't match: %s has %q, %s has %q", aName, a.Description, bName, b.Description)
 	}
 
-	if a.SrcApplicationPoint.Id != b.SrcApplicationPoint.Id {
-		t.Fatalf("Policy SrcApplicationPoints don't match: %s has %q, %s has %q", aName, a.SrcApplicationPoint.Id, bName, b.SrcApplicationPoint.Id)
+	if a.SrcApplicationPoint.ID != b.SrcApplicationPoint.ID {
+		t.Fatalf("Policy SrcApplicationPoints don't match: %s has %q, %s has %q", aName, a.SrcApplicationPoint.ID, bName, b.SrcApplicationPoint.ID)
 	}
 
-	if a.DstApplicationPoint.Id != b.DstApplicationPoint.Id {
-		t.Fatalf("Policy DstApplicationPoints don't match: %s has %q, %s has %q", aName, a.DstApplicationPoint.Id, bName, b.DstApplicationPoint.Id)
+	if a.DstApplicationPoint.ID != b.DstApplicationPoint.ID {
+		t.Fatalf("Policy DstApplicationPoints don't match: %s has %q, %s has %q", aName, a.DstApplicationPoint.ID, bName, b.DstApplicationPoint.ID)
 	}
 
 	compareSlicesAsSets(t, a.Tags, b.Tags, fmt.Sprintf("%s tags: %v, %s tags %v", aName, a.Tags, bName, b.Tags))
@@ -299,8 +299,8 @@ func TestCreateDatacenterPolicy(t *testing.T) {
 					Enabled:             randBool(),
 					Label:               randString(5, "hex"),
 					Description:         randString(5, "hex"),
-					SrcApplicationPoint: &datacenter.PolicyApplicationPointData{Id: vnIds[0]},
-					DstApplicationPoint: &datacenter.PolicyApplicationPointData{Id: vnIds[1]},
+					SrcApplicationPoint: &datacenter.PolicyApplicationPointData{ID: vnIds[0]},
+					DstApplicationPoint: &datacenter.PolicyApplicationPointData{ID: vnIds[1]},
 					Rules:               nil,
 					Tags:                tags,
 				},
@@ -308,8 +308,8 @@ func TestCreateDatacenterPolicy(t *testing.T) {
 					Enabled:             randBool(),
 					Label:               randString(5, "hex"),
 					Description:         randString(5, "hex"),
-					SrcApplicationPoint: &datacenter.PolicyApplicationPointData{Id: vnIds[1]},
-					DstApplicationPoint: &datacenter.PolicyApplicationPointData{Id: vnIds[0]},
+					SrcApplicationPoint: &datacenter.PolicyApplicationPointData{ID: vnIds[1]},
+					DstApplicationPoint: &datacenter.PolicyApplicationPointData{ID: vnIds[0]},
 					Rules:               nil,
 					Tags:                tags,
 				},
@@ -418,8 +418,8 @@ func TestAddDeletePolicyRule(t *testing.T) {
 			policyId, err := bp.CreatePolicy(ctx, &PolicyData{
 				Enabled:             false,
 				Label:               randString(5, "hex"),
-				SrcApplicationPoint: &datacenter.PolicyApplicationPointData{Id: vnIds[0]},
-				DstApplicationPoint: &datacenter.PolicyApplicationPointData{Id: vnIds[1]},
+				SrcApplicationPoint: &datacenter.PolicyApplicationPointData{ID: vnIds[0]},
+				DstApplicationPoint: &datacenter.PolicyApplicationPointData{ID: vnIds[1]},
 			})
 			if err != nil {
 				t.Fatal(err)

--- a/datacenter/policy_application_point_data.go
+++ b/datacenter/policy_application_point_data.go
@@ -7,7 +7,7 @@ package datacenter
 import "github.com/Juniper/apstra-go-sdk/enum"
 
 type PolicyApplicationPointData struct {
-	Id    string                           `json:"id"`
+	ID    string                           `json:"id"`
 	Label string                           `json:"label"`
 	Type  *enum.PolicyApplicationPointType `json:"type"`
 }

--- a/datacenter/policy_application_point_data.go
+++ b/datacenter/policy_application_point_data.go
@@ -1,0 +1,13 @@
+// Copyright (c) Juniper Networks, Inc., 2026-2026.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package datacenter
+
+import "github.com/Juniper/apstra-go-sdk/enum"
+
+type PolicyApplicationPointData struct {
+	Id    string                           `json:"id"`
+	Label string                           `json:"label"`
+	Type  *enum.PolicyApplicationPointType `json:"type"`
+}

--- a/enum/enums.go
+++ b/enum/enums.go
@@ -383,11 +383,13 @@ var (
 type PolicyApplicationPointType oenum.Member[string]
 
 var (
-	PolicyApplicationPointTypeExternal       = PolicyApplicationPointType{Value: "external"}
-	PolicyApplicationPointTypeGroup          = PolicyApplicationPointType{Value: "group"}
-	PolicyApplicationPointTypeInternal       = PolicyApplicationPointType{Value: "internal"}
-	PolicyApplicationPointTypeSecurityZone   = PolicyApplicationPointType{Value: "security_zone"}
-	PolicyApplicationPointTypeVirtualNetwork = PolicyApplicationPointType{Value: "virtual_network"}
+	PolicyApplicationPointTypeExternal          = PolicyApplicationPointType{Value: "external"}
+	PolicyApplicationPointTypeExternalEndpoints = PolicyApplicationPointType{Value: "external_endpoints"}
+	PolicyApplicationPointTypeGroup             = PolicyApplicationPointType{Value: "group"}
+	PolicyApplicationPointTypeInternal          = PolicyApplicationPointType{Value: "internal"}
+	PolicyApplicationPointTypeInternalEndpoints = PolicyApplicationPointType{Value: "internal_endpoints"}
+	PolicyApplicationPointTypeSecurityZone      = PolicyApplicationPointType{Value: "security_zone"}
+	PolicyApplicationPointTypeVirtualNetwork    = PolicyApplicationPointType{Value: "virtual_network"}
 )
 
 type PolicyRuleAction oenum.Member[string]

--- a/enum/generated_enums.go
+++ b/enum/generated_enums.go
@@ -2203,8 +2203,10 @@ var (
 	_                           enum = new(PolicyApplicationPointType)
 	PolicyApplicationPointTypes      = oenum.New(
 		PolicyApplicationPointTypeExternal,
+		PolicyApplicationPointTypeExternalEndpoints,
 		PolicyApplicationPointTypeGroup,
 		PolicyApplicationPointTypeInternal,
+		PolicyApplicationPointTypeInternalEndpoints,
 		PolicyApplicationPointTypeSecurityZone,
 		PolicyApplicationPointTypeVirtualNetwork,
 	)


### PR DESCRIPTION
This PR moves the `PolicyApplicationPointData` struct from the `apstra` package to the `datacenter` package.

Really minor updates associated with this one:
- Change `Id ObjectId` to `ID string` in struct
- Change type of existing `string` pointer into pointer to existing enum `PolicyApplicationPointType`
- Add a couple of new enum values to `PolicyApplicationPointType` (found in REST API Explorer) 