### PR TITLE
Update `PortRange` and `PortRanges` marshal/unmarshal behavior

### DIFF
--- a/datacenter/port_range.go
+++ b/datacenter/port_range.go
@@ -25,7 +25,6 @@ type PortRange struct {
 
 func (pr PortRange) MarshalText() ([]byte, error) {
 	pr.canonicalize()
-
 	err := pr.validate()
 	if err != nil {
 		return nil, err
@@ -72,9 +71,12 @@ func (pr *PortRange) UnmarshalText(in []byte) error {
 	}
 
 	result.canonicalize()
+	err := result.validate()
+	if err != nil {
+		return err
+	}
 
-	pr.First = result.First
-	pr.Last = result.Last
+	*pr = result
 	return nil
 }
 

--- a/datacenter/port_range_test.go
+++ b/datacenter/port_range_test.go
@@ -108,6 +108,18 @@ func TestPortRange_UnmarshalText(t *testing.T) {
 			in:     "65536",
 			expErr: true,
 		},
+		"invalid_zero": {
+			in:     "0",
+			expErr: true,
+		},
+		"invalid_begin_zero": {
+			in:     "0-10",
+			expErr: true,
+		},
+		"invalid_end_zero": {
+			in:     "10-0",
+			expErr: true,
+		},
 		"invalid_negative": {
 			in:     "-1",
 			expErr: true,

--- a/datacenter/port_ranges.go
+++ b/datacenter/port_ranges.go
@@ -25,6 +25,7 @@ var (
 type PortRanges []PortRange
 
 func (prs PortRanges) MarshalText() ([]byte, error) {
+	prs.canonicalize()
 	err := prs.validate()
 	if err != nil {
 		return nil, err
@@ -77,11 +78,11 @@ func (prs *PortRanges) UnmarshalText(in []byte) error {
 		result = append(result, pr)
 	}
 
+	result.canonicalize()
 	err := result.validate()
 	if err != nil {
-		return fmt.Errorf("unmarshaling PortRanges %q: %w", string(in), err)
+		return err
 	}
-
 	*prs = result
 	return nil
 }
@@ -99,23 +100,30 @@ func (prs PortRanges) validate() error {
 		return nil
 	}
 
-	// validate the first entry
-	err := prs[0].validate()
+	// make a clone so that we don't modify the underlying array when we
+	// canonicalize it b/c we're supposed to be merely validating
+	clone := make(PortRanges, len(prs))
+	copy(clone, prs)
+
+	clone.canonicalize()
+
+	// validate the first entry in the clone
+	err := clone[0].validate()
 	if err != nil {
-		return fmt.Errorf("validating PortRange at index 0: %w", err)
+		return err
 	}
 
-	// validate and compare to the previous each entry following the first one
-	for i, pr := range prs[1:] {
+	// validate each remaining entry and compare to the previous one
+	for i, pr := range clone[1:] {
 		err = pr.validate()
 		if err != nil {
-			return fmt.Errorf("validating PortRange at index %d: %w", 1+i, err)
+			return err
 		}
 
-		previous := prs[i] // i is indexed off prs[1:], so prs[i] refers to the one before pr
+		previous := clone[i] // i is indexed off clone[1:], so clone[i] refers to the one before pr
 
 		if previous.Last >= pr.First {
-			return fmt.Errorf("PortRanges must be sorted and must not overlap")
+			return fmt.Errorf("ranges must must not overlap")
 		}
 	}
 

--- a/datacenter/port_ranges_test.go
+++ b/datacenter/port_ranges_test.go
@@ -48,17 +48,17 @@ func TestPortRanges_MarshalText(t *testing.T) {
 			},
 			exp: "20-21,80,443",
 		},
+		"out_of_order": {
+			in: datacenter.PortRanges{
+				{First: 81, Last: 81},
+				{First: 80, Last: 80},
+			},
+			exp: "80,81",
+		},
 		"with_invalid_range": {
 			in: datacenter.PortRanges{
 				{First: 20, Last: 21},
 				{First: 0, Last: 10},
-			},
-			expErr: true,
-		},
-		"invalid_order": {
-			in: datacenter.PortRanges{
-				{First: 81, Last: 81},
-				{First: 80, Last: 80},
 			},
 			expErr: true,
 		},
@@ -154,8 +154,20 @@ func TestPortRanges_UnmarshalText(t *testing.T) {
 			in:     "80,,443",
 			expErr: true,
 		},
-		"invalid_nested_range": {
-			in:     "20-21,21-20",
+		"invalid_head_to_tail": {
+			in:     "20-21,21-22",
+			expErr: true,
+		},
+		"invalid_overlap": {
+			in:     "10-20,15-25",
+			expErr: true,
+		},
+		"invalid_a_contains_b": {
+			in:     "10-20,14-16",
+			expErr: true,
+		},
+		"invalid_b_contains_a": {
+			in:     "14-16,10-20",
 			expErr: true,
 		},
 		"invalid_non_numeric": {
@@ -195,7 +207,7 @@ func TestPortRanges_UnmarshalText_DoesNotMutateOnError(t *testing.T) {
 	result := make(datacenter.PortRanges, len(original))
 	copy(result, original)
 
-	err := result.UnmarshalText([]byte("20-21,0"))
+	err := result.UnmarshalText([]byte("abc"))
 	require.Error(t, err)
 	require.Equal(t, original, result)
 }


### PR DESCRIPTION
The `PortRange` and `PortRanges` structs did not agree about validation and canonicalization in their `MarshalText()` and `UnmarshalText()` functions.

This PR ensures that both types will `canonicalize()` and then `validate()` during both `MarshalText()` and `UnmarshalText()`

I'm a little on the fence about _validating_ data during `UnmarshalText()`. The issue is parseable-but-invalid data from the API. Postel's law suggests that we should not, but this is a fairly narrow corner: If the API is using port `0`, or sending overlapping ranges, I think we want to know about it.