### PR TITLE
Introduce `GetSwitchingZoneByMACVRFName()` convenience function

### DIFF
--- a/apstra/query_node.go
+++ b/apstra/query_node.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2023-2025.
+// Copyright (c) Juniper Networks, Inc., 2023-2026.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/apstra/query_node.go
+++ b/apstra/query_node.go
@@ -30,6 +30,7 @@ const (
 	NodeTypeRoutingPolicy
 	NodeTypeRoutingZoneConstraint
 	NodeTypeSecurityZone
+	NodeTypeSwitchingZone
 	NodeTypeSecurityZoneInstance
 	NodeTypeSecurityZonePolicy
 	NodeTypeSystem
@@ -62,6 +63,7 @@ const (
 	nodeTypeRoutingPolicy          = nodeType("routing_policy")
 	nodeTypeRoutingZoneConstraint  = nodeType("routing_zone_constraint")
 	nodeTypeSecurityZone           = nodeType("security_zone")
+	nodeTypeSwitchingZone          = nodeType("switching_zone")
 	nodeTypeSecurityZoneInstance   = nodeType("sz_instance")
 	nodeTypeSecurityZonePolicy     = nodeType("security_zone_policy")
 	nodeTypeSystem                 = nodeType("system")
@@ -125,6 +127,8 @@ func (o NodeType) String() string {
 		return string(nodeTypeRoutingZoneConstraint)
 	case NodeTypeSecurityZone:
 		return string(nodeTypeSecurityZone)
+	case NodeTypeSwitchingZone:
+		return string(nodeTypeSwitchingZone)
 	case NodeTypeSecurityZoneInstance:
 		return string(nodeTypeSecurityZoneInstance)
 	case NodeTypeSecurityZonePolicy:

--- a/apstra/two_stage_l3_clos_switching_zone.go
+++ b/apstra/two_stage_l3_clos_switching_zone.go
@@ -99,6 +99,36 @@ func (c *TwoStageL3ClosClient) GetSwitchingZoneByLabel(ctx context.Context, labe
 	return *result, nil
 }
 
+func (c *TwoStageL3ClosClient) GetSwitchingZoneByMACVRFName(ctx context.Context, macVRFName string) (datacenter.SwitchingZone, error) {
+	items, err := c.GetSwitchingZones(ctx)
+	if err != nil {
+		return datacenter.SwitchingZone{}, err
+	}
+
+	var result *datacenter.SwitchingZone
+	for _, item := range items {
+		if item.MACVRFName != nil && *item.MACVRFName == macVRFName {
+			if result == nil {
+				result = &item
+			} else {
+				return datacenter.SwitchingZone{}, ClientErr{
+					errType: ErrMultipleMatch,
+					err:     fmt.Errorf("found multiple Switching Zones with MAC VRF name %q", macVRFName),
+				}
+			}
+		}
+	}
+
+	if result == nil {
+		return datacenter.SwitchingZone{}, ClientErr{
+			errType: ErrNotfound,
+			err:     fmt.Errorf("no Switching Zone with MAC VRF name %q", macVRFName),
+		}
+	}
+
+	return *result, nil
+}
+
 func (c *TwoStageL3ClosClient) DefaultSwitchingZoneID(ctx context.Context) (*string, error) {
 	if !compatibility.DatacenterSwitchingZoneOK.Check(c.client.apiVersion) {
 		return nil, nil

--- a/compatibility/compatibility.go
+++ b/compatibility/compatibility.go
@@ -44,5 +44,6 @@ func SupportedApiVersions() []string {
 		apstra610,
 		apstra611,
 		apstra612,
+		apstra620,
 	}
 }

--- a/datacenter/route_target.go
+++ b/datacenter/route_target.go
@@ -1,0 +1,126 @@
+// Copyright (c) Juniper Networks, Inc., 2026-2026.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package datacenter
+
+import (
+	"encoding"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"net"
+	"net/netip"
+	"strconv"
+	"strings"
+)
+
+type routeTargetEncoding uint8
+
+const (
+	rtEncodingUnknown    routeTargetEncoding = iota
+	rtEncodingAS2Local4                      // RFC 4360 section 3, selected when parsing text where both parts are <= 65535
+	rtEncodingAS4Local2                      // RFC 5668 (4-octet AS specific extended community)
+	rtEncodingIPv4Local2                     // RFC 4360 section 4
+)
+
+var (
+	_ encoding.TextMarshaler   = (*RouteTarget)(nil)
+	_ encoding.TextUnmarshaler = (*RouteTarget)(nil)
+)
+
+// RouteTarget represents the value outlined in RFC 4360 section 3 and section 4, and RFC 5668. The value is stored in
+// a 6-byte array along with a parameter which indicates how those bytes are to be interpreted. One of:
+// - 2-byte ASN followed by 4-byte numerical value
+// - 4-byte ASN followed by 2-byte numerical value
+// - 4-byte IPv4 address followed by 2-byte numerical value
+type RouteTarget struct {
+	e routeTargetEncoding
+	v [6]byte
+}
+
+func (r RouteTarget) MarshalText() ([]byte, error) {
+	switch r.e {
+	case rtEncodingAS2Local4:
+		v2 := uint64(binary.BigEndian.Uint16(r.v[0:2]))
+		v4 := uint64(binary.BigEndian.Uint32(r.v[2:6]))
+		return []byte(strconv.FormatUint(v2, 10) + ":" + strconv.FormatUint(v4, 10)), nil
+	case rtEncodingAS4Local2:
+		v4 := uint64(binary.BigEndian.Uint32(r.v[0:4]))
+		v2 := uint64(binary.BigEndian.Uint16(r.v[4:6]))
+		return []byte(strconv.FormatUint(v4, 10) + ":" + strconv.FormatUint(v2, 10)), nil
+	case rtEncodingIPv4Local2:
+		ip := net.IP(r.v[0:4])
+		v2 := uint64(binary.BigEndian.Uint16(r.v[4:6]))
+		return []byte(ip.String() + ":" + strconv.FormatUint(v2, 10)), nil
+	case rtEncodingUnknown:
+		return nil, errors.New("cannot marshal route target with unknown encoding")
+	default:
+		return nil, fmt.Errorf("cannot marshal route target with unhandled encoding type %d", r.e)
+	}
+}
+
+// UnmarshalText parses text strings ([]byte) like "1:1", "65535:4294967295", "4294967295:65535" or "192.0.2.1:65535"
+// into the RouteTarget, storing their value and encoding type. Note that in the case of RT strings where both parts
+// are numerical values <= 65535, the rtEncodingAS2Local4 encoding is preferred.
+func (r *RouteTarget) UnmarshalText(text []byte) error {
+	if r == nil {
+		return fmt.Errorf("cannot unmarshal into nil %T", r)
+	}
+
+	parts := strings.Split(string(text), ":")
+	if len(parts) != 2 {
+		return fmt.Errorf("route target %q has invalid format", string(text))
+	}
+
+	var e routeTargetEncoding
+	var v [6]byte
+
+	if n, err := strconv.ParseUint(parts[0], 10, 32); err == nil {
+		if n <= math.MaxUint16 {
+			e = rtEncodingAS2Local4
+			binary.BigEndian.PutUint16(v[0:2], uint16(n))
+		} else {
+			e = rtEncodingAS4Local2
+			binary.BigEndian.PutUint32(v[0:4], uint32(n))
+		}
+	} else {
+		if a, err := netip.ParseAddr(parts[0]); err == nil {
+			if !a.Is4() {
+				return fmt.Errorf("route target %q uses unsupported address", string(text))
+			}
+			e = rtEncodingIPv4Local2
+			*(*[4]byte)(v[:4]) = a.As4() // store IP address in first four bytes of v
+		} else {
+			// cannot parse part 0 as uint nor as ip address
+			return fmt.Errorf("cannot parse 1st part of route target %q", string(text))
+		}
+	}
+
+	switch e {
+	case rtEncodingAS4Local2, rtEncodingIPv4Local2: // part 1 must be 16 bit
+		n, err := strconv.ParseUint(parts[1], 10, 16)
+		if err != nil {
+			return fmt.Errorf("parsing 2nd part of route target %q: %w", string(text), err)
+		}
+		binary.BigEndian.PutUint16(v[4:6], uint16(n))
+	case rtEncodingAS2Local4: // part 1 must be 32 bit
+		n, err := strconv.ParseUint(parts[1], 10, 32)
+		if err != nil {
+			return fmt.Errorf("parsing 2nd part of route target %q: %w", string(text), err)
+		}
+		binary.BigEndian.PutUint32(v[2:6], uint32(n))
+	default:
+		return fmt.Errorf("internal error: failed parsing route target %q", string(text))
+	}
+
+	r.e = e
+	r.v = v
+	return nil
+}
+
+func NewRouteTarget(in string) (RouteTarget, error) {
+	var result RouteTarget
+	return result, result.UnmarshalText([]byte(in))
+}

--- a/datacenter/route_target.go
+++ b/datacenter/route_target.go
@@ -23,6 +23,7 @@ const (
 	rtEncodingAS2Local4                      // RFC 4360 section 3, selected when parsing text where both parts are <= 65535
 	rtEncodingAS4Local2                      // RFC 5668 (4-octet AS specific extended community)
 	rtEncodingIPv4Local2                     // RFC 4360 section 4
+	rtEncodingNull                           // marshals to `null` - useful for clearing values from the API
 )
 
 var (
@@ -54,6 +55,8 @@ func (r RouteTarget) MarshalText() ([]byte, error) {
 		ip := net.IP(r.v[0:4])
 		v2 := uint64(binary.BigEndian.Uint16(r.v[4:6]))
 		return []byte(ip.String() + ":" + strconv.FormatUint(v2, 10)), nil
+	case rtEncodingNull:
+		return []byte("null"), nil
 	case rtEncodingUnknown:
 		return nil, errors.New("cannot marshal route target with unknown encoding")
 	default:
@@ -64,9 +67,16 @@ func (r RouteTarget) MarshalText() ([]byte, error) {
 // UnmarshalText parses text strings ([]byte) like "1:1", "65535:4294967295", "4294967295:65535" or "192.0.2.1:65535"
 // into the RouteTarget, storing their value and encoding type. Note that in the case of RT strings where both parts
 // are numerical values <= 65535, the rtEncodingAS2Local4 encoding is preferred.
+// The string "null" unmarshals into a RouteTarget with rtEncodingNull.
 func (r *RouteTarget) UnmarshalText(text []byte) error {
 	if r == nil {
 		return fmt.Errorf("cannot unmarshal into nil %T", r)
+	}
+
+	if string(text) == "null" {
+		r.e = rtEncodingNull
+		clear(r.v[:])
+		return nil
 	}
 
 	parts := strings.Split(string(text), ":")

--- a/datacenter/route_target.go
+++ b/datacenter/route_target.go
@@ -7,6 +7,7 @@ package datacenter
 import (
 	"encoding"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -29,6 +30,7 @@ const (
 var (
 	_ encoding.TextMarshaler   = (*RouteTarget)(nil)
 	_ encoding.TextUnmarshaler = (*RouteTarget)(nil)
+	_ json.Marshaler           = (*RouteTarget)(nil)
 )
 
 // RouteTarget represents the value outlined in RFC 4360 section 3 and section 4, and RFC 5668. The value is stored in
@@ -39,6 +41,20 @@ var (
 type RouteTarget struct {
 	e routeTargetEncoding
 	v [6]byte
+}
+
+// MarshalJSON implements json.Marshaler. It emits the JSON null keyword for
+// rtEncodingNull, and a quoted string for all other encoding types.
+func (r RouteTarget) MarshalJSON() ([]byte, error) {
+	if r.e == rtEncodingNull {
+		return []byte("null"), nil
+	}
+
+	b, err := r.MarshalText()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(string(b))
 }
 
 func (r RouteTarget) MarshalText() ([]byte, error) {
@@ -56,11 +72,11 @@ func (r RouteTarget) MarshalText() ([]byte, error) {
 		v2 := uint64(binary.BigEndian.Uint16(r.v[4:6]))
 		return []byte(ip.String() + ":" + strconv.FormatUint(v2, 10)), nil
 	case rtEncodingNull:
-		return []byte("null"), nil
+		return nil, errors.New("cannot marshal route target text with null encoding")
 	case rtEncodingUnknown:
-		return nil, errors.New("cannot marshal route target with unknown encoding")
+		return nil, errors.New("cannot marshal route target text with unknown encoding")
 	default:
-		return nil, fmt.Errorf("cannot marshal route target with unhandled encoding type %d", r.e)
+		return nil, fmt.Errorf("cannot marshal route target text with unhandled encoding type %d", r.e)
 	}
 }
 

--- a/datacenter/route_target_test.go
+++ b/datacenter/route_target_test.go
@@ -1,0 +1,182 @@
+// Copyright (c) Juniper Networks, Inc., 2026-2026.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package datacenter
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRouteTarget_MarshalText(t *testing.T) {
+	type testCase struct {
+		in     RouteTarget
+		exp    string
+		expErr bool
+	}
+
+	mkAS2 := func(asn uint16, local uint32) RouteTarget {
+		var rt RouteTarget
+		rt.e = rtEncodingAS2Local4
+		binary.BigEndian.PutUint16(rt.v[0:2], asn)
+		binary.BigEndian.PutUint32(rt.v[2:6], local)
+		return rt
+	}
+
+	mkAS4 := func(asn uint32, local uint16) RouteTarget {
+		var rt RouteTarget
+		rt.e = rtEncodingAS4Local2
+		binary.BigEndian.PutUint32(rt.v[0:4], asn)
+		binary.BigEndian.PutUint16(rt.v[4:6], local)
+		return rt
+	}
+
+	mkIPv4 := func(a, b, c, d byte, local uint16) RouteTarget {
+		var rt RouteTarget
+		rt.e = rtEncodingIPv4Local2
+		rt.v[0], rt.v[1], rt.v[2], rt.v[3] = a, b, c, d
+		binary.BigEndian.PutUint16(rt.v[4:6], local)
+		return rt
+	}
+
+	testCases := map[string]testCase{
+		"as2_local4": {
+			in:  mkAS2(65000, 123456),
+			exp: "65000:123456",
+		},
+		"as4_local2": {
+			in:  mkAS4(70000, 321),
+			exp: "70000:321",
+		},
+		"ipv4_local2": {
+			in:  mkIPv4(192, 0, 2, 1, 456),
+			exp: "192.0.2.1:456",
+		},
+		"unknown": {
+			in:     RouteTarget{},
+			expErr: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, err := tc.in.MarshalText()
+			if tc.expErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.exp, string(got))
+		})
+	}
+}
+
+func TestRouteTarget_UnmarshalText(t *testing.T) {
+	type testCase struct {
+		in     string
+		exp    RouteTarget
+		expErr bool
+	}
+
+	mkAS2 := func(asn uint16, local uint32) [6]byte {
+		var v [6]byte
+		binary.BigEndian.PutUint16(v[0:2], asn)
+		binary.BigEndian.PutUint32(v[2:6], local)
+		return v
+	}
+
+	mkAS4 := func(asn uint32, local uint16) [6]byte {
+		var v [6]byte
+		binary.BigEndian.PutUint32(v[0:4], asn)
+		binary.BigEndian.PutUint16(v[4:6], local)
+		return v
+	}
+
+	mkIPv4 := func(a, b, c, d byte, local uint16) [6]byte {
+		var v [6]byte
+		v[0], v[1], v[2], v[3] = a, b, c, d
+		binary.BigEndian.PutUint16(v[4:6], local)
+		return v
+	}
+
+	testCases := map[string]testCase{
+		"as2_local4": {
+			in:  "65000:123456",
+			exp: RouteTarget{e: rtEncodingAS2Local4, v: mkAS2(65000, 123456)},
+		},
+		"as4_local2": {
+			in:  "70000:321",
+			exp: RouteTarget{e: rtEncodingAS4Local2, v: mkAS4(70000, 321)},
+		},
+		"ipv4_local2": {
+			in:  "192.0.2.1:456",
+			exp: RouteTarget{e: rtEncodingIPv4Local2, v: mkIPv4(192, 0, 2, 1, 456)},
+		},
+		"ambiguous_prefers_as2": {
+			in:  "1:1",
+			exp: RouteTarget{e: rtEncodingAS2Local4, v: mkAS2(1, 1)},
+		},
+		"bad_format": {
+			in:     "1",
+			expErr: true,
+		},
+		"bad_part0": {
+			in:     "abc:1",
+			expErr: true,
+		},
+		"bad_part1": {
+			in:     "1:abc",
+			expErr: true,
+		},
+		"bad_ipv6": {
+			in:     "3fff::/64:65536",
+			expErr: true,
+		},
+		"as4_part0_overflow": {
+			in:     "4294967296:1",
+			expErr: true,
+		},
+		"as2_part1_overflow": {
+			in:     "1:4294967296",
+			expErr: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var got RouteTarget
+			err := got.UnmarshalText([]byte(tc.in))
+			if tc.expErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.exp, got)
+		})
+	}
+}
+
+func TestRouteTarget_RoundTrip(t *testing.T) {
+	inputs := []string{
+		"65000:123456",
+		"70000:321",
+		"192.0.2.1:456",
+		"1:1",
+	}
+
+	for _, in := range inputs {
+		t.Run(in, func(t *testing.T) {
+			rt, err := NewRouteTarget(in)
+			require.NoError(t, err)
+
+			out, err := rt.MarshalText()
+			require.NoError(t, err)
+			require.Equal(t, in, string(out))
+		})
+	}
+}

--- a/datacenter/route_target_test.go
+++ b/datacenter/route_target_test.go
@@ -55,6 +55,10 @@ func TestRouteTarget_MarshalText(t *testing.T) {
 			in:  mkIPv4(192, 0, 2, 1, 456),
 			exp: "192.0.2.1:456",
 		},
+		"null": {
+			in:  RouteTarget{e: rtEncodingNull},
+			exp: "null",
+		},
 		"unknown": {
 			in:     RouteTarget{},
 			expErr: true,
@@ -120,6 +124,14 @@ func TestRouteTarget_UnmarshalText(t *testing.T) {
 			in:  "1:1",
 			exp: RouteTarget{e: rtEncodingAS2Local4, v: mkAS2(1, 1)},
 		},
+		"null": {
+			in:  "null",
+			exp: RouteTarget{e: rtEncodingNull, v: mkAS2(0, 0)},
+		},
+		"empty": {
+			in:     "",
+			expErr: true,
+		},
 		"bad_format": {
 			in:     "1",
 			expErr: true,
@@ -167,6 +179,7 @@ func TestRouteTarget_RoundTrip(t *testing.T) {
 		"70000:321",
 		"192.0.2.1:456",
 		"1:1",
+		"null",
 	}
 
 	for _, in := range inputs {

--- a/datacenter/route_target_test.go
+++ b/datacenter/route_target_test.go
@@ -6,6 +6,7 @@ package datacenter
 
 import (
 	"encoding/binary"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -56,8 +57,8 @@ func TestRouteTarget_MarshalText(t *testing.T) {
 			exp: "192.0.2.1:456",
 		},
 		"null": {
-			in:  RouteTarget{e: rtEncodingNull},
-			exp: "null",
+			in:     RouteTarget{e: rtEncodingNull},
+			expErr: true,
 		},
 		"unknown": {
 			in:     RouteTarget{},
@@ -179,7 +180,6 @@ func TestRouteTarget_RoundTrip(t *testing.T) {
 		"70000:321",
 		"192.0.2.1:456",
 		"1:1",
-		"null",
 	}
 
 	for _, in := range inputs {
@@ -192,4 +192,99 @@ func TestRouteTarget_RoundTrip(t *testing.T) {
 			require.Equal(t, in, string(out))
 		})
 	}
+}
+
+func TestRouteTarget_MarshalJSON(t *testing.T) {
+	type testCase struct {
+		in     RouteTarget
+		exp    string // expected raw JSON bytes
+		expErr bool
+	}
+
+	mkAS2 := func(asn uint16, local uint32) RouteTarget {
+		var rt RouteTarget
+		rt.e = rtEncodingAS2Local4
+		binary.BigEndian.PutUint16(rt.v[0:2], asn)
+		binary.BigEndian.PutUint32(rt.v[2:6], local)
+		return rt
+	}
+
+	mkAS4 := func(asn uint32, local uint16) RouteTarget {
+		var rt RouteTarget
+		rt.e = rtEncodingAS4Local2
+		binary.BigEndian.PutUint32(rt.v[0:4], asn)
+		binary.BigEndian.PutUint16(rt.v[4:6], local)
+		return rt
+	}
+
+	mkIPv4 := func(a, b, c, d byte, local uint16) RouteTarget {
+		var rt RouteTarget
+		rt.e = rtEncodingIPv4Local2
+		rt.v[0], rt.v[1], rt.v[2], rt.v[3] = a, b, c, d
+		binary.BigEndian.PutUint16(rt.v[4:6], local)
+		return rt
+	}
+
+	testCases := map[string]testCase{
+		"null_encoding_produces_json_null_keyword": {
+			in:  RouteTarget{e: rtEncodingNull},
+			exp: `null`,
+		},
+		"unknown_encoding_is_error": {
+			in:     RouteTarget{},
+			expErr: true,
+		},
+		"as2_produces_json_string": {
+			in:  mkAS2(65000, 123456),
+			exp: `"65000:123456"`,
+		},
+		"as4_produces_json_string": {
+			in:  mkAS4(70000, 321),
+			exp: `"70000:321"`,
+		},
+		"ipv4_produces_json_string": {
+			in:  mkIPv4(192, 0, 2, 1, 456),
+			exp: `"192.0.2.1:456"`,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, err := tc.in.MarshalJSON()
+			if tc.expErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.exp, string(got))
+		})
+	}
+}
+
+func TestRouteTarget_MarshalJSON_InStruct(t *testing.T) {
+	// Verify that encoding/json uses MarshalJSON (not MarshalText) when
+	// marshaling a struct containing a RouteTarget.
+	type payload struct {
+		RT RouteTarget `json:"rt"`
+	}
+
+	t.Run("null_field_is_json_null", func(t *testing.T) {
+		p := payload{RT: RouteTarget{e: rtEncodingNull}}
+		b, err := json.Marshal(p)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"rt": null}`, string(b))
+	})
+
+	t.Run("as2_field_is_json_string", func(t *testing.T) {
+		var rt RouteTarget
+		rt.e = rtEncodingAS2Local4
+		binary.BigEndian.PutUint16(rt.v[0:2], 65000)
+		binary.BigEndian.PutUint32(rt.v[2:6], 123456)
+
+		p := payload{RT: rt}
+		b, err := json.Marshal(p)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"rt": "65000:123456"}`, string(b))
+	})
 }

--- a/datacenter/switching_zone.go
+++ b/datacenter/switching_zone.go
@@ -25,7 +25,7 @@ type SwitchingZone struct {
 	MACVRFDescription *string                              `json:"mac_vrf_description,omitempty"`
 	MACVRFName        *string                              `json:"mac_vrf_name,omitempty"`
 	MACVRFServiceType *enum.SwitchingZoneMACVRFServiceType `json:"mac_vrf_service_type,omitempty"`
-	RouteTarget       *string                              `json:"route_target,omitempty"`
+	RouteTarget       *RouteTarget                         `json:"route_target,omitempty"`
 	Tags              []string                             `json:"tags,omitempty"`
 	id                string
 }

--- a/datacenter/switching_zone_integration_test.go
+++ b/datacenter/switching_zone_integration_test.go
@@ -28,6 +28,12 @@ func TestSwitchingZone_CRUD(t *testing.T) {
 	ctx := testutils.ContextWithTestID(context.Background(), t)
 	clients := testclient.GetTestClients(t, ctx)
 
+	newRT := func(t testing.TB, s string) *datacenter.RouteTarget {
+		var result datacenter.RouteTarget
+		require.NoError(t, result.UnmarshalText([]byte(s)))
+		return &result
+	}
+
 	type testCase struct {
 		constraints []compatibility.Constraint
 		create      datacenter.SwitchingZone
@@ -42,12 +48,14 @@ func TestSwitchingZone_CRUD(t *testing.T) {
 				MACVRFDescription: pointer.To(testutils.RandString(6, "hex")),
 				MACVRFName:        pointer.To(testutils.RandString(6, "hex")),
 				MACVRFServiceType: pointer.To(enum.SwitchingZoneMACVRFServiceTypeVLANAware),
-				RouteTarget:       pointer.To(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)), Tags: nil,
+				RouteTarget:       newRT(t, fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
+				Tags:              nil,
 			},
 			update: datacenter.SwitchingZone{
 				Label:             pointer.To(testutils.RandString(6, "hex")),
 				MACVRFDescription: pointer.To(testutils.RandString(6, "hex")),
-				RouteTarget:       pointer.To(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)), Tags: nil,
+				RouteTarget:       newRT(t, fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
+				Tags:              nil,
 			},
 		},
 		"vlan_bundle": {
@@ -57,12 +65,14 @@ func TestSwitchingZone_CRUD(t *testing.T) {
 				MACVRFDescription: pointer.To(testutils.RandString(6, "hex")),
 				MACVRFName:        pointer.To(testutils.RandString(6, "hex")),
 				MACVRFServiceType: pointer.To(enum.SwitchingZoneMACVRFServiceTypeVLANBundle),
-				RouteTarget:       pointer.To(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)), Tags: nil,
+				RouteTarget:       newRT(t, fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
+				Tags:              nil,
 			},
 			update: datacenter.SwitchingZone{
 				Label:             pointer.To(testutils.RandString(6, "hex")),
 				MACVRFDescription: pointer.To(testutils.RandString(6, "hex")),
-				RouteTarget:       pointer.To(fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)), Tags: nil,
+				RouteTarget:       newRT(t, fmt.Sprintf("%d:%d", rand.Intn(math.MaxUint16)+1, rand.Intn(math.MaxUint16)+1)),
+				Tags:              nil,
 			},
 		},
 	}

--- a/datacenter/switching_zone_integration_test.go
+++ b/datacenter/switching_zone_integration_test.go
@@ -117,6 +117,17 @@ func TestSwitchingZone_CRUD(t *testing.T) {
 						require.Equal(t, id, *idPtr)
 						comparedatacenter.SwitchingZone(t, create, obj)
 					}
+
+					// retrieve the object by MAC VRF name and validate
+					if create.MACVRFName != nil {
+						obj, err = bp.GetSwitchingZoneByMACVRFName(ctx, *create.MACVRFName)
+						require.NoError(t, err)
+						idPtr = obj.ID()
+						require.NotNil(t, idPtr)
+						require.Equal(t, id, *idPtr)
+						comparedatacenter.SwitchingZone(t, create, obj)
+					}
+
 					// retrieve the list of IDs - ours must be in there
 					ids, err := bp.ListSwitchingZones(ctx)
 					require.NoError(t, err)
@@ -164,6 +175,14 @@ func TestSwitchingZone_CRUD(t *testing.T) {
 					// get the object by label
 					if create.Label != nil {
 						_, err = bp.GetSwitchingZoneByLabel(ctx, *create.Label)
+						require.Error(t, err)
+						require.ErrorAs(t, err, &ace)
+						require.Equal(t, apstra.ErrNotfound, ace.Type())
+					}
+
+					// get the object by MAC VRF name
+					if create.MACVRFName != nil {
+						_, err = bp.GetSwitchingZoneByMACVRFName(ctx, *create.MACVRFName)
 						require.Error(t, err)
 						require.ErrorAs(t, err, &ace)
 						require.Equal(t, apstra.ErrNotfound, ace.Type())

--- a/datacenter/switching_zone_test.go
+++ b/datacenter/switching_zone_test.go
@@ -31,6 +31,12 @@ func TestSwitchingZone_ID_SetID(t *testing.T) {
 }
 
 func TestSwitchingZone_MarshalJSON(t *testing.T) {
+	newRT := func(t testing.TB, s string) *datacenter.RouteTarget {
+		var result datacenter.RouteTarget
+		require.NoError(t, result.UnmarshalText([]byte(s)))
+		return &result
+	}
+
 	type testCase struct {
 		d datacenter.SwitchingZone
 		e string
@@ -43,7 +49,7 @@ func TestSwitchingZone_MarshalJSON(t *testing.T) {
 				MACVRFDescription: pointer.To("description1"),
 				MACVRFName:        pointer.To("name1"),
 				MACVRFServiceType: pointer.To(enum.SwitchingZoneMACVRFServiceTypeVLANAware),
-				RouteTarget:       pointer.To("1:1"),
+				RouteTarget:       newRT(t, "1:1"),
 				Tags:              []string{"tag1", "tag2"},
 			},
 			e: `{
@@ -62,7 +68,7 @@ func TestSwitchingZone_MarshalJSON(t *testing.T) {
 				MACVRFDescription: pointer.To("description2"),
 				MACVRFName:        pointer.To("name2"),
 				MACVRFServiceType: pointer.To(enum.SwitchingZoneMACVRFServiceTypeVLANBundle),
-				RouteTarget:       pointer.To("2:2"),
+				RouteTarget:       newRT(t, "2:2"),
 				Tags:              []string{"tag3", "tag4"},
 			},
 			e: `{
@@ -88,6 +94,12 @@ func TestSwitchingZone_MarshalJSON(t *testing.T) {
 }
 
 func TestSwitchingZone_UnmarshalJSON(t *testing.T) {
+	newRT := func(t testing.TB, s string) *datacenter.RouteTarget {
+		var result datacenter.RouteTarget
+		require.NoError(t, result.UnmarshalText([]byte(s)))
+		return &result
+	}
+
 	type testCase struct {
 		d   string
 		e   datacenter.SwitchingZone
@@ -111,7 +123,7 @@ func TestSwitchingZone_UnmarshalJSON(t *testing.T) {
 				MACVRFDescription: pointer.To("description1"),
 				MACVRFName:        pointer.To("name1"),
 				MACVRFServiceType: pointer.To(enum.SwitchingZoneMACVRFServiceTypeVLANAware),
-				RouteTarget:       pointer.To("1:1"),
+				RouteTarget:       newRT(t, "1:1"),
 				Tags:              []string{"tag1", "tag2"},
 			},
 			eid: "abc",
@@ -132,7 +144,7 @@ func TestSwitchingZone_UnmarshalJSON(t *testing.T) {
 				MACVRFDescription: pointer.To("description2"),
 				MACVRFName:        pointer.To("name2"),
 				MACVRFServiceType: pointer.To(enum.SwitchingZoneMACVRFServiceTypeVLANBundle),
-				RouteTarget:       pointer.To("2:2"),
+				RouteTarget:       newRT(t, "2:2"),
 				Tags:              []string{"tag3", "tag4"},
 			},
 			eid: "def",


### PR DESCRIPTION
Same logic as `GetSwitchingZoneByLabel()`, will be used by terraform data source.

Tested with 6.2.0.