### PR TITLE
Introduce VLAN attribute to "VN Single" CT object

### DIFF
--- a/apstra/two_stage_l3_clos_connectivity_template_integration_test.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_integration_test.go
@@ -17,7 +17,11 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/Juniper/apstra-go-sdk/datacenter"
+	"github.com/Juniper/apstra-go-sdk/enum"
+	"github.com/Juniper/apstra-go-sdk/internal/pointer"
 	"github.com/hashicorp/go-version"
+	"github.com/stretchr/testify/require"
 )
 
 func compareCts(t testing.TB, a, b *ConnectivityTemplate, info string) {
@@ -159,10 +163,33 @@ func TestCreateGetUpdateDeleteCT(t *testing.T) {
 			}
 
 			bpClient := testBlueprintA(ctx, t, client.client)
+			rzLabel := randString(6, "hex")
+			testRZ, err := bpClient.CreateSecurityZone(ctx, datacenter.SecurityZone{
+				Label:   rzLabel,
+				Type:    enum.SecurityZoneTypeEVPN,
+				VRFName: rzLabel,
+			})
+			require.NoError(t, err)
+
+			leafIDs, err := getSystemIdsByRole(ctx, bpClient, "leaf")
+			require.NoError(t, err)
+			require.Greater(t, len(leafIDs), 0)
+			bindings := make([]datacenter.VNBinding, 0, len(leafIDs))
+			for _, leafID := range leafIDs {
+				bindings = append(bindings, datacenter.VNBinding{SystemID: string(leafID)})
+			}
+
+			testVN, err := bpClient.CreateVirtualNetwork(ctx, datacenter.VirtualNetwork{
+				Bindings:       bindings,
+				Label:          randString(6, "hex"),
+				Type:           enum.VnTypeVxlan,
+				SecurityZoneID: testRZ,
+			})
+			require.NoError(t, err)
 
 			apiVersion := version.Must(version.NewVersion(bpClient.client.apiVersion.String()))
 
-			sz, err := bpClient.GetSecurityZoneByVRFName(ctx, "default")
+			defaultRZ, err := bpClient.GetSecurityZoneByVRFName(ctx, "default")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -194,7 +221,7 @@ func TestCreateGetUpdateDeleteCT(t *testing.T) {
 						Subpolicies: []*ConnectivityTemplatePrimitive{
 							{
 								Attributes: &ConnectivityTemplatePrimitiveAttributesAttachLogicalLink{
-									SecurityZone:       (*ObjectId)(sz.ID()),
+									SecurityZone:       (*ObjectId)(defaultRZ.ID()),
 									Tagged:             false,
 									IPv4AddressingType: CtPrimitiveIPv4AddressingTypeNumbered,
 									IPv6AddressingType: CtPrimitiveIPv6AddressingTypeLinkLocal,
@@ -202,7 +229,7 @@ func TestCreateGetUpdateDeleteCT(t *testing.T) {
 							},
 							{
 								Attributes: &ConnectivityTemplatePrimitiveAttributesAttachLogicalLink{
-									SecurityZone:       (*ObjectId)(sz.ID()),
+									SecurityZone:       (*ObjectId)(defaultRZ.ID()),
 									Tagged:             true,
 									Vlan:               &vlan10,
 									IPv4AddressingType: CtPrimitiveIPv4AddressingTypeNumbered,
@@ -242,7 +269,7 @@ func TestCreateGetUpdateDeleteCT(t *testing.T) {
 						Subpolicies: []*ConnectivityTemplatePrimitive{
 							{
 								Attributes: &ConnectivityTemplatePrimitiveAttributesAttachLogicalLink{
-									SecurityZone:       (*ObjectId)(sz.ID()),
+									SecurityZone:       (*ObjectId)(defaultRZ.ID()),
 									Tagged:             false,
 									IPv4AddressingType: CtPrimitiveIPv4AddressingTypeNumbered,
 									IPv6AddressingType: CtPrimitiveIPv6AddressingTypeLinkLocal,
@@ -254,10 +281,29 @@ func TestCreateGetUpdateDeleteCT(t *testing.T) {
 					},
 					eStatus: CtPrimitiveStatusReady,
 				},
+				"vn_single_with_vlan_id": {
+					versionConstraint: version.MustConstraints(version.NewConstraint(">=6.2.0")),
+					ct: ConnectivityTemplate{
+						Label:       randString(5, "hex"),
+						Description: randString(10, "hex"),
+						Subpolicies: []*ConnectivityTemplatePrimitive{
+							{
+								Label: randString(6, "hex"),
+								Attributes: &ConnectivityTemplatePrimitiveAttributesAttachSingleVlan{
+									Label:    randString(6, "hex"),
+									Tagged:   true,
+									VnNodeId: pointer.To(ObjectId(testVN)),
+									VLAN:     pointer.To(1000 + uint16(rand.Intn(1000))),
+								},
+							},
+						},
+						Tags: randomTags,
+					},
+					eStatus: CtPrimitiveStatusReady,
+				},
 			}
 
 			for tName, tCase := range testCases {
-				tName, tCase := tName, tCase
 				t.Run(tName, func(t *testing.T) {
 					if tCase.versionConstraint != nil && !tCase.versionConstraint.Check(apiVersion) {
 						t.Skipf("skipping test case %q because it cannot be run with Apstra %s", tName, apiVersion)

--- a/apstra/two_stage_l3_clos_connectivity_template_primitive_attributes.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_primitive_attributes.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+
+	"github.com/Juniper/apstra-go-sdk/internal/pointer"
 )
 
 // ConnectivityTemplatePrimitiveAttributes are the data structures which make the various
@@ -29,6 +31,7 @@ type ConnectivityTemplatePrimitiveAttributesAttachSingleVlan struct {
 	Label    string
 	Tagged   bool
 	VnNodeId *ObjectId
+	VLAN     *uint16
 }
 
 func (o *ConnectivityTemplatePrimitiveAttributesAttachSingleVlan) fromRawJson(in json.RawMessage) error {
@@ -42,16 +45,16 @@ func (o *ConnectivityTemplatePrimitiveAttributesAttachSingleVlan) fromRawJson(in
 }
 
 func (o *ConnectivityTemplatePrimitiveAttributesAttachSingleVlan) raw() (json.RawMessage, error) {
-	var tagType string
-	if o.Tagged {
-		tagType = "vlan_tagged"
-	} else {
-		tagType = "untagged"
+	raw := rawConnectivityTemplatePrimitiveAttributesAttachSingleVlan{
+		// TagType:  "", // handled below
+		VnNodeId: pointer.ToCopyOfValue(o.VnNodeId),
+		VLAN:     pointer.ToCopyOfValue(o.VLAN),
 	}
 
-	raw := rawConnectivityTemplatePrimitiveAttributesAttachSingleVlan{
-		TagType:  tagType,
-		VnNodeId: o.VnNodeId,
+	if o.Tagged {
+		raw.TagType = "vlan_tagged"
+	} else {
+		raw.TagType = "untagged"
 	}
 
 	return json.Marshal(&raw)
@@ -616,21 +619,21 @@ func (o *ConnectivityTemplatePrimitiveAttributesAttachRoutingZoneConstraint) fro
 type rawConnectivityTemplatePrimitiveAttributesAttachSingleVlan struct {
 	VnNodeId *ObjectId `json:"vn_node_id"`
 	TagType  string    `json:"tag_type"`
+	VLAN     *uint16   `json:"vlan_id"`
 }
 
 func (o rawConnectivityTemplatePrimitiveAttributesAttachSingleVlan) polish(t *ConnectivityTemplatePrimitiveAttributesAttachSingleVlan) error {
-	var tagged bool
 	switch o.TagType {
 	case "vlan_tagged":
-		tagged = true
+		t.Tagged = true
 	case "untagged":
-		tagged = false
+		t.Tagged = false
 	default:
 		return fmt.Errorf("unexpected tag_type %q", o.TagType)
 	}
 
-	t.Tagged = tagged
-	t.VnNodeId = o.VnNodeId
+	t.VnNodeId = pointer.ToCopyOfValue(o.VnNodeId)
+	t.VLAN = pointer.ToCopyOfValue(o.VLAN)
 
 	return nil
 }

--- a/apstra/two_stage_l3_clos_connectivity_template_primitive_attributes.go
+++ b/apstra/two_stage_l3_clos_connectivity_template_primitive_attributes.go
@@ -635,6 +635,10 @@ func (o rawConnectivityTemplatePrimitiveAttributesAttachSingleVlan) polish(t *Co
 	t.VnNodeId = pointer.ToCopyOfValue(o.VnNodeId)
 	t.VLAN = pointer.ToCopyOfValue(o.VLAN)
 
+	if t.VLAN != nil && *t.VLAN == 0 {
+		t.VLAN = nil // API may return 0 when no override VLAN is specified - fix it
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Apstra 6.2.0 introduced the `vlan_id` attribute to the VN single JSON schema.

This PR adds that attribute, along with a test case which exercises 6.2.0+ only.

**Odds and Ends:**
- added some test objects (RZ, leaf IDs, VN, bindings) required to exercise the new test case
- renamed `sz` (default security zone ID) to `defaultRZ`
- minor restructure of logic of `ConnectivityTemplatePrimitiveAttributesAttachSingleVlan` type's `raw()` and `polish()` methods.

Closes #756