### PR TITLE
Add `AddressFamily` attribute to `datacenter.Policy` for 6.2.0

### DIFF
--- a/compatibility/constraints.go
+++ b/compatibility/constraints.go
@@ -21,7 +21,7 @@ var (
 		constraints: version.MustConstraints(version.NewConstraint("<=" + apstra612)),
 	}
 	DatacenterPolicyAddressFamilyRequired = Constraint{
-		constraints: version.MustConstraints(version.NewConstraint(">=" + apstra620)),
+		constraints: version.MustConstraints(version.NewConstraint(">" + apstra612)),
 	}
 	DatacenterSwitchingZoneOK = Constraint{
 		constraints: version.MustConstraints(version.NewConstraint(">=" + apstra620)),

--- a/compatibility/constraints.go
+++ b/compatibility/constraints.go
@@ -17,6 +17,12 @@ var (
 	BpHasVirtualNetworkPolicyNode = Constraint{
 		constraints: version.MustConstraints(version.NewConstraint("<=" + apstra420)),
 	}
+	DatacenterPolicyAddressFamilyNotSupported = Constraint{
+		constraints: version.MustConstraints(version.NewConstraint("<=" + apstra612)),
+	}
+	DatacenterPolicyAddressFamilyRequired = Constraint{
+		constraints: version.MustConstraints(version.NewConstraint(">=" + apstra620)),
+	}
 	DatacenterSwitchingZoneOK = Constraint{
 		constraints: version.MustConstraints(version.NewConstraint(">=" + apstra620)),
 	}

--- a/datacenter/policy.go
+++ b/datacenter/policy.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/Juniper/apstra-go-sdk/enum"
 	"github.com/Juniper/apstra-go-sdk/errors"
 	"github.com/Juniper/apstra-go-sdk/internal"
 	"github.com/Juniper/apstra-go-sdk/internal/pointer"
@@ -20,13 +21,14 @@ var (
 )
 
 type Policy struct {
-	Enabled             bool         `json:"enabled"`
-	Label               string       `json:"label"`
-	Description         string       `json:"description"`
-	SrcApplicationPoint *string      `json:"src_application_point"`
-	DstApplicationPoint *string      `json:"dst_application_point"`
-	Rules               []PolicyRule `json:"rules"`
-	Tags                []string     `json:"tags"`
+	Enabled             bool                      `json:"enabled"`
+	Label               string                    `json:"label"`
+	Description         string                    `json:"description"`
+	SrcApplicationPoint *string                   `json:"src_application_point"`
+	DstApplicationPoint *string                   `json:"dst_application_point"`
+	AddressFamily       *enum.PolicyAddressFamily `json:"ip_version,omitempty"`
+	Rules               []PolicyRule              `json:"rules"`
+	Tags                []string                  `json:"tags"`
 
 	id string
 }

--- a/datacenter/policy_integration_test.go
+++ b/datacenter/policy_integration_test.go
@@ -36,7 +36,8 @@ func TestCrudPolicy(t *testing.T) {
 	}
 
 	testCases := map[string]testCase{
-		"start_minimal_src_rz": {
+		"start_minimal_src_rz_6.1_and_earlier": {
+			versionConstraint: &compatibility.DatacenterPolicyAddressFamilyNotSupported,
 			create: datacenter.Policy{
 				Label: testutils.RandString(6, "hex"),
 			},
@@ -67,7 +68,8 @@ func TestCrudPolicy(t *testing.T) {
 				Tags: testutils.RandomStrings(3, 6, 6, "hex"),
 			},
 		},
-		"start_maximal_dst_rz": {
+		"start_maximal_dst_rz_6.1_and_earlier": {
+			versionConstraint: &compatibility.DatacenterPolicyAddressFamilyNotSupported,
 			create: datacenter.Policy{
 				Enabled:             true,
 				Label:               testutils.RandString(6, "hex"),
@@ -98,7 +100,8 @@ func TestCrudPolicy(t *testing.T) {
 				Label: testutils.RandString(6, "hex"),
 			},
 		},
-		"start_minimal_intra_rz_vns": {
+		"start_minimal_intra_rz_vns_6.1_and_earlier": {
+			versionConstraint: &compatibility.DatacenterPolicyAddressFamilyNotSupported,
 			create: datacenter.Policy{
 				Label: testutils.RandString(6, "hex"),
 			},
@@ -106,6 +109,109 @@ func TestCrudPolicy(t *testing.T) {
 				Enabled:             true,
 				Label:               testutils.RandString(6, "hex"),
 				Description:         testutils.RandString(6, "hex"),
+				SrcApplicationPoint: pointer.To("vn:a:a1"),
+				DstApplicationPoint: pointer.To("vn:a:a2"),
+				Rules: []datacenter.PolicyRule{
+					{
+						Label:             testutils.RandString(6, "hex"),
+						Description:       testutils.RandString(6, "hex"),
+						Protocol:          enum.PolicyRuleProtocolTcp,
+						Action:            testutils.OneOf(enum.PolicyRuleActionDeny, enum.PolicyRuleActionDenyLog, enum.PolicyRuleActionPermit, enum.PolicyRuleActionPermitLog),
+						SrcPort:           dctestobj.RandomPortRanges(3),
+						DstPort:           dctestobj.RandomPortRanges(3),
+						TcpStateQualifier: testutils.OneOf(nil, pointer.To(enum.TcpStateQualifierEstablished)),
+					},
+					{
+						Label:       testutils.RandString(6, "hex"),
+						Description: testutils.RandString(6, "hex"),
+						Protocol:    enum.PolicyRuleProtocolUdp,
+						Action:      testutils.OneOf(enum.PolicyRuleActionDeny, enum.PolicyRuleActionDenyLog, enum.PolicyRuleActionPermit, enum.PolicyRuleActionPermitLog),
+						SrcPort:     dctestobj.RandomPortRanges(3),
+						DstPort:     dctestobj.RandomPortRanges(3),
+					},
+				},
+				Tags: testutils.RandomStrings(3, 6, 6, "hex"),
+			},
+		},
+		"start_minimal_src_rz": {
+			versionConstraint: &compatibility.DatacenterPolicyAddressFamilyRequired,
+			create: datacenter.Policy{
+				Label:         testutils.RandString(6, "hex"),
+				AddressFamily: pointer.To(testutils.OneOf(enum.PolicyAddressFamilyIPv4, enum.PolicyAddressFamilyIPv6, enum.PolicyAddressFamilyIPv4IPv6)),
+			},
+			update: &datacenter.Policy{
+				Enabled:             true,
+				Label:               testutils.RandString(6, "hex"),
+				Description:         testutils.RandString(6, "hex"),
+				AddressFamily:       pointer.To(testutils.OneOf(enum.PolicyAddressFamilyIPv4, enum.PolicyAddressFamilyIPv6, enum.PolicyAddressFamilyIPv4IPv6)),
+				SrcApplicationPoint: pointer.To("rz:a"),
+				Rules: []datacenter.PolicyRule{
+					{
+						Label:             testutils.RandString(6, "hex"),
+						Description:       testutils.RandString(6, "hex"),
+						Protocol:          enum.PolicyRuleProtocolTcp,
+						Action:            testutils.OneOf(enum.PolicyRuleActionDeny, enum.PolicyRuleActionDenyLog, enum.PolicyRuleActionPermit, enum.PolicyRuleActionPermitLog),
+						SrcPort:           dctestobj.RandomPortRanges(3),
+						DstPort:           dctestobj.RandomPortRanges(3),
+						TcpStateQualifier: testutils.OneOf(nil, pointer.To(enum.TcpStateQualifierEstablished)),
+					},
+					{
+						Label:       testutils.RandString(6, "hex"),
+						Description: testutils.RandString(6, "hex"),
+						Protocol:    enum.PolicyRuleProtocolUdp,
+						Action:      testutils.OneOf(enum.PolicyRuleActionDeny, enum.PolicyRuleActionDenyLog, enum.PolicyRuleActionPermit, enum.PolicyRuleActionPermitLog),
+						SrcPort:     dctestobj.RandomPortRanges(3),
+						DstPort:     dctestobj.RandomPortRanges(3),
+					},
+				},
+				Tags: testutils.RandomStrings(3, 6, 6, "hex"),
+			},
+		},
+		"start_maximal_dst_rz": {
+			versionConstraint: &compatibility.DatacenterPolicyAddressFamilyRequired,
+			create: datacenter.Policy{
+				Enabled:             true,
+				Label:               testutils.RandString(6, "hex"),
+				Description:         testutils.RandString(6, "hex"),
+				AddressFamily:       pointer.To(testutils.OneOf(enum.PolicyAddressFamilyIPv4, enum.PolicyAddressFamilyIPv6, enum.PolicyAddressFamilyIPv4IPv6)),
+				DstApplicationPoint: pointer.To("rz:b"),
+				Rules: []datacenter.PolicyRule{
+					{
+						Label:             testutils.RandString(6, "hex"),
+						Description:       testutils.RandString(6, "hex"),
+						Protocol:          enum.PolicyRuleProtocolTcp,
+						Action:            testutils.OneOf(enum.PolicyRuleActionDeny, enum.PolicyRuleActionDenyLog, enum.PolicyRuleActionPermit, enum.PolicyRuleActionPermitLog),
+						SrcPort:           dctestobj.RandomPortRanges(3),
+						DstPort:           dctestobj.RandomPortRanges(3),
+						TcpStateQualifier: testutils.OneOf(nil, pointer.To(enum.TcpStateQualifierEstablished)),
+					},
+					{
+						Label:       testutils.RandString(6, "hex"),
+						Description: testutils.RandString(6, "hex"),
+						Protocol:    enum.PolicyRuleProtocolUdp,
+						Action:      testutils.OneOf(enum.PolicyRuleActionDeny, enum.PolicyRuleActionDenyLog, enum.PolicyRuleActionPermit, enum.PolicyRuleActionPermitLog),
+						SrcPort:     dctestobj.RandomPortRanges(3),
+						DstPort:     dctestobj.RandomPortRanges(3),
+					},
+				},
+				Tags: testutils.RandomStrings(3, 6, 6, "hex"),
+			},
+			update: &datacenter.Policy{
+				Label:         testutils.RandString(6, "hex"),
+				AddressFamily: pointer.To(testutils.OneOf(enum.PolicyAddressFamilyIPv4, enum.PolicyAddressFamilyIPv6, enum.PolicyAddressFamilyIPv4IPv6)),
+			},
+		},
+		"start_minimal_intra_rz_vns": {
+			versionConstraint: &compatibility.DatacenterPolicyAddressFamilyRequired,
+			create: datacenter.Policy{
+				Label:         testutils.RandString(6, "hex"),
+				AddressFamily: pointer.To(testutils.OneOf(enum.PolicyAddressFamilyIPv4, enum.PolicyAddressFamilyIPv6, enum.PolicyAddressFamilyIPv4IPv6)),
+			},
+			update: &datacenter.Policy{
+				Enabled:             true,
+				Label:               testutils.RandString(6, "hex"),
+				Description:         testutils.RandString(6, "hex"),
+				AddressFamily:       pointer.To(testutils.OneOf(enum.PolicyAddressFamilyIPv4, enum.PolicyAddressFamilyIPv6, enum.PolicyAddressFamilyIPv4IPv6)),
 				SrcApplicationPoint: pointer.To("vn:a:a1"),
 				DstApplicationPoint: pointer.To("vn:a:a2"),
 				Rules: []datacenter.PolicyRule{

--- a/datacenter/policy_integration_test.go
+++ b/datacenter/policy_integration_test.go
@@ -451,7 +451,8 @@ func TestPolicyAddDeleteRule(t *testing.T) {
 			bp := dctestobj.TestBlueprintA(t, ctx, client.Client)
 
 			pid, err := bp.CreatePolicy(ctx, datacenter.Policy{
-				Label: testutils.RandString(6, "hex"),
+				Label:         testutils.RandString(6, "hex"),
+				AddressFamily: &enum.PolicyAddressFamilyIPv4,
 				Rules: []datacenter.PolicyRule{
 					{
 						Label:    testutils.RandString(6, "hex"),

--- a/enum/enums.go
+++ b/enum/enums.go
@@ -380,6 +380,14 @@ var (
 	OverlayControlProtocolNone = OverlayControlProtocol{Value: ""}
 )
 
+type PolicyAddressFamily oenum.Member[string]
+
+var (
+	PolicyAddressFamilyIPv4     = PolicyAddressFamily{Value: "ipv4"}
+	PolicyAddressFamilyIPv6     = PolicyAddressFamily{Value: "ipv6"}
+	PolicyAddressFamilyIPv4IPv6 = PolicyAddressFamily{Value: "ipv4_ipv6"}
+)
+
 type PolicyApplicationPointType oenum.Member[string]
 
 var (

--- a/enum/generated_enums.go
+++ b/enum/generated_enums.go
@@ -1191,6 +1191,37 @@ func (o *OverlayControlProtocol) UnmarshalJSON(bytes []byte) error {
 }
 
 var (
+	_ enum             = (*PolicyAddressFamily)(nil)
+	_ json.Marshaler   = (*PolicyAddressFamily)(nil)
+	_ json.Unmarshaler = (*PolicyAddressFamily)(nil)
+)
+
+func (o PolicyAddressFamily) String() string {
+	return o.Value
+}
+
+func (o *PolicyAddressFamily) FromString(s string) error {
+	if PolicyAddressFamilies.Parse(s) == nil {
+		return newEnumParseError(o, s)
+	}
+	o.Value = s
+	return nil
+}
+
+func (o PolicyAddressFamily) MarshalJSON() ([]byte, error) {
+	return json.Marshal(o.String())
+}
+
+func (o *PolicyAddressFamily) UnmarshalJSON(bytes []byte) error {
+	var s string
+	err := json.Unmarshal(bytes, &s)
+	if err != nil {
+		return err
+	}
+	return o.FromString(s)
+}
+
+var (
 	_ enum             = (*PolicyApplicationPointType)(nil)
 	_ json.Marshaler   = (*PolicyApplicationPointType)(nil)
 	_ json.Unmarshaler = (*PolicyApplicationPointType)(nil)
@@ -2198,6 +2229,13 @@ var (
 	OverlayControlProtocols      = oenum.New(
 		OverlayControlProtocolEVPN,
 		OverlayControlProtocolNone,
+	)
+
+	_                     enum = new(PolicyAddressFamily)
+	PolicyAddressFamilies      = oenum.New(
+		PolicyAddressFamilyIPv4,
+		PolicyAddressFamilyIPv6,
+		PolicyAddressFamilyIPv4IPv6,
 	)
 
 	_                           enum = new(PolicyApplicationPointType)

--- a/internal/test_utils/compare/datacenter/policy.go
+++ b/internal/test_utils/compare/datacenter/policy.go
@@ -34,6 +34,12 @@ func Policy(t testing.TB, req, resp datacenter.Policy, msg ...string) {
 		require.NotNil(t, resp.DstApplicationPoint, msg)
 		require.Equal(t, *req.DstApplicationPoint, *resp.DstApplicationPoint, msg)
 	}
+	if req.AddressFamily == nil {
+		require.Nil(t, resp.AddressFamily, msg)
+	} else {
+		require.NotNil(t, resp.AddressFamily, msg)
+		require.Equal(t, *req.AddressFamily, *resp.AddressFamily, msg)
+	}
 	require.Equal(t, len(req.Rules), len(resp.Rules), msg)
 	for i := range req.Rules {
 		PolicyRule(t, req.Rules[i], resp.Rules[i], fmt.Sprintf("Comparing Policy Rule at index %d", i))


### PR DESCRIPTION
This PR introduces Apstra 6.2.0's `AddressFamily` attribute to the `datacenter.Policy` struct.

Tests and comparison test helper functions updated accordingly.

Test cases are doubled:
- original tests constrained to run on earlier releases
- new clone test cases with `AddressFamily` attribute constrained to run on 6.2.0+

Closes #704
Closes #705