### PR TITLE
Add Apstra 6.2.0 to compatibility list

### DIFF
--- a/compatibility/compatibility.go
+++ b/compatibility/compatibility.go
@@ -44,5 +44,6 @@ func SupportedApiVersions() []string {
 		apstra610,
 		apstra611,
 		apstra612,
+		apstra620,
 	}
 }


### PR DESCRIPTION
All tests pass with 6.2.0