### PR TITLE
6.2.0 error string quotes node ids

### DIFF
--- a/apstra/talk_to_api_ops.go
+++ b/apstra/talk_to_api_ops.go
@@ -130,7 +130,7 @@ func (o *Client) talkToApiOps(ctx context.Context, in *talkToApstraIn) error {
 	if resp.StatusCode/100 != 2 {
 		req.URL = apstraUrl
 		req.URL.Host = "api-ops"
-		return newTalkToApstraErr(req, requestBody, resp, fmt.Sprintf("API-ops proxy response code: %d", resp.StatusCode))
+		return newTalkToApstraErr(req, requestBody, resp, fmt.Sprintf("API-ops proxy response code: %d", resp.StatusCode), o.apiVersion)
 	}
 
 	var proxyResponse struct {
@@ -147,7 +147,7 @@ func (o *Client) talkToApiOps(ctx context.Context, in *talkToApstraIn) error {
 	if proxyResponse.ErrorMsg != "" {
 		req.URL = apstraUrl
 		req.URL.Host = "api-ops"
-		return newTalkToApstraErr(req, requestBody, resp, fmt.Sprintf("API-ops proxy error message for transaction %s: %s", proxyResponse.Uid, proxyResponse.ErrorMsg))
+		return newTalkToApstraErr(req, requestBody, resp, fmt.Sprintf("API-ops proxy error message for transaction %s: %s", proxyResponse.Uid, proxyResponse.ErrorMsg), o.apiVersion)
 	}
 	// we'll check the proxied status code (the one from AOS) later, after we've assembled a stunt-double http response
 
@@ -225,7 +225,7 @@ func (o *Client) talkToApiOps(ctx context.Context, in *talkToApstraIn) error {
 	if innerResp.StatusCode/100 != 2 {
 		req.URL = apstraUrl
 		req.URL.Host = "api-ops"
-		return newTalkToApstraErr(req, msg.Body, innerResp, "")
+		return newTalkToApstraErr(req, msg.Body, innerResp, "", o.apiVersion)
 	}
 
 	// If the caller gave us an httpBodyWriter, copy the response body into it and return
@@ -243,7 +243,7 @@ func (o *Client) talkToApiOps(ctx context.Context, in *talkToApstraIn) error {
 	if err != nil {
 		req.URL = apstraUrl
 		req.URL.Host = "api-ops"
-		return newTalkToApstraErr(req, requestBody, innerResp, fmt.Sprintf("error peeking response body: %v", err))
+		return newTalkToApstraErr(req, requestBody, innerResp, fmt.Sprintf("error peeking response body: %v", err), o.apiVersion)
 	}
 
 	// no task ID response, so no polling tomfoolery required
@@ -274,7 +274,7 @@ func (o *Client) talkToApiOps(ctx context.Context, in *talkToApstraIn) error {
 	case bpId == "" && tIdR.BlueprintId == "":
 		req.URL = apstraUrl
 		req.URL.Host = "api-ops"
-		return newTalkToApstraErr(req, requestBody, innerResp, "blueprint id not found in url nor in response body")
+		return newTalkToApstraErr(req, requestBody, innerResp, "blueprint id not found in url nor in response body", o.apiVersion)
 	case bpId == "":
 		bpId = tIdR.BlueprintId
 	}
@@ -326,6 +326,7 @@ func (o *Client) talkToApiOps(ctx context.Context, in *talkToApstraIn) error {
 			Request:  request,
 			Response: response,
 			Msg:      string(dsMsg),
+			Version:  o.apiVersion,
 		}
 	}
 

--- a/apstra/talk_to_apstra.go
+++ b/apstra/talk_to_apstra.go
@@ -282,20 +282,20 @@ func (o *Client) talkToApstra(ctx context.Context, in *talkToApstraIn) error {
 			if strings.HasSuffix(apstraUrl.Path, apiUrlUserLogin) {
 				return newTalkToApstraErr(req, requestBody, resp,
 					fmt.Sprintf("http %d at '%s' - check username/password",
-						resp.StatusCode, apstraUrl))
+						resp.StatusCode, apstraUrl), o.apiVersion)
 			}
 
 			// Auth fail with "doNotLogin == true" is fatal for this transaction
 			if in.doNotLogin {
 				return newTalkToApstraErr(req, requestBody, resp,
 					fmt.Sprintf("http %d at '%s' and doNotLogin is %t",
-						resp.StatusCode, apstraUrl, in.doNotLogin))
+						resp.StatusCode, apstraUrl, in.doNotLogin), o.apiVersion)
 			}
 
 			if _, ok := os.LookupEnv(envAosOpsEdgeId); ok {
 				return newTalkToApstraErr(req, requestBody, resp,
 					fmt.Sprintf("http %d at '%s' and %s has been set",
-						resp.StatusCode, apstraUrl, envAosOpsEdgeId))
+						resp.StatusCode, apstraUrl, envAosOpsEdgeId), o.apiVersion)
 			}
 
 			o.logStr(1, fmt.Sprintf("got http %d '%s' at '%s' attempting login", resp.StatusCode, resp.Status, apstraUrl.String()))
@@ -310,7 +310,7 @@ func (o *Client) talkToApstra(ctx context.Context, in *talkToApstraIn) error {
 			return o.talkToApstra(ctx, in)
 		} // HTTP 401
 
-		return newTalkToApstraErr(req, requestBody, resp, "")
+		return newTalkToApstraErr(req, requestBody, resp, "", o.apiVersion)
 	}
 
 	// noinspection GoUnhandledErrorResult
@@ -329,7 +329,7 @@ func (o *Client) talkToApstra(ctx context.Context, in *talkToApstraIn) error {
 	var tIdR taskIdResponse
 	taskResponseFound, err := peekParseResponseBodyAsTaskId(resp, &tIdR)
 	if err != nil {
-		return newTalkToApstraErr(req, requestBody, resp, fmt.Sprintf("error peeking response body: %v", err))
+		return newTalkToApstraErr(req, requestBody, resp, fmt.Sprintf("error peeking response body: %v", err), o.apiVersion)
 	}
 
 	// no task ID response, so no polling tomfoolery required
@@ -358,7 +358,7 @@ func (o *Client) talkToApstra(ctx context.Context, in *talkToApstraIn) error {
 	case (bpId != "" && tIdR.BlueprintId != "") && (bpId != tIdR.BlueprintId):
 		return fmt.Errorf("blueprint Id in URL ('%s') and returned object body ('%s') don't match", bpId, tIdR.BlueprintId)
 	case bpId == "" && tIdR.BlueprintId == "":
-		return newTalkToApstraErr(req, requestBody, resp, "blueprint id not found in url nor in response body")
+		return newTalkToApstraErr(req, requestBody, resp, "blueprint id not found in url nor in response body", o.apiVersion)
 	case bpId == "":
 		bpId = tIdR.BlueprintId
 	}
@@ -410,6 +410,7 @@ func (o *Client) talkToApstra(ctx context.Context, in *talkToApstraIn) error {
 			Request:  request,
 			Response: response,
 			Msg:      string(dsMsg),
+			Version:  o.apiVersion,
 		}
 	}
 

--- a/apstra/talk_to_apstra_error.go
+++ b/apstra/talk_to_apstra_error.go
@@ -1,4 +1,4 @@
-// Copyright (c) Juniper Networks, Inc., 2025-2025.
+// Copyright (c) Juniper Networks, Inc., 2025-2026.
 // All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/apstra/talk_to_apstra_error.go
+++ b/apstra/talk_to_apstra_error.go
@@ -13,6 +13,14 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+
+	"github.com/Juniper/apstra-go-sdk/compatibility"
+	"github.com/hashicorp/go-version"
+)
+
+var (
+	policyIDErrorRegex       = regexp.MustCompile(`^Endpoint policy with node id "(.*)" does not exist$`)
+	policyIDErrorRegexPre620 = regexp.MustCompile(`^Endpoint policy with node id (.*) does not exist$`)
 )
 
 // TalkToApstraErr implements error{} and carries around http.Request and
@@ -22,6 +30,7 @@ type TalkToApstraErr struct {
 	Request  *http.Request
 	Response *http.Response
 	Msg      string
+	Version  *version.Version
 }
 
 func (o TalkToApstraErr) Error() string {
@@ -94,8 +103,6 @@ func (o TalkToApstraErr) parseApiUrlBlueprintObjPolicyBatchApplyError() error {
 		Policy string `json:"policy"`
 	}
 
-	policyIdErrorRegex := regexp.MustCompile("^Endpoint policy with node id (.*) does not exist$")
-
 	// store collected indexes and ids in maps for de-dup reasons
 	invalidApIds := make(map[ObjectId]struct{})
 	invalidCTIds := make(map[ObjectId]struct{})
@@ -111,7 +118,12 @@ func (o TalkToApstraErr) parseApiUrlBlueprintObjPolicyBatchApplyError() error {
 				}
 			}
 
-			policyIdSubMatches := policyIdErrorRegex.FindStringSubmatch(rawPolicyStruct.Policy)
+			var policyIdSubMatches []string
+			if o.Version == nil || !compatibility.PolicyIDErrorHasNoQuotes.Check(o.Version) {
+				policyIdSubMatches = policyIDErrorRegex.FindStringSubmatch(rawPolicyStruct.Policy)
+			} else {
+				policyIdSubMatches = policyIDErrorRegexPre620.FindStringSubmatch(rawPolicyStruct.Policy) // legacy error message
+			}
 
 			switch {
 			case len(policyIdSubMatches) == 2:
@@ -149,7 +161,7 @@ func (o TalkToApstraErr) parseApiUrlBlueprintObjPolicyBatchApplyError() error {
 // be closed by a 'defer body.Close()' somewhere, so we'll replace that as well,
 // up to some reasonable limit (don't try to buffer gigabytes of data from the
 // webserver).
-func newTalkToApstraErr(req *http.Request, reqBody []byte, resp *http.Response, errMsg string) TalkToApstraErr {
+func newTalkToApstraErr(req *http.Request, reqBody []byte, resp *http.Response, errMsg string, version *version.Version) TalkToApstraErr {
 	// don't include secret in error
 	req.Header.Del(apstraAuthHeader)
 
@@ -187,5 +199,6 @@ func newTalkToApstraErr(req *http.Request, reqBody []byte, resp *http.Response, 
 		Request:  req,
 		Response: resp,
 		Msg:      errMsg,
+		Version:  version,
 	}
 }

--- a/compatibility/constraints.go
+++ b/compatibility/constraints.go
@@ -56,6 +56,9 @@ var (
 	RoutingPolicyExportHasL3EdgeLinks = Constraint{
 		constraints: version.MustConstraints(version.NewConstraint("<" + apstra500)),
 	}
+	PolicyIDErrorHasNoQuotes = Constraint{
+		constraints: version.MustConstraints(version.NewConstraint("<" + apstra620)),
+	}
 	SecurityZoneAddressingSupported = Constraint{
 		constraints: version.MustConstraints(version.NewConstraint(">=" + apstra610)),
 	}


### PR DESCRIPTION
This PR handles the 6.2.0 change in API error string from this:
```json
{
  "error_code": 422,
  "errors": {
    "application_points": {
      "0": {
        "policies": {
          "0": {
            "policy": "Endpoint policy with node id b4bdf0 does not exist"
          },
          "2": {
            "policy": "Endpoint policy with node id 104a5b does not exist"
          }
        }
      }
    }
  }
}
```
To this:
```json
{
  "error_code": 422,
  "errors": {
    "application_points": {
      "0": {
        "policies": {
          "0": {
            "policy": "Endpoint policy with node id \"b4bdf0\" does not exist"
          },
          "2": {
            "policy": "Endpoint policy with node id \"104a5b\" does not exist"
          }
        }
      }
    }
  }
}
```

It does that by extending the `TalkToApstraErr` struct to include the version of the API we're talking to.

The function which parses that error string now expects quotes (or not) depending on the API version reflected in the error.

Closes #759