### PR TITLE
Test uses random blueprint, rather than a guaranteed non-freeform one

### DIFF
--- a/apstra/two_stage_l3_clos_system_node_info_integration_test.go
+++ b/apstra/two_stage_l3_clos_system_node_info_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2023-2025.
+// Copyright (c) Juniper Networks, Inc., 2023-2026.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/apstra/two_stage_l3_clos_system_node_info_integration_test.go
+++ b/apstra/two_stage_l3_clos_system_node_info_integration_test.go
@@ -51,7 +51,7 @@ func TestSystemNodeInfo(t *testing.T) {
 		var bpClient *TwoStageL3ClosClient
 		if bpId != "" {
 			log.Printf("testing NewTwoStageL3ClosClient() against %s %s (%s)", client.clientType, clientName, client.client.ApiVersion())
-			bpClient, err = client.client.NewTwoStageL3ClosClient(ctx, bpIds[0])
+			bpClient, err = client.client.NewTwoStageL3ClosClient(ctx, bpId)
 			require.NoError(t, err)
 		} else {
 			bpClient = testBlueprintA(ctx, t, client.client)


### PR DESCRIPTION
An old test which parses node info used to just use the first blueprint it encountered.

When freeform support was introduced or expanded, that first blueprint might have been the wrong type, so logic was added to filter out datacenter blueprints from freeform ones.

Unfortunately, we didn't actually _use_ the filtered results.

This PR changes the logic from"use the first blueprint" to "use the first _datacenter_ blueprint".

Closes #743